### PR TITLE
Infrastructure cleanup part 1

### DIFF
--- a/RawSpeed/Camera.cpp
+++ b/RawSpeed/Camera.cpp
@@ -1,10 +1,11 @@
 #include "StdAfx.h"
 #include "Camera.h"
-#include <iostream>
+
 /*
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -27,115 +28,102 @@ namespace RawSpeed {
 
 using namespace pugi;
 
-
 Camera::Camera(pugi::xml_node &camera) : cfa(iPoint2D(0,0)) {
-
-  pugi::xml_attribute key = camera.attribute("make");
-  if (!key)
+  make = canonical_make = camera.attribute("make").as_string();
+  if (make.empty())
     ThrowCME("Camera XML Parser: \"make\" attribute not found.");
-  make = canonical_make = key.as_string();
 
-  key = camera.attribute("model");
-  if (!key)
+  model = canonical_model = canonical_alias = camera.attribute("model").as_string();
+  // chdk cameras seem to have an empty model?
+  if (!camera.attribute("model")) // (model.empty())
     ThrowCME("Camera XML Parser: \"model\" attribute not found.");
-  model = canonical_model = canonical_alias = key.as_string();
 
   canonical_id = make + " " + model;
 
-  supported = true;
-  key = camera.attribute("supported");
-  if (key) {
-    string s = string(key.as_string());
-    if (s.compare("no") == 0)
-      supported = false;
-  }
+  supported = camera.attribute("supported").as_string("yes") == string("yes");
+  mode = camera.attribute("mode").as_string("");
+  decoderVersion = camera.attribute("decoder_version").as_int(0);
 
-  key = camera.attribute("mode");
-  if (key) {
-    mode = key.as_string();
-  } else {
-    mode = string("");
-  }
-
-  key = camera.attribute("decoder_version");
-  if (key) {
-    decoderVersion = key.as_int(0);
-  } else {
-    decoderVersion = 0;
-  }
-
-  for (xml_node node = camera.first_child(); node; node = node.next_sibling()) {
-    parseCameraChild(node);
+  for (xml_node c : camera.children()) {
+    parseCameraChild(c);
   }
 }
 
-Camera::Camera( const Camera* camera, uint32 alias_num) : cfa(iPoint2D(0,0))
+Camera::Camera(const Camera* camera, uint32 alias_num) : cfa(iPoint2D(0,0))
 {
   if (alias_num >= camera->aliases.size())
     ThrowCME("Camera: Internal error, alias number out of range specified.");
 
-  make = camera->make;
+  *this = *camera;
   model = camera->aliases[alias_num];
-  canonical_make = camera->canonical_make;
-  canonical_model = camera->canonical_model;
   canonical_alias = camera->canonical_aliases[alias_num];
-  canonical_id = camera->canonical_id;
-  mode = camera->mode;
-  cfa = camera->cfa;
-  supported = camera->supported;
-  cropSize = camera->cropSize;
-  cropPos = camera->cropPos;
-  decoderVersion = camera->decoderVersion;
-  for (uint32 i = 0; i < camera->blackAreas.size(); i++) {
-    blackAreas.push_back(camera->blackAreas[i]);
-  }
-  for (uint32 i = 0; i < camera->sensorInfo.size(); i++) {
-    sensorInfo.push_back(camera->sensorInfo[i]);
-  }
-  map<string,string>::const_iterator mi = camera->hints.begin();
-  for (; mi != camera->hints.end(); ++mi) {
-    hints.insert(make_pair((*mi).first, (*mi).second));
-  }
+  aliases.clear();
+  canonical_aliases.clear();
 }
 
-Camera::~Camera(void) {
+static string name(const xml_node &a) {
+  return string(a.name());
 }
 
-static bool isTag(const char_t *a, const char* b) {
-  return 0 == strcmp(a, b);
-}
+void Camera::parseCameraChild(const xml_node& cur) {
 
-void Camera::parseCameraChild(xml_node &cur) {
-  if (isTag(cur.name(), "CFA")) {
-    if (2 != cur.attribute("width").as_int(0) || 2 != cur.attribute("height").as_int(0)) {
-      supported = FALSE;
-    } else {
-      cfa.setSize(iPoint2D(2,2));
-      xml_node c = cur.child("Color");
-      while (c != NULL) {
-        parseCFA(c);
-        c = c.next_sibling("Color");
+  if (name(cur) == "CFA" || name(cur) == "CFA2") {
+
+    cfa.setSize(iPoint2D(cur.attribute("width").as_int(0), cur.attribute("height").as_int(0)));
+    for (xml_node c : cur.children()) {
+      try {
+        if (name(c) == "ColorRow") {
+          int y = c.attribute("y").as_int(-1);
+          if (y < 0 || y >= cfa.size.y) {
+            ThrowCME("Invalid y coordinate in CFA array of camera %s %s", make.c_str(), model.c_str());
+          }
+          string key = c.child_value();
+          if ((int)key.size() != cfa.size.x) {
+            ThrowCME("Invalid number of colors in definition for row %d in camera %s %s. Expected %d, found %zu.", y, make.c_str(), model.c_str(),  cfa.size.x, key.size());
+          }
+          const map<char, CFAColor> char2enum = {
+            {'g', CFA_GREEN},
+            {'r', CFA_RED},
+            {'b', CFA_BLUE},
+            {'f', CFA_FUJI_GREEN},
+            {'c', CFA_CYAN},
+            {'m', CFA_MAGENTA},
+            {'y', CFA_YELLOW},
+          };
+          for (size_t x=0; x<key.size(); ++x) {
+            cfa.setColorAt(iPoint2D((int)x, y), char2enum.at((char)tolower(key[x])));
+          }
+        } else if (name(c) == "Color") {
+          int x = c.attribute("x").as_int(-1);
+          if (x < 0 || x >= cfa.size.x) {
+            ThrowCME("Invalid x coordinate in CFA array of camera %s %s", make.c_str(), model.c_str());
+          }
+
+          int y = c.attribute("y").as_int(-1);
+          if (y < 0 || y >= cfa.size.y) {
+            ThrowCME("Invalid y coordinate in CFA array of camera %s %s", make.c_str(), model.c_str());
+          }
+
+          const map<string, CFAColor> str2enum = {
+            {"GREEN",     CFA_GREEN},
+            {"RED",       CFA_RED},
+            {"BLUE",      CFA_BLUE},
+            {"FUJI_GREEN",CFA_FUJI_GREEN},
+            {"CYAN",      CFA_CYAN},
+            {"MAGENTA",   CFA_MAGENTA},
+            {"YELLOW",    CFA_YELLOW},
+          };
+          cfa.setColorAt(iPoint2D(x, y), str2enum.at(c.child_value()));
+        }
+      } catch (std::out_of_range&) {
+        ThrowCME("Invalid color in CFA array of camera %s %s", make.c_str(), model.c_str());
       }
     }
-    return;
-  }
 
-  if (isTag(cur.name(), "CFA2")) {
-    cfa.setSize(iPoint2D(cur.attribute("width").as_int(0),cur.attribute("height").as_int(0)));
-    xml_node c = cur.child("Color");
-    while (c != NULL) {
-      parseCFA(c);
-      c = c.next_sibling("Color");
-    }
-    c = cur.child("ColorRow");
-    while (c != NULL) {
-      parseCFA(c);
-      c = c.next_sibling("ColorRow");
-    }
-    return;
-  }
+  } else if (name(cur) == "Crop") {
 
-  if (isTag(cur.name(), "Crop")) {
+    cropSize.x = cur.attribute("width").as_int(0);
+    cropSize.y = cur.attribute("height").as_int(0);
     cropPos.x = cur.attribute("x").as_int(0);
     cropPos.y = cur.attribute("y").as_int(0);
 
@@ -144,229 +132,101 @@ void Camera::parseCameraChild(xml_node &cur) {
     if (cropPos.y < 0)
       ThrowCME("Negative Y axis crop specified in camera %s %s", make.c_str(), model.c_str());
 
-    cropSize.x = cur.attribute("width").as_int(0);
-    cropSize.y = cur.attribute("height").as_int(0);
-    return;
-  }
+  } else if (name(cur) == "BlackAreas") {
 
-  if (isTag(cur.name(), "Sensor")) {
-    parseSensorInfo(cur);
-    return;
-  }
+    for (xml_node c : cur.children()) {
+      if (name(c) == "Vertical") {
+        int x = c.attribute("x").as_int(-1);
+        if (x < 0) {
+          ThrowCME("Invalid x coordinate in vertical BlackArea of in camera %s %s", make.c_str(), model.c_str());
+        }
 
-  if (isTag(cur.name(), "BlackAreas")) {
-    xml_node c = cur.first_child();
-    while (c != NULL) {
-      parseBlackAreas(c);
-      c = c.next_sibling();
-    }
-    return;
-  }
+        int w = c.attribute("width").as_int(-1);
+        if (w < 0) {
+          ThrowCME("Invalid width in vertical BlackArea of in camera %s %s", make.c_str(), model.c_str());
+        }
 
-  if (isTag(cur.name(), "Aliases")) {
-    xml_node c = cur.child("Alias");
-    while (c != NULL) {
-      parseAlias(c);
-      c = c.next_sibling();
-    }
-    return;
-  }
+        blackAreas.push_back(BlackArea(x, w, true));
 
-  if (isTag(cur.name(), "Hints")) {
-    xml_node c = cur.child("Hint");
-    while (c != NULL) {
-      parseHint(c);
-      c = c.next_sibling();
-    }
-    return;
-  }
+      } else if (name(c) == "Horizontal") {
 
-  if (isTag(cur.name(), "ID")) {
-    parseID(cur);
-    return;
-  }
-}
+        int y = c.attribute("y").as_int(-1);
+        if (y < 0) {
+          ThrowCME("Invalid y coordinate in horizontal BlackArea of camera %s %s", make.c_str(), model.c_str());
+        }
 
-void Camera::parseCFA(xml_node &cur) {
-  if (isTag(cur.name(), "ColorRow")) {
-    int y = cur.attribute("y").as_int(-1);
-    if (y < 0 || y >= cfa.size.y) {
-      ThrowCME("Invalid y coordinate in CFA array of in camera %s %s", make.c_str(), model.c_str());
-    }
-    const char* key = cur.first_child().value();
-    if ((int)strlen(key) != cfa.size.x) {
-      ThrowCME("Invalid number of colors in definition for row %d in camera %s %s. Expected %d, found %zu.", y, make.c_str(), model.c_str(),  cfa.size.x, strlen(key));
-    }
-    for (int x = 0; x < cfa.size.x; x++) {
-    	char v = (char)tolower((int)key[x]);
-    	if (v == 'g')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_GREEN);
-    	else if (v == 'r')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_RED);
-    	else if (v == 'b')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_BLUE);
-    	else if (v == 'f')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_FUJI_GREEN);
-    	else if (v == 'c')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_CYAN);
-    	else if (v == 'm')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_MAGENTA);
-    	else if (v == 'y')
-      	cfa.setColorAt(iPoint2D(x, y), CFA_YELLOW);
-      else 
-        supported = FALSE;
-    }
-  }
-  if (isTag(cur.name(), "Color")) {
-    int x = cur.attribute("x").as_int(-1);
-    if (x < 0 || x >= cfa.size.x) {
-      ThrowCME("Invalid x coordinate in CFA array of in camera %s %s", make.c_str(), model.c_str());
-    }
+        int h = c.attribute("height").as_int(-1);
+        if (h < 0) {
+          ThrowCME("Invalid height in horizontal BlackArea of camera %s %s", make.c_str(), model.c_str());
+        }
 
-    int y = cur.attribute("y").as_int(-1);
-    if (y < 0 || y >= cfa.size.y) {
-      ThrowCME("Invalid y coordinate in CFA array of in camera %s %s", make.c_str(), model.c_str());
-    }
-
-    const char* key = cur.first_child().value();
-    if (isTag(key, "GREEN"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_GREEN);
-    else if (isTag(key, "RED"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_RED);
-    else if (isTag(key, "BLUE"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_BLUE);
-    else if (isTag(key, "FUJIGREEN"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_FUJI_GREEN);
-    else if (isTag(key, "CYAN"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_CYAN);
-    else if (isTag(key, "MAGENTA"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_MAGENTA);
-    else if (isTag(key, "YELLOW"))
-      cfa.setColorAt(iPoint2D(x, y), CFA_YELLOW);
-  }
-}
-
-void Camera::parseBlackAreas(xml_node &cur) {
-  if (isTag(cur.name(), "Vertical")) {
-
-    int x = cur.attribute("x").as_int(-1);
-    if (x < 0) {
-      ThrowCME("Invalid x coordinate in vertical BlackArea of in camera %s %s", make.c_str(), model.c_str());
-    }
-
-    int w = cur.attribute("width").as_int(-1);
-    if (w < 0) {
-      ThrowCME("Invalid width in vertical BlackArea of in camera %s %s", make.c_str(), model.c_str());
-    }
-
-    blackAreas.push_back(BlackArea(x, w, true));
-
-  } else if (isTag(cur.name(), "Horizontal")) {
-
-    int y = cur.attribute("y").as_int(-1);
-    if (y < 0) {
-      ThrowCME("Invalid y coordinate in horizontal BlackArea of in camera %s %s", make.c_str(), model.c_str());
-    }
-
-    int h = cur.attribute("height").as_int(-1);
-    if (h < 0) {
-      ThrowCME("Invalid width in horizontal BlackArea of in camera %s %s", make.c_str(), model.c_str());
-    }
-    blackAreas.push_back(BlackArea(y, h, false));
-  }
-}
-
-vector<int> Camera::MultipleStringToInt(const char *in, const char *tag, const char* attribute) {
-  int i;
-  vector<int> ret;
-  vector<string> v = split_string(string((const char*)in), ' ');
-
-  for (uint32 j = 0; j < v.size(); j++) {
-#if defined(__unix__) || defined(__APPLE__) || defined(__MINGW32__)
-    if (EOF == sscanf(v[j].c_str(), "%d", &i))
-#else
-    if (EOF == sscanf_s(v[j].c_str(), "%d", &i))
-#endif
-      ThrowCME("Error parsing attribute %s in tag %s, in camera %s %s.", attribute, tag, make.c_str(), model.c_str());
-    ret.push_back(i);
-  }
-  return ret;
-}
-
-void Camera::parseAlias( xml_node &cur )
-{
-  if (isTag(cur.name(), "Alias")) {
-    aliases.push_back(string(cur.first_child().value()));
-    pugi::xml_attribute key = cur.attribute("id");
-    if (key)
-      canonical_aliases.push_back(string(key.as_string()));
-    else
-      canonical_aliases.push_back(string(cur.first_child().value()));
-  }
-}
-
-void Camera::parseHint( xml_node &cur )
-{
-  if (isTag(cur.name(), "Hint")) {
-    string hint_name, hint_value;
-    pugi::xml_attribute key = cur.attribute("name");
-    if (key) {
-      hint_name = string(key.as_string());
-    } else
-      ThrowCME("CameraMetadata: Could not find name for hint for %s %s camera.", make.c_str(), model.c_str());
-
-    key = cur.attribute("value");
-    if (key) {
-      hint_value = string(key.as_string());
-    } else
-      ThrowCME("CameraMetadata: Could not find value for hint %s for %s %s camera.", hint_name.c_str(), make.c_str(), model.c_str());
-
-    hints.insert(make_pair(hint_name, hint_value));
-  }
-}
-
-void Camera::parseID( xml_node &cur )
-{
-  if (isTag(cur.name(), "ID")) {
-    pugi::xml_attribute id_make = cur.attribute("make");
-    if (id_make) {
-      canonical_make = string(id_make.as_string());
-    } else
-      ThrowCME("CameraMetadata: Could not find make for ID for %s %s camera.", make.c_str(), model.c_str());
-
-    pugi::xml_attribute id_model = cur.attribute("model");
-    if (id_model) {
-      canonical_model = string(id_model.as_string());
-      canonical_alias = string(id_model.as_string());
-    } else
-      ThrowCME("CameraMetadata: Could not find model for ID for %s %s camera.", make.c_str(), model.c_str());
-
-    canonical_id = string(cur.first_child().value());
-  }
-}
-
-void Camera::parseSensorInfo( xml_node &cur )
-{
-  int min_iso = cur.attribute("iso_min").as_int(0);
-  int max_iso = cur.attribute("iso_max").as_int(0);;
-  int black = cur.attribute("black").as_int(-1);
-  int white = cur.attribute("white").as_int(65536);
-
-  pugi::xml_attribute key = cur.attribute("black_colors");
-  vector<int> black_colors;
-  if (key) {
-    black_colors = MultipleStringToInt(key.as_string(), cur.name(), "black_colors");
-  }
-  key = cur.attribute("iso_list");
-  if (key) {
-    vector<int> values = MultipleStringToInt(key.as_string(), cur.name(), "iso_list");
-    if (!values.empty()) {
-      for (uint32 i = 0; i < values.size(); i++) {
-        sensorInfo.push_back(CameraSensorInfo(black, white, values[i], values[i], black_colors));
+        blackAreas.push_back(BlackArea(y, h, false));
       }
     }
-  } else {
-    sensorInfo.push_back(CameraSensorInfo(black, white, min_iso, max_iso, black_colors));
+
+  } else if (name(cur) == "Aliases") {
+
+    for (xml_node c : cur.children("Alias")) {
+      aliases.push_back(c.child_value());
+      canonical_aliases.push_back(c.attribute("id").as_string(c.child_value()));
+    }
+
+  } else if (name(cur) == "Hints") {
+
+    for (xml_node c : cur.children("Hint")) {
+      string name = c.attribute("name").as_string();
+      if (name.empty())
+        ThrowCME("CameraMetadata: Could not find name for hint for %s %s camera.", make.c_str(), model.c_str());
+
+      string value = c.attribute("value").as_string();
+
+      hints.insert({name, value});
+    }
+
+  } else if (name(cur) == "ID") {
+
+    string id_make = cur.attribute("make").as_string();
+    if (id_make.empty())
+      ThrowCME("CameraMetadata: Could not find make for ID for %s %s camera.", make.c_str(), model.c_str());
+
+    string id_model = cur.attribute("model").as_string();
+    if (id_model.empty())
+      ThrowCME("CameraMetadata: Could not find model for ID for %s %s camera.", make.c_str(), model.c_str());
+
+    canonical_make = id_make;
+    canonical_model = id_model;
+    canonical_alias = id_model;
+    canonical_id = cur.child_value();
+
+  } else if (name(cur) == "Sensor") {
+
+    auto stringToListOfInts = [this, &cur](const char* attribute) {
+      vector<int> ret;
+      try {
+        for (string s : split_string(cur.attribute(attribute).as_string(), ' ')) {
+          ret.push_back(stoi(s));
+        }
+      } catch (...) {
+        ThrowCME("Error parsing attribute %s in tag %s, in camera %s %s.", attribute, cur.name(), make.c_str(), model.c_str());
+      }
+      return ret;
+    };
+
+    int min_iso = cur.attribute("iso_min").as_int(0);
+    int max_iso = cur.attribute("iso_max").as_int(0);
+    int black = cur.attribute("black").as_int(-1);
+    int white = cur.attribute("white").as_int(65536);
+
+    vector<int> black_colors = stringToListOfInts("black_colors");
+    vector<int> iso_list = stringToListOfInts("iso_list");
+    if (!iso_list.empty()) {
+      for (int iso : iso_list) {
+        sensorInfo.push_back(CameraSensorInfo(black, white, iso, iso, black_colors));
+      }
+    } else {
+      sensorInfo.push_back(CameraSensorInfo(black, white, min_iso, max_iso, black_colors));
+    }
+
   }
 }
 
@@ -379,27 +239,24 @@ const CameraSensorInfo* Camera::getSensorInfo( int iso )
 
   // If only one, just return that
   if (sensorInfo.size() == 1)
-    return &sensorInfo[0];
+    return &sensorInfo.front();
 
   vector<CameraSensorInfo*> candidates;
-  vector<CameraSensorInfo>::iterator i = sensorInfo.begin();
-  do
-  {
-    if (i->isIsoWithin(iso))
-      candidates.push_back(&(*i));
-  } while (++i != sensorInfo.end());
+  for (auto& i : sensorInfo) {
+    if (i.isIsoWithin(iso))
+      candidates.push_back(&i);
+  }
 
   if (candidates.size() == 1)
-    return candidates[0];
+    return candidates.front();
 
-  vector<CameraSensorInfo*>::iterator j = candidates.begin();
-  do
-  {
-    if (!(*j)->isDefault())
-      return *j;
-  } while (++j != candidates.end());
+  for (auto i : candidates) {
+    if (!i->isDefault())
+      return i;
+  }
+
   // Several defaults??? Just return first
-  return candidates[0];
+  return candidates.front();
 }
 
 } // namespace RawSpeed

--- a/RawSpeed/Camera.h
+++ b/RawSpeed/Camera.h
@@ -35,9 +35,7 @@ class Camera
 public:
   Camera(pugi::xml_node &camera);
   Camera(const Camera* camera, uint32 alias_num);
-  void parseCameraChild( pugi::xml_node &node );
   const CameraSensorInfo* getSensorInfo(int iso);
-  virtual ~Camera(void);
   string make;
   string model;
   string mode;
@@ -56,13 +54,7 @@ public:
   int decoderVersion;
   map<string,string> hints;
 protected:
-  void parseCFA( pugi::xml_node &node );
-  void parseAlias( pugi::xml_node &node );
-  void parseHint( pugi::xml_node &node );
-  void parseID( pugi::xml_node &node );
-  void parseBlackAreas( pugi::xml_node &node );
-  void parseSensorInfo( pugi::xml_node &node );
-  vector<int> MultipleStringToInt(const char *in, const char *tag, const char* attribute);
+  void parseCameraChild(const pugi::xml_node &node);
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/CameraMetaData.cpp
+++ b/RawSpeed/CameraMetaData.cpp
@@ -35,12 +35,12 @@ CameraMetaData::CameraMetaData(const char *docname) {
     ThrowCME("CameraMetaData: XML Document could not be parsed successfully. Error was: %s in %s", 
       result.description(), doc.child("node").attribute("attr").value());
   }
-  xml_node cameras = doc.child("Cameras");
 
-  for (xml_node camera = cameras.child("Camera"); camera; camera = camera.next_sibling("Camera")) {
+  for (xml_node camera : doc.child("Cameras").children("Camera")) {
     Camera *cam = new Camera(camera);
 
-    if(!addCamera(cam)) continue;
+    if (!addCamera(cam))
+      continue;
 
     // Create cameras for aliases.
     for (uint32 i = 0; i < cam->aliases.size(); i++) {
@@ -62,44 +62,33 @@ static inline string getId(string make, string model, string mode)
   TrimSpaces(model);
   TrimSpaces(mode);
 
-  return string(make).append(model).append(mode);
-}
-
-static inline string getId(Camera* cam)
-{
-  return getId(cam->make, cam->model, cam->mode);
+  return make + model + mode;
 }
 
 Camera* CameraMetaData::getCamera(string make, string model, string mode) {
-  string id = getId(make, model, mode);
-  if (cameras.end() == cameras.find(id))
-    return NULL;
-  return cameras[id];
+ auto camera = cameras.find(getId(make, model, mode));
+ return camera == cameras.end() ? nullptr : camera->second;
 }
 
 Camera* CameraMetaData::getCamera(string make, string model) {
   string id = getId(make, model, "");
 
   // do a prefix match, i.e. the make and model match, but not mode.
-  std::map<string,Camera*>::iterator iter = cameras.lower_bound(id);
+  auto iter = cameras.lower_bound(id);
 
   if (iter == cameras.find(id))
-    return NULL;
+    return nullptr;
 
-  return cameras[iter->first];
+  return iter->second;
 }
 
 bool CameraMetaData::hasCamera(string make, string model, string mode) {
-  string id = getId(make, model, mode);
-  if (cameras.end() == cameras.find(id))
-    return FALSE;
-  return TRUE;
+  return getCamera(make, model, mode);
 }
 
 Camera* CameraMetaData::getChdkCamera(uint32 filesize) {
-  if (chdkCameras.end() == chdkCameras.find(filesize))
-    return NULL;
-  return chdkCameras[filesize];
+  auto camera = chdkCameras.find(filesize);
+  return camera == chdkCameras.end() ? nullptr : camera->second;
 }
 
 bool CameraMetaData::hasChdkCamera(uint32 filesize) {
@@ -108,22 +97,20 @@ bool CameraMetaData::hasChdkCamera(uint32 filesize) {
 
 bool CameraMetaData::addCamera( Camera* cam )
 {
-  string id = getId(cam);
+  string id = getId(cam->make, cam->model, cam->mode);
   if (cameras.end() != cameras.find(id)) {
     writeLog(DEBUG_PRIO_WARNING, "CameraMetaData: Duplicate entry found for camera: %s %s, Skipping!\n", cam->make.c_str(), cam->model.c_str());
-    delete(cam);
+    delete cam;
     return false;
   } else {
     cameras[id] = cam;
   }
   if (string::npos != cam->mode.find("chdk")) {
-    if (cam->hints.find("filesize") == cam->hints.end()) {
+    auto filesize_hint = cam->hints.find("filesize");
+    if (filesize_hint == cam->hints.end() || filesize_hint->second.empty()) {
       writeLog(DEBUG_PRIO_WARNING, "CameraMetaData: CHDK camera: %s %s, no \"filesize\" hint set!\n", cam->make.c_str(), cam->model.c_str());
     } else {
-      uint32 size;
-      stringstream fsize(cam->hints.find("filesize")->second);
-      fsize >> size;
-      chdkCameras[size] = cam;
+      chdkCameras[stoi(filesize_hint->second)] = cam;
       // writeLog(DEBUG_PRIO_WARNING, "CHDK camera: %s %s size:%u\n", cam->make.c_str(), cam->model.c_str(), size);
     }
   }
@@ -132,23 +119,17 @@ bool CameraMetaData::addCamera( Camera* cam )
 
 void CameraMetaData::disableMake( string make )
 {
-  map<string, Camera*>::iterator i = cameras.begin();
-  for (; i != cameras.end(); ++i) {
-    Camera* cam = (*i).second;
-    if (0 == cam->make.compare(make)) {
-      cam->supported = FALSE;
-    }
+  for (auto cam : cameras) {
+    if (cam.second->make == make)
+      cam.second->supported = false;
   }
 }
 
 void CameraMetaData::disableCamera( string make, string model )
 {
-  map<string, Camera*>::iterator i = cameras.begin();
-  for (; i != cameras.end(); ++i) {
-    Camera* cam = (*i).second;
-    if (0 == cam->make.compare(make) && 0 == cam->model.compare(model)) {
-      cam->supported = FALSE;
-    }
+  for (auto cam : cameras) {
+    if (cam.second->make == make && cam.second->model == model)
+      cam.second->supported = false;
   }
 }
 

--- a/RawSpeed/ColorFilterArray.cpp
+++ b/RawSpeed/ColorFilterArray.cpp
@@ -155,7 +155,7 @@ void ColorFilterArray::shiftDown(int n) {
 }
 
 std::string ColorFilterArray::asString() {
-  string dst = string("");
+  string dst;
   for (int y = 0; y < size.y; y++) {
     for (int x = 0; x < size.x; x++) {
       dst += colorToString(getColorAt(x,y));
@@ -237,8 +237,8 @@ CFAColor ColorFilterArray::toRawspeedColor( uint32 dcrawColor )
     case 1: return CFA_GREEN;
     case 2: return CFA_BLUE;
     case 3: return CFA_GREEN2;
+    default: return CFA_UNKNOWN;
   }
-  return CFA_UNKNOWN;
 }
 
 RawSpeed::uint32 ColorFilterArray::toDcrawColor( CFAColor c )
@@ -252,10 +252,8 @@ RawSpeed::uint32 ColorFilterArray::toDcrawColor( CFAColor c )
     case CFA_BLUE: return 2;
     case CFA_YELLOW:
     case CFA_GREEN2: return 3;
-    default:
-      break;
+    default: return 0;
   }
-  return 0;
 }
 
 

--- a/RawSpeed/ColorFilterArray.h
+++ b/RawSpeed/ColorFilterArray.h
@@ -54,7 +54,6 @@ public:
   virtual void setSize(iPoint2D size);
   void setColorAt(iPoint2D pos, CFAColor c);
   virtual void setCFA(iPoint2D size, ...);
-  CFAColor* getCfaWrt() {return cfa;};
   virtual CFAColor getColorAt(uint32 x, uint32 y);
   virtual uint32 getDcrawFilter();
   virtual void shiftLeft(int n = 1);

--- a/RawSpeed/Common.h
+++ b/RawSpeed/Common.h
@@ -234,7 +234,8 @@ inline vector<string> split_string(string input, char c = ' ') {
     while(*str != c && *str)
       str++;
 
-    result.push_back(string(begin, str));
+    if(begin != str)
+      result.push_back(string(begin, str));
 
     if(0 == *str++)
       break;

--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -122,8 +122,7 @@ RawImage DngDecoder::decodeRawInternal() {
       TiffEntry *cfadim = raw->getEntry(CFAREPEATPATTERNDIM);
       if (cfadim->count != 2)
         ThrowRDE("DNG Decoder: Couldn't read CFA pattern dimension");
-      TiffEntry *pDim = raw->getEntry(CFAREPEATPATTERNDIM); // Get the size
-      const uchar8* cPat = raw->getEntry(CFAPATTERN)->getData();                 // Does NOT contain dimensions as some documents state
+      TiffEntry* cPat = raw->getEntry(CFAPATTERN);                 // Does NOT contain dimensions as some documents state
       /*
             if (raw->hasEntry(CFAPLANECOLOR)) {
               TiffEntry* e = raw->getEntry(CFAPLANECOLOR);
@@ -135,14 +134,14 @@ RawImage DngDecoder::decodeRawInternal() {
               printf("\n");
             }
       */
-      iPoint2D cfaSize(pDim->getInt(1), pDim->getInt(0));
+      iPoint2D cfaSize(cfadim->getInt(1), cfadim->getInt(0));
+      if (cfaSize.area() != cPat->count)
+        ThrowRDE("DNG Decoder: CFA pattern dimension and pattern count does not match: %d.", cPat->count);
       mRaw->cfa.setSize(cfaSize);
-      if (cfaSize.area() != raw->getEntry(CFAPATTERN)->count)
-        ThrowRDE("DNG Decoder: CFA pattern dimension and pattern count does not match: %d.", raw->getEntry(CFAPATTERN)->count);
 
       for (int y = 0; y < cfaSize.y; y++) {
         for (int x = 0; x < cfaSize.x; x++) {
-          uint32 c1 = cPat[x+y*cfaSize.x];
+          uint32 c1 = cPat->getByte(x+y*cfaSize.x);
           CFAColor c2;
           switch (c1) {
             case 0:

--- a/RawSpeed/KdcDecoder.cpp
+++ b/RawSpeed/KdcDecoder.cpp
@@ -124,10 +124,9 @@ void KdcDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if (mRootIFD->hasEntryRecursive(KODAKWB)) {
     TiffEntry *wb = mRootIFD->getEntryRecursive(KODAKWB);
     if (wb->count == 734 || wb->count == 1502) {
-      const uchar8 *tmp = wb->getData();
-      mRaw->metadata.wbCoeffs[0] = (float)((((ushort16) tmp[148])<<8)|tmp[149])/256.0f;
+      mRaw->metadata.wbCoeffs[0] = (float)((((ushort16) wb->getByte(148))<<8)|wb->getByte(149))/256.0f;
       mRaw->metadata.wbCoeffs[1] = 1.0f;
-      mRaw->metadata.wbCoeffs[2] = (float)((((ushort16) tmp[150])<<8)|tmp[151])/256.0f;
+      mRaw->metadata.wbCoeffs[2] = (float)((((ushort16) wb->getByte(150))<<8)|wb->getByte(151))/256.0f;
     }
   }
 }

--- a/RawSpeed/LJpegDecompressor.cpp
+++ b/RawSpeed/LJpegDecompressor.cpp
@@ -62,24 +62,6 @@
 
 namespace RawSpeed {
 
-const uint32 bitMask[] = {  0xffffffff, 0x7fffffff,
-                           0x3fffffff, 0x1fffffff,
-                           0x0fffffff, 0x07ffffff,
-                           0x03ffffff, 0x01ffffff,
-                           0x00ffffff, 0x007fffff,
-                           0x003fffff, 0x001fffff,
-                           0x000fffff, 0x0007ffff,
-                           0x0003ffff, 0x0001ffff,
-                           0x0000ffff, 0x00007fff,
-                           0x00003fff, 0x00001fff,
-                           0x00000fff, 0x000007ff,
-                           0x000003ff, 0x000001ff,
-                           0x000000ff, 0x0000007f,
-                           0x0000003f, 0x0000001f,
-                           0x0000000f, 0x00000007,
-                           0x00000003, 0x00000001
-                        };
-
 LJpegDecompressor::LJpegDecompressor(FileMap* file, RawImage img):
     mFile(file), mRaw(img) {
   input = 0;
@@ -303,17 +285,17 @@ void LJpegDecompressor::parseDHT() {
     if (Th > 3)
       ThrowRDE("LJpegDecompressor::parseDHT: Invalid huffman table destination id.");
 
-    uint32 acc = 0;
     HuffmanTable* t = &huff[Th];
 
     if (t->initialized)
       ThrowRDE("LJpegDecompressor::parseDHT: Duplicate table definition");
 
-    for (uint32 i = 0; i < 16 ;i++) {
-      t->bits[i+1] = input->getByte();
-      acc += t->bits[i+1];
-    }
+    uint32 acc = 0;
     t->bits[0] = 0;
+    for (uint32 i = 1; i <= 16; i++) {
+      t->bits[i] = input->getByte();
+      acc += t->bits[i];
+    }
     memset(t->huffval, 0, sizeof(t->huffval));
     if (acc > 256)
       ThrowRDE("LJpegDecompressor::parseDHT: Invalid DHT table.");
@@ -343,56 +325,42 @@ JpegMarker LJpegDecompressor::getNextMarker(bool allowskip) {
       ThrowRDE("LJpegDecompressor::getNextMarker: (Noskip) Expected marker, but found stuffed 00 or ff.");
 
     return mark;
+  } else {
+    // skipToMarker
+    uchar8 c0, c1 = input->getByte();
+    do {
+      c0 = c1;
+      c1 = input->getByte();
+    } while (!(c0 == 0xFF && c1 != 0 && c1 != 0xFF));
+
+    return (JpegMarker)c1;
   }
-  input->skipToMarker();
-  uchar8 id = input->getByte();
-  _ASSERTE(0xff == id);
-  JpegMarker mark = (JpegMarker)input->getByte();
-  return mark;
 }
 
 void LJpegDecompressor::createHuffmanTable(HuffmanTable *htbl) {
-  int p, i, l, lastp, si;
   char huffsize[257];
   ushort16 huffcode[257];
-  ushort16 code;
-  int size;
-  int value, ll, ul;
 
   /*
   * Figure C.1: make table of Huffman code length for each symbol
-  * Note that this is in code-length order.
-  */
-  p = 0;
-  for (l = 1; l <= 16; l++) {
-    for (i = 1; i <= (int)htbl->bits[l]; i++) {
-      huffsize[p++] = (char)l;
-      if (p > 256)
-        ThrowRDE("LJpegDecompressor::createHuffmanTable: Code length too long. Corrupt data.");
-    }
-  }
-  huffsize[p] = 0;
-  lastp = p;
-
-
-  /*
   * Figure C.2: generate the codes themselves
   * Note that this is in code-length order.
   */
-  code = 0;
-  si = huffsize[0];
-  p = 0;
-  while (huffsize[p]) {
-    while (((int)huffsize[p]) == si) {
-      huffcode[p++] = code;
-      code++;
+  int p = 0;
+  ushort16 code = 0;
+  for (int l = 1; l <= 16; l++) {
+    for (uint32 i = 0; i < htbl->bits[l]; i++) {
+      huffsize[p] = l;
+      huffcode[p] = code;
+      ++code;
+      ++p;
+      if (p > 256)
+        ThrowRDE("LJpegDecompressor::createHuffmanTable: Code length too long. Corrupt data.");
     }
     code <<= 1;
-    si++;
-    if (p > 256)
-      ThrowRDE("createHuffmanTable: Code length too long. Corrupt data.");
   }
-
+  huffsize[p] = 0;
+  int lastp = p;
 
   /*
   * Figure F.15: generate decoding tables
@@ -400,7 +368,7 @@ void LJpegDecompressor::createHuffmanTable(HuffmanTable *htbl) {
   htbl->mincode[0] = 0;
   htbl->maxcode[0] = 0;
   p = 0;
-  for (l = 1; l <= 16; l++) {
+  for (int l = 1; l <= 16; l++) {
     if (htbl->bits[l]) {
       htbl->valptr[l] = p;
       htbl->mincode[l] = huffcode[p];
@@ -408,17 +376,20 @@ void LJpegDecompressor::createHuffmanTable(HuffmanTable *htbl) {
       htbl->maxcode[l] = huffcode[p - 1];
     } else {
       htbl->valptr[l] = 0xff;   // This check must be present to avoid crash on junk
-      htbl->maxcode[l] = -1;
+      htbl->maxcode[l] = 0;
     }
-    if (p > 256)
-      ThrowRDE("createHuffmanTable: Code length too long. Corrupt data.");
   }
 
   /*
   * We put in this value to ensure HuffDecode terminates.
   */
-  htbl->maxcode[17] = 0xFFFFFL;
+  htbl->maxcode[17] = 0xffff;
 
+  const ushort16 bitMask[] = {
+    0x00ff, 0x007f, 0x003f, 0x001f,
+    0x000f, 0x0007, 0x0003, 0x0001,
+    0x0
+  };
   /*
   * Build the numbits, value lookup tables.
   * These table allow us to gather 8 bits from the bits stream,
@@ -428,19 +399,14 @@ void LJpegDecompressor::createHuffmanTable(HuffmanTable *htbl) {
   */
   memset(htbl->numbits, 0, sizeof(htbl->numbits));
   for (p = 0; p < lastp; p++) {
-    size = huffsize[p];
+    int size = huffsize[p];
     if (size <= 8) {
-      value = htbl->huffval[p];
-      code = huffcode[p];
-      ll = code << (8 - size);
-      if (size < 8) {
-        ul = ll | bitMask[24+size];
-      } else {
-        ul = ll;
-      }
-      if (ul > 256 || ll > ul)
+      ushort16 ll = huffcode[p] << (8 - size);
+      ushort16 ul = ll | bitMask[size];
+      if (ul > 256)
         ThrowRDE("createHuffmanTable: Code length too long. Corrupt data.");
-      for (i = ll; i <= ul; i++) {
+      uint32 value = htbl->huffval[p];
+      for (ushort16 i = ll; i <= ul; i++) {
         htbl->numbits[i] = size | (value << 4);
       }
     }
@@ -463,27 +429,25 @@ void LJpegDecompressor::createHuffmanTable(HuffmanTable *htbl) {
  ************************************/
 
 void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
-  const uint32 bits = 14;      // HuffDecode functions must be changed, if this is modified.
+  const uint32 bits = HuffmanTable::TableBitDepth;      // HuffDecode functions must be changed, if this is modified.
   const uint32 size = 1 << bits;
-  int rv = 0;
-  int temp;
-  uint32 l;
 
   if (!htbl->bigTable)
     htbl->bigTable = (int*)_aligned_malloc(size * sizeof(int), 16);
   if (!htbl->bigTable)
-	ThrowRDE("Out of memory, failed to allocate %zu bytes", size*sizeof(int));
+    ThrowRDE("Out of memory, failed to allocate %zu bytes", size*sizeof(int));
   for (uint32 i = 0; i < size; i++) {
-    ushort16 input = i << 2; // Calculate input value
-    int code = input >> 8;   // Get 8 bits
+    ushort16 input = i << (16-bits); // Calculate input value
+    ushort16 code = input >> 8;   // Get 8 bits
+    ushort16 rv = 0;
     uint32 val = htbl->numbits[code];
-    l = val & 15;
+    uint32 l = val & 0xf;
     if (l) {
       rv = val >> 4;
     }  else {
       l = 8;
       while (code > htbl->maxcode[l]) {
-        temp = input >> (15 - l) & 1;
+        ushort16 temp = input >> (15 - l) & 1;
         code = (code << 1) | temp;
         l++;
       }
@@ -495,18 +459,16 @@ void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
       if (l > frame.prec || htbl->valptr[l] == 0xff) {
         htbl->bigTable[i] = 0xff;
         continue;
-      } else {
-        rv = htbl->huffval[htbl->valptr[l] +
-                           ((int)(code - htbl->mincode[l]))];
       }
+
+      rv = htbl->huffval[htbl->valptr[l] + (code - htbl->mincode[l])];
     }
 
 
     if (rv == 16) {
       if (mDNGCompatible)
-        htbl->bigTable[i] = (-(32768 << 8)) | (16 + l);
-      else
-        htbl->bigTable[i] = (-(32768 << 8)) | l;
+        l += 16;
+      htbl->bigTable[i] = (-(32768 << 8)) | l;
       continue;
     }
 
@@ -515,14 +477,10 @@ void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
       continue;
     }
 
-    if (rv) {
-      int x = input >> (16 - l - rv) & ((1 << rv) - 1);
-      if ((x & (1 << (rv - 1))) == 0)
-        x -= (1 << rv) - 1;
-      htbl->bigTable[i] = (x << 8) | (l + rv);
-    } else {
-      htbl->bigTable[i] = l;
-    }
+    htbl->bigTable[i] = l + rv;
+
+    if (rv)
+      htbl->bigTable[i] |= HuffExtend(rv, input >> (16 - l - rv) & ((1 << rv) - 1)) << 8;
   }
 }
 
@@ -544,32 +502,30 @@ void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
 *--------------------------------------------------------------
 */
 int LJpegDecompressor::HuffDecode(HuffmanTable *htbl) {
-  int rv;
-  int temp;
-  int code, val;
-  uint32 l;
   /**
-   * First attempt to do complete decode, by using the first 14 bits
+   * First attempt to do complete decode, by using the first TableBitDepth bits
    */
 
   bits->fill();
-  code = bits->peekBitsNoFill(14);
+  uint32 code = bits->peekBitsNoFill(HuffmanTable::TableBitDepth);
+
   if (htbl->bigTable) {
-    val = htbl->bigTable[code];
+    int val = htbl->bigTable[code];
     if ((val&0xff) !=  0xff) {
       bits->skipBitsNoFill(val&0xff);
       return val >> 8;
     }
   }
+
   /*
   * If the huffman code is less than 8 bits, we can use the fast
   * table lookup to get its value.  It's more than 8 bits about
   * 3-4% of the time.
   */
-  rv = 0;
-  code = code>>6;
-  val = htbl->numbits[code];
-  l = val & 15;
+  ushort16 rv = 0;
+  code >>= HuffmanTable::TableBitDepth-8;
+  uint32 val = htbl->numbits[code];
+  uint32 l = val & 0xf;
   if (l) {
     bits->skipBitsNoFill(l);
     rv = val >> 4;
@@ -577,7 +533,7 @@ int LJpegDecompressor::HuffDecode(HuffmanTable *htbl) {
     bits->skipBitsNoFill(8);
     l = 8;
     while (code > htbl->maxcode[l]) {
-      temp = bits->getBitNoFill();
+      uint32 temp = bits->getBitsNoFill(1);
       code = (code << 1) | temp;
       l++;
     }
@@ -586,12 +542,10 @@ int LJpegDecompressor::HuffDecode(HuffmanTable *htbl) {
     * With garbage input we may reach the sentinel value l = 17.
     */
 
-    if (l > frame.prec || htbl->valptr[l] == 0xff) {
+    if (l > frame.prec || htbl->valptr[l] == 0xff)
       ThrowRDE("Corrupt JPEG data: bad Huffman code:%u", l);
-    } else {
-      rv = htbl->huffval[htbl->valptr[l] +
-                         ((int)(code - htbl->mincode[l]))];
-    }
+
+    rv = htbl->huffval[htbl->valptr[l] + (code - htbl->mincode[l])];
   }
 
   if (rv == 16) {
@@ -600,25 +554,14 @@ int LJpegDecompressor::HuffDecode(HuffmanTable *htbl) {
     return -32768;
   }
 
-  // Ensure we have enough bits
-  if ((rv + l) > 24) {
-    if (rv > 16) // There is no values above 16 bits.
-      ThrowRDE("Corrupt JPEG data: Too many bits requested.");
-    else
-      bits->fill();
-  }
-
   /*
   * Section F.2.2.1: decode the difference and
   * Figure F.12: extend sign bit
   */
 
-  if (rv) {
-    int x = bits->getBitsNoFill(rv);
-    if ((x & (1 << (rv - 1))) == 0)
-      x -= (1 << rv) - 1;
-    return x;
-  }
+  if (rv)
+    return HuffExtend(rv, bits->getBitsNoFill(rv));
+
   return 0;
 }
 

--- a/RawSpeed/LJpegDecompressor.cpp
+++ b/RawSpeed/LJpegDecompressor.cpp
@@ -554,6 +554,11 @@ int LJpegDecompressor::HuffDecode(HuffmanTable *htbl) {
     return -32768;
   }
 
+  // check for the rare case that our cache in the bitpump is not large enough
+  if ((rv + l) > 24) {
+    bits->fill();
+  }
+
   /*
   * Section F.2.2.1: decode the difference and
   * Figure F.12: extend sign bit

--- a/RawSpeed/LJpegDecompressor.h
+++ b/RawSpeed/LJpegDecompressor.h
@@ -143,11 +143,13 @@ struct HuffmanTable {
   */
 
   ushort16 mincode[17];
-  int maxcode[18];
-  short valptr[17];
+  ushort16 maxcode[18];
+  ushort16 valptr[17];
   uint32 numbits[256];
   int* bigTable;
   bool initialized;
+
+  static const uint32 TableBitDepth = 13;
 };
 
 class SOFInfo {
@@ -184,6 +186,10 @@ protected:
   JpegMarker getNextMarker(bool allowskip);
   void parseDHT();
   int HuffDecode(HuffmanTable *htbl);
+  inline int HuffExtend(uint32 len, uint32 diff) {
+    int x = diff;
+    return ((x & (1 << (len - 1))) == 0) ? x - (1 << len) + 1 : x;
+  }
   ByteStream* input;
   BitPumpJPEG* bits;
   FileMap *mFile;

--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -52,21 +52,15 @@ RawImage RafDecoder::decodeRawInternal() {
     width = raw->getEntry(FUJI_RAWIMAGEFULLWIDTH)->getInt();
   } else if (raw->hasEntry(IMAGEWIDTH)) {
     TiffEntry *e = raw->getEntry(IMAGEWIDTH);
-    if (e->count < 2)
-      ThrowRDE("Fuji decoder: Size array too small");
     height = e->getShort(0);
     width = e->getShort(1);
-  } 
+  } else
+    ThrowRDE("RAF decoder: Unable to locate image size");
+
   if (raw->hasEntry(FUJI_LAYOUT)) {
     TiffEntry *e = raw->getEntry(FUJI_LAYOUT);
-    if (e->count < 2)
-      ThrowRDE("Fuji decoder: Layout array too small");
-    const uchar8 *layout = e->getData();
-    alt_layout = !(layout[0] >> 7);
+    alt_layout = !(e->getByte(0) >> 7);
   }
-
-  if (width <= 0 ||  height <= 0)
-    ThrowRDE("RAF decoder: Unable to locate image size");
 
   TiffEntry *offsets = raw->getEntry(FUJI_STRIPOFFSETS);
   TiffEntry *counts = raw->getEntry(FUJI_STRIPBYTECOUNTS);
@@ -94,7 +88,7 @@ RawImage RafDecoder::decodeRawInternal() {
   ByteStream input(mFile, off);
   iPoint2D pos(0, 0);
 
-  if (count*8/(width*height) < 10) {
+  if (counts->getInt()*8/(width*height) < 10) {
     ThrowRDE("Don't know how to decode compressed images");
   } else if (double_width) {
     Decode16BitRawUnpacked(input, width*2, height);

--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -69,7 +69,6 @@ RawImage RafDecoder::decodeRawInternal() {
     ThrowRDE("RAF Decoder: Multiple Strips found: %u %u", offsets->count, counts->count);
 
   int off = offsets->getInt();
-  int count = counts->getInt();
 
   int bps = 16;
   if (raw->hasEntry(FUJI_BITSPERSAMPLE))

--- a/RawSpeed/TiffEntry.cpp
+++ b/RawSpeed/TiffEntry.cpp
@@ -117,7 +117,7 @@ bool TiffEntry::isInt() {
 }
 
 uchar8 TiffEntry::getByte(uint32 num) {
-  if (type != TIFF_BYTE)
+  if (type != TIFF_BYTE && type != TIFF_UNDEFINED)
     ThrowTPE("TIFF, getByte: Wrong type %u encountered. Expected Byte on 0x%x", type, tag);
 
   if (num >= bytesize)


### PR DESCRIPTION
This is the first part of my bigger infrastructure cleanup efforts. It is actually pretty small and the different patches are only loosely related. I tried to extract as many small patches as possible before going for the big change, which is going to be huge because the FileMap/BytesStream(Swap)/TiffEntry(BE)/BitPump* rewrites are all interdependent.

The different Huffman decoder changes are meant to make the different similar versions even more equal, to show that they can actually be combined later on.