### PR TITLE
Rw2Decoder: fix default CFA pattern...

### DIFF
--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -194,7 +194,7 @@ void Rw2Decoder::checkSupportInternal(CameraMetaData *meta) {
 }
 
 void Rw2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_BLUE, CFA_GREEN, CFA_GREEN2, CFA_RED);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_BLUE, CFA_GREEN, CFA_GREEN, CFA_RED);
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())


### PR DESCRIPTION
... allowing to successfully decode unknown Panasonic models.