### PR TITLE
Leica X2: add dng support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8976,6 +8976,9 @@
 	<Camera make="Leica Camera AG" model="LEICA M (Typ 240)" mode="dng">
 		<ID make="Leica" model="M (Typ 240)">LEICA M (Typ 240)</ID>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA X2" mode="dng">
+		<ID make="Leica" model="X2">LEICA X2</ID>
+	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="GR" mode="dng">
 		<ID make="Ricoh" model="GR">GR</ID>
 	</Camera>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -359,6 +359,7 @@
       <xs:enumeration value="Konica Minolta Camera, Inc."/>
       <xs:enumeration value="LEICA"/>
       <xs:enumeration value="Leaf"/>
+      <xs:enumeration value="LEICA CAMERA AG"/>
       <xs:enumeration value="Leica Camera AG"/>
       <xs:enumeration value="Mamiya-OP Co.,Ltd."/>
       <xs:enumeration value="Matrix"/>


### PR DESCRIPTION
samples can be used from darktable #10950

dng is the only raw mode, no file size settings according to user manual