### PR TITLE
Stack size reduction cleanup

### DIFF
--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -75,14 +75,12 @@ RawImage Cr2Decoder::decodeRawInternal() {
     }
 
     mRaw->createData();
-    LJpegPlain *l = new LJpegPlain(mFile, mRaw);
+    LJpegPlain l(mFile, mRaw);
     try {
-      l->startDecoder(off, mFile->getSize()-off, 0, 0);
+      l.startDecoder(off, mFile->getSize()-off, 0, 0);
     } catch (IOException& e) {
       mRaw->setError(e.what());
     }
-
-    delete l;
 
     if(hints.find("double_line_ljpeg") != hints.end()) {
       // We now have a double width half height image we need to convert to the
@@ -146,9 +144,8 @@ RawImage Cr2Decoder::decodeRawInternal() {
       slice.offset = offsets[0].getInt();
       slice.count = counts[0].getInt();
       SOFInfo sof;
-      LJpegPlain *l = new LJpegPlain(mFile, mRaw);
-      l->getSOF(&sof, slice.offset, slice.count);
-      delete l;
+      LJpegPlain l(mFile, mRaw);
+      l.getSOF(&sof, slice.offset, slice.count);
       slice.w = sof.w * sof.cps;
       slice.h = sof.h;
       if (sof.cps == 4 && slice.w > slice.h * 4) {
@@ -230,14 +227,12 @@ RawImage Cr2Decoder::decodeRawInternal() {
   for (uint32 i = 0; i < slices.size(); i++) {
     Cr2Slice slice = slices[i];
     try {
-      LJpegPlain *l = new LJpegPlain(mFile, mRaw);
-      l->addSlices(s_width);
-      l->mUseBigtable = true;
-      l->mCanonFlipDim = flipDims;
-      l->mCanonDoubleHeight = doubleHeight;
-      l->mWrappedCr2Slices = wrappedCr2Slices;
-      l->startDecoder(slice.offset, slice.count, 0, offY);
-      delete l;
+      LJpegPlain l(mFile, mRaw);
+      l.addSlices(s_width);
+      l.mUseBigtable = true;
+      l.mCanonFlipDim = flipDims;
+      l.mCanonDoubleHeight = doubleHeight;
+      l.startDecoder(slice.offset, slice.count, 0, offY);
     } catch (RawDecoderException &e) {
       if (i == 0)
         throw;

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -232,6 +232,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
       l.mUseBigtable = true;
       l.mCanonFlipDim = flipDims;
       l.mCanonDoubleHeight = doubleHeight;
+      l.mWrappedCr2Slices = wrappedCr2Slices;
       l.startDecoder(slice.offset, slice.count, 0, offY);
     } catch (RawDecoderException &e) {
       if (i == 0)

--- a/RawSpeed/LJpegDecompressor.h
+++ b/RawSpeed/LJpegDecompressor.h
@@ -195,7 +195,8 @@ protected:
   uint32 Pt;
   uint32 offX, offY;  // Offset into image where decoding should start
   uint32 skipX, skipY;   // Tile is larger than output, skip these border pixels
-  HuffmanTable huff[4]; 
+  // allocate large HuffmanTable struct on heap to make libmusl happy
+  vector<HuffmanTable> huff = vector<HuffmanTable>(4);
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -108,18 +108,17 @@ RawImage NefDecoder::decodeRawInternal() {
   }
 
   try {
-    NikonDecompressor* decompressor = new NikonDecompressor(mFile, mRaw);
-    decompressor->uncorrectedRawValues = uncorrectedRawValues;
+    NikonDecompressor decompressor(mFile, mRaw);
+    decompressor.uncorrectedRawValues = uncorrectedRawValues;
     ByteStream* metastream;
     if (getHostEndianness() == data[0]->endian)
       metastream = new ByteStream(meta->getData(), meta->count);
     else
       metastream = new ByteStreamSwap(meta->getData(), meta->count);
 
-    decompressor->DecompressNikon(metastream, width, height, bitPerPixel, offsets->getInt(), counts->getInt());
+    decompressor.DecompressNikon(metastream, width, height, bitPerPixel, offsets->getInt(), counts->getInt());
 
     delete metastream;
-    delete decompressor;
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -28,9 +28,6 @@ namespace RawSpeed {
 
 NikonDecompressor::NikonDecompressor(FileMap* file, RawImage img) :
     LJpegDecompressor(file, img) {
-  for (uint32 i = 0; i < 0x8000 ; i++) {
-    curve[i]  = i;
-  }
 }
 
 void NikonDecompressor::initTable(uint32 huffSelect) {
@@ -70,6 +67,10 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   pUp2[0] = metadata->getShort();
   pUp2[1] = metadata->getShort();
 
+  vector<ushort16> curve(65536);
+  for (size_t i = 0; i < curve.size(); i++)
+    curve[i] = i;
+
   int _max = 1 << bitsPS & 0x7fff;
   uint32 step = 0;
   uint32 csize = metadata->getShort();
@@ -92,7 +93,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   initTable(huffSelect);
 
   if (!uncorrectedRawValues) {
-    mRaw->setTable(curve, _max, true);
+    mRaw->setTable(&curve[0], _max, true);
   }
 
   uint32 x, y;
@@ -128,7 +129,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   }
 
   if (uncorrectedRawValues) {
-    mRaw->setTable(curve, _max, false);
+    mRaw->setTable(&curve[0], _max, false);
   } else {
     mRaw->setTable(NULL);
   }

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -89,7 +89,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
     metadata->setAbsoluteOffset(562);
     split = metadata->getShort();
   } else if (v0 != 70 && csize <= 0x4001) {
-    curve.resize(csize);
+    curve.resize(csize+1);
     for (uint32 i = 0; i < csize; i++) {
       curve[i] = metadata->getShort();
     }

--- a/RawSpeed/NikonDecompressor.h
+++ b/RawSpeed/NikonDecompressor.h
@@ -39,7 +39,6 @@ public:
 private:
   void initTable(uint32 huffSelect);
   int HuffDecodeNikon(BitPumpMSB& bits);
-  ushort16 curve[65536];
 };
 
 static const uchar8 nikon_tree[][32] = {

--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -305,12 +305,14 @@ std::string Rw2Decoder::guessMode() {
 }
 
 PanaBitpump::PanaBitpump(ByteStream* _input) : input(_input), vbits(0) {
+  buf = new uchar8[0x4000];
 }
 
 PanaBitpump::~PanaBitpump() {
   if (input)
     delete input;
   input = 0;
+  delete [] buf;
 }
 
 void PanaBitpump::skipBytes(int bytes) {

--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -123,9 +123,9 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
   skip += w * 2 * t->start_y;
   skip /= 8;
 
-  PanaBitpump *bits = new PanaBitpump(new ByteStream(input_start));
-  bits->load_flags = load_flags;
-  bits->skipBytes(skip);
+  PanaBitpump bits(new ByteStream(input_start));
+  bits.load_flags = load_flags;
+  bits.skipBytes(skip);
 
   vector<uint32> zero_pos;
   for (y = t->start_y; y < t->end_y; y++) {
@@ -137,17 +137,17 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
         // Even pixels
         if (u == 2)
         {
-          sh = 4 >> (3 - bits->getBits(2));
+          sh = 4 >> (3 - bits.getBits(2));
           u = -1;
         }
         if (nonz[0]) {
-          if ((j = bits->getBits(8))) {
+          if ((j = bits.getBits(8))) {
             if ((pred[0] -= 0x80 << sh) < 0 || sh == 4)
               pred[0] &= ~(-1 << sh);
             pred[0] += j << sh;
           }
-        } else if ((nonz[0] = bits->getBits(8)) || i > 11)
-          pred[0] = nonz[0] << 4 | bits->getBits(4);
+        } else if ((nonz[0] = bits.getBits(8)) || i > 11)
+          pred[0] = nonz[0] << 4 | bits.getBits(4);
         *dest++ = pred[0];
         if (zero_is_bad && 0 == pred[0])
           zero_pos.push_back((y<<16) | (x*14+i));
@@ -157,17 +157,17 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
         u++;
         if (u == 2)
         {
-          sh = 4 >> (3 - bits->getBits(2));
+          sh = 4 >> (3 - bits.getBits(2));
           u = -1;
         }
         if (nonz[1]) {
-          if ((j = bits->getBits(8))) {
+          if ((j = bits.getBits(8))) {
             if ((pred[1] -= 0x80 << sh) < 0 || sh == 4)
               pred[1] &= ~(-1 << sh);
             pred[1] += j << sh;
           }
-        } else if ((nonz[1] = bits->getBits(8)) || i > 11)
-          pred[1] = nonz[1] << 4 | bits->getBits(4);
+        } else if ((nonz[1] = bits.getBits(8)) || i > 11)
+          pred[1] = nonz[1] << 4 | bits.getBits(4);
         *dest++ = pred[1];
         if (zero_is_bad && 0 == pred[1])
           zero_pos.push_back((y<<16) | (x*14+i));
@@ -180,8 +180,6 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
     mRaw->mBadPixelPositions.insert(mRaw->mBadPixelPositions.end(), zero_pos.begin(), zero_pos.end());
     pthread_mutex_unlock(&mRaw->mBadPixelMutex);
   }
-
-  delete bits;
 }
 
 void Rw2Decoder::checkSupportInternal(CameraMetaData *meta) {

--- a/RawSpeed/Rw2Decoder.h
+++ b/RawSpeed/Rw2Decoder.h
@@ -35,7 +35,7 @@ class PanaBitpump {
   PanaBitpump(ByteStream* input);
   virtual ~PanaBitpump();
   ByteStream* input;
-  uchar8 buf[0x4000];
+  uchar8* buf;
   int vbits;
   uint32 load_flags;
   uint32 getBits(int nbits);


### PR DESCRIPTION
As mentioned in my comment #163 on the former upstream repo from klauspost (https://github.com/klauspost/rawspeed/issues/163#issuecomment-259680348) regarding the solution to reduce the necessary stack size to support the musl libc, I think it is better to reduce the stack size of certain object instantiations inside the class than to force the user of the class to allocate the object on the heap.

Advantages:
 * more localized code changes
 * all usages of e.g. LJpegDecompressor profit at the same time
 * removed memory leaks that occur on exceptions
