### PR TITLE
rstest workflow improvement

### DIFF
--- a/RawSpeed/rstest.cpp
+++ b/RawSpeed/rstest.cpp
@@ -31,7 +31,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#include <vector>
+#include <map>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -269,7 +269,7 @@ int main(int argc, char **argv) {
   CameraMetaData metadata(CMAKE_SOURCE_DIR "/data/cameras.xml");
 
   size_t time = 0;
-  vector<string> failedTests;
+  map<string, string> failedTests;
 #ifdef _OPENMP
 #pragma omp parallel for default(shared) schedule(static, 1) reduction(+ : time)
 #endif
@@ -284,8 +284,9 @@ int main(int argc, char **argv) {
 #pragma omp critical(io)
 #endif
       {
-        failedTests.push_back(string(argv[i]) + " failed: " + e.what());
-        cerr << failedTests.back() << endl;
+        string msg = string(argv[i]) + " failed: " + e.what();
+        cerr << msg << endl;
+        failedTests.emplace(argv[i], msg);
       }
     }
   }
@@ -295,8 +296,13 @@ int main(int argc, char **argv) {
   if (!failedTests.empty()) {
     cerr << "WARNING: the following " << failedTests.size()
          << " tests have failed:\n";
-    for (const auto &i : failedTests)
-      cerr << i << "\n";
+    for (const auto &i : failedTests) {
+      cerr << i.second << "\n";
+#ifndef WIN32
+      if (system(("diff -u0 " + i.first + ".hash* >> rstest.log").c_str()))
+        ; // this is only to supress the warn-unused-result warning
+#endif
+    }
   }
 
   return failedTests.empty() ? 0 : 1;

--- a/RawSpeed/rstest.cpp
+++ b/RawSpeed/rstest.cpp
@@ -164,6 +164,9 @@ size_t process(const string &filename, CameraMetaData *metadata, bool create,
   // if not creating and hash is missing -> skip as well
   ifstream hf(hashfile);
   if (!(hf.good() ^ create)) {
+#ifdef _OPENMP
+#pragma omp critical(io)
+#endif
     cout << left << setw(55) << filename << ": hash "
          << (create ? "exists" : "missing") << ", skipping" << endl;
     return 0;


### PR DESCRIPTION
a omp fix and an automatic generation of a log file showing all the diffs from all failed tests.

This allows to quickly go over the hash diffs to find out what went wrong. it looks like this will happen quite often in the future: with every new info in the cameras.xml.