### PR TITLE
Huffman decoder rewrite / cleanup

### DIFF
--- a/RawSpeed/Buffer.h
+++ b/RawSpeed/Buffer.h
@@ -51,6 +51,8 @@ public:
   Buffer() = default;
   // Allocates the memory
   Buffer(size_type size);
+  // Data already allocated
+  explicit Buffer(const uchar8* data, size_type size) : data(data), size(size) {}
   // creates a (non-owning) copy / view of rhs
   Buffer(const Buffer& rhs)
     : data(rhs.data), size(rhs.size) {}
@@ -71,6 +73,19 @@ public:
 
   // get pointer to memory at 'offset', make sure at least 'count' bytes are accessable
   const uchar8* getData(size_type offset, size_type count) const;
+
+  // convenience getter for single bytes
+  uchar8 operator[](size_type offset) const {
+    return *getData(offset, 1);
+  }
+
+  // std begin/end iterators to allow for range loop
+  const uchar8* begin() const {
+    return data;
+  }
+  const uchar8* end() const {
+    return data + size;
+  }
 
   // get memory of type T from byte offset 'offset + sizeof(T)*index' and swap byte order if required
   template<typename T> inline T get(bool inNativeByteOrder, size_type offset, size_type index = 0) const {
@@ -100,9 +115,6 @@ public:
   }
 
 protected:
-  // Data already allocated
-  Buffer(const uchar8* data, size_type size) : data(data), size(size) {}
-
   const uchar8* data = nullptr;
   size_type size = 0;
   bool isOwner = false;

--- a/RawSpeed/ByteStream.h
+++ b/RawSpeed/ByteStream.h
@@ -72,6 +72,11 @@ public:
     pos += count;
     return ret;
   }
+  inline Buffer getBuffer(size_type size) {
+    Buffer ret = getSubView(pos, size);
+    pos += size;
+    return ret;
+  }
 
   inline uchar8 peekByte(size_type i = 0) const {
     check(i+1);

--- a/RawSpeed/HuffmanTable.h
+++ b/RawSpeed/HuffmanTable.h
@@ -1,0 +1,271 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2017 Axel Waggershauser
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "Buffer.h"
+
+/*
+* The following code is inspired by the IJG JPEG library.
+*
+* Copyright (C) 1991, 1992, Thomas G. Lane.
+* Part of the Independent JPEG Group's software.
+* See the file Copyright for more details.
+*
+* Copyright (c) 1993 Brian C. Smith, The Regents of the University
+* of California
+* All rights reserved.
+*
+* Copyright (c) 1994 Kongji Huang and Brian C. Smith.
+* Cornell University
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software and its
+* documentation for any purpose, without fee, and without written agreement is
+* hereby granted, provided that the above copyright notice and the following
+* two paragraphs appear in all copies of this software.
+*
+* IN NO EVENT SHALL CORNELL UNIVERSITY BE LIABLE TO ANY PARTY FOR
+* DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
+* OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF CORNELL
+* UNIVERSITY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* CORNELL UNIVERSITY SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+* AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+* ON AN "AS IS" BASIS, AND CORNELL UNIVERSITY HAS NO OBLIGATION TO
+* PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+*/
+
+namespace RawSpeed {
+
+class HuffmanTable
+{
+  // private fields calculated from codesPerBits and codeValues
+  // they are index '1' based, so we can directly lookup the value
+  // for code length l without decrementing
+  vector<ushort16> maxCodeOL;    // index is length of code
+  vector<ushort16> codeOffsetOL; // index is length of code
+
+  // The code can be compiled with two different decode lookup table layouts.
+  // The idea is that different CPU architectures may perform better with
+  // one or the other, depending on the relative performance of their arithmetic
+  // core vs their memory access. For an Intel Core i7, the big table is better.
+#if 1
+  // lookup table containing 3 fields: payload:16|flag:8|len:8
+  // The payload may be the fully decoded diff or the length of the diff.
+  // The len field contains the number of bits, this lookup consumed.
+  // A lookup value of 0 means the code was too big to fit into the table.
+  // The optimal LookupDepth is also likely to depend on the CPU architecture.
+  static constexpr unsigned PayloadShift = 16;
+  static constexpr unsigned FlagMask = 0x100;
+  static constexpr unsigned LenMask = 0xff;
+  static constexpr unsigned LookupDepth = 13;
+  vector<int32> decodeLookup;
+#else
+  // lookup table containing 2 fields: payload:4|len:4
+  // the payload is the length of the diff, len is the length of the code
+  static constexpr unsigned LookupDepth = 15;
+  static constexpr unsigned PayloadShift = 4;
+  static constexpr unsigned FlagMask = 0;
+  static constexpr unsigned LenMask = 0x0f;
+  vector<uchar8> decodeLookup;
+#endif
+
+  bool fixDNGBug16 = false;
+
+  size_t maxCodePlusDiffLength() const {
+    return nCodesPerLength.size()-1 + codeValues.size()-1;
+  }
+
+public:
+
+  // These two fields directly represent the contents of a JPEG DHT field
+  // 1. The number of codes there are per bit length, this is index 1 based.
+  // (there are always 0 codes of length 0)
+  vector<int> nCodesPerLength; // index is length of code
+  // 2. This is the actual huffman encoded data, i.e. the 'alphabet'. Each value
+  // is the number of bits following the code that encode the difference to the
+  // last pixel. Valid values are in the range 0..16.
+  // signExtended() is used to decode the difference bits to a signed int.
+  vector<uchar8> codeValues;   // index is just sequential number
+
+  bool operator==(const HuffmanTable& other) const {
+    return nCodesPerLength == other.nCodesPerLength
+        && codeValues      == other.codeValues;
+  }
+
+  uint32 setNCodesPerLength(const Buffer& data) {
+    assert(data.getSize() == 16);
+    nCodesPerLength.resize(17);
+    copy(data.begin(), data.end(), &nCodesPerLength[1]);
+    return accumulate(data.begin(), data.end(), 0);
+  }
+
+  void setCodeValues(const Buffer& data) {
+    // spec says max 16 but Hasselblad ignores that -> allow 17
+    assert(data.getSize() <= 17);
+    codeValues.assign(data.begin(), data.end());
+  }
+
+  void setup(bool fullDecode, bool fixDNGBug16) {
+    this->fixDNGBug16 = fixDNGBug16;
+
+    // store the code lengths in bits, valid values are 0..16
+    vector<uchar8> code_len; // index is just sequential number
+    // store the codes themselfs (bit patterns found inside the stream)
+    vector<ushort16> codes;  // index is just sequential number
+
+    // trim empty entries from the codes per length table on the right
+    while (!nCodesPerLength.back())
+      nCodesPerLength.pop_back();
+    int maxCodeLength = nCodesPerLength.size()-1;
+
+    // Figure C.1: make table of Huffman code length for each symbol
+    // Figure C.2: generate the codes themselves
+    uint32 code = 0;
+    for (int l = 1; l <= maxCodeLength; ++l) {
+      assert(nCodesPerLength[l] < (1<<l));
+      for (int i = 0; i < nCodesPerLength[l]; ++i) {
+        assert(code <= 0xffff);
+        code_len.push_back(l);
+        codes.push_back(code++);
+      }
+      code <<= 1;
+    }
+
+    // Figure F.15: generate decoding tables
+    codeOffsetOL.resize(maxCodeLength+1, 0xffff);
+    maxCodeOL.resize(maxCodeLength+1);
+    int code_index = 0;
+    for (int l = 1; l <= maxCodeLength; l++) {
+      if (nCodesPerLength[l]) {
+        codeOffsetOL[l] = codes[code_index] - code_index;
+        code_index += nCodesPerLength[l];
+        maxCodeOL[l] = codes[code_index - 1];
+      }
+    }
+
+    // Generate lookup table for fast decoding lookup.
+    // See definition of decodeLookup above
+    decodeLookup.resize(1 << LookupDepth);
+    for (size_t i = 0; i < codes.size(); i++) {
+      uchar8 code_l = code_len[i];
+      if (code_l > (int)LookupDepth)
+        break;
+
+      ushort16 ll = codes[i] << (LookupDepth - code_l);
+      ushort16 ul = ll | ((1 << (LookupDepth - code_l)) - 1);
+      ushort16 diff_l = codeValues[i];
+      for (ushort16 c = ll; c <= ul; c++) {
+        if (!FlagMask || !fullDecode || diff_l + code_l > LookupDepth) {
+          // lookup bit depth is too small to fit both the encoded length
+          // and the final difference value.
+          // -> store only the length and do a normal sign extension later
+          decodeLookup[c] = diff_l << PayloadShift | code_l;
+        } else {
+          // diff_l + code_l <= lookupDepth
+          // The table bit depth is large enough to store both.
+          decodeLookup[c] = (code_l + diff_l) | FlagMask;
+
+          if (diff_l) {
+            uint32 diff = (c >> (LookupDepth - code_l - diff_l)) & ((1 << diff_l) - 1);
+            decodeLookup[c] |= (uint32)signExtended(diff, diff_l) << PayloadShift;
+          }
+        }
+      }
+    }
+  }
+
+  inline static int signExtended(uint32 diff, uint32 len) {
+#if 0
+#define _X(x) (1<<x)-1
+    constexpr static int offset[16] = {
+      0,     _X(1), _X(2),  _X(3),  _X(4),  _X(5),  _X(6),  _X(7),
+      _X(8), _X(9), _X(10), _X(11), _X(12), _X(13), _X(14), _X(15)};
+#undef _X
+    if ((diff & (1 << (len - 1))) == 0)
+      diff -= offset[len];
+#else
+    if ((diff & (1 << (len - 1))) == 0)
+      diff -= (1 << len) - 1;
+#endif
+    return diff;
+  }
+
+  template<typename BIT_STREAM> inline int decodeLength(BIT_STREAM& bs) const {
+    return decode<BIT_STREAM, false>(bs);
+  }
+
+  template<typename BIT_STREAM> inline int decodeNext(BIT_STREAM& bs) const {
+    return decode<BIT_STREAM, true>(bs);
+  }
+
+  // The bool template paraeter is to enable two versions:
+  // one returning only the length of the of diff bits (see Hasselblad),
+  // one to return the fully decoded diff.
+  // All ifs depending on this bool will be optimized out by the compiler
+  template<typename BIT_STREAM, bool FULL_DECODE> inline int decode(BIT_STREAM& bs) const {
+    // 32 is the absolute maximum combined length of code + diff
+    // for processors supporting bmi2 instructions, using maxCodePlusDiffLength()
+    // might be benifitial
+    bs.fill(32);
+    uint32 code = bs.peekBitsNoFill(LookupDepth);
+
+    int val = decodeLookup[code];
+    int len = val & LenMask;
+    // if the code is invalid (bitstream corrupted) len will be 0
+    bs.skipBitsNoFill(len);
+    if (FULL_DECODE && val & FlagMask) {
+      // if the flag bit is set, the payload is the already sign extended difference
+      return val >> PayloadShift;
+    } else if (len) {
+      // if the flag bit is not set but len != 0, the payload is the number of bits to sign extend and return
+      int l_diff = val >> PayloadShift;
+      return FULL_DECODE ? signExtended(bs.getBitsNoFill(l_diff), l_diff) : l_diff;
+    } else {
+      uint32 code_l = LookupDepth;
+      bs.skipBitsNoFill(code_l);
+      while (code_l < maxCodeOL.size() && code > maxCodeOL[code_l]) {
+        uint32 temp = bs.getBitsNoFill(1);
+        code = (code << 1) | temp;
+        code_l++;
+      }
+
+      if (code > maxCodeOL[code_l])
+        ThrowRDE("Corrupt JPEG data: bad Huffman code: %u (len: %u)", code, code_l);
+
+      int diff_l = codeValues[code - codeOffsetOL[code_l]];
+
+      if (!FULL_DECODE)
+        return diff_l;
+
+      if (diff_l == 16) {
+        if (fixDNGBug16)
+          bs.skipBits(16);
+        return -32768;
+      }
+
+      return diff_l ? signExtended(bs.getBitsNoFill(diff_l), diff_l) : 0;
+    }
+  }
+};
+
+} // namespace RawSpeed

--- a/RawSpeed/HuffmanTable.h
+++ b/RawSpeed/HuffmanTable.h
@@ -77,7 +77,7 @@ class HuffmanTable
   static constexpr unsigned PayloadShift = 16;
   static constexpr unsigned FlagMask = 0x100;
   static constexpr unsigned LenMask = 0xff;
-  static constexpr unsigned LookupDepth = 13;
+  static constexpr unsigned LookupDepth = 11;
   vector<int32> decodeLookup;
 #else
   // lookup table containing 2 fields: payload:4|len:4

--- a/RawSpeed/HuffmanTable.h
+++ b/RawSpeed/HuffmanTable.h
@@ -116,6 +116,9 @@ public:
     assert(data.getSize() == 16);
     nCodesPerLength.resize(17);
     copy(data.begin(), data.end(), &nCodesPerLength[1]);
+    // trim empty entries from the codes per length table on the right
+    while (nCodesPerLength.back() == 0)
+      nCodesPerLength.pop_back();
     return accumulate(data.begin(), data.end(), 0);
   }
 
@@ -133,9 +136,6 @@ public:
     // store the codes themselfs (bit patterns found inside the stream)
     vector<ushort16> codes;  // index is just sequential number
 
-    // trim empty entries from the codes per length table on the right
-    while (!nCodesPerLength.back())
-      nCodesPerLength.pop_back();
     int maxCodeLength = nCodesPerLength.size()-1;
 
     // Figure C.1: make table of Huffman code length for each symbol

--- a/RawSpeed/LJpegDecompressor.cpp
+++ b/RawSpeed/LJpegDecompressor.cpp
@@ -223,7 +223,8 @@ void LJpegDecompressor::parseDHT() {
   // in the huffmanTableStore to be later transalted to pointers.
   // neccessary because the addition of objects to the store invalidates pointers
   // so we can not directly store the pointers during processing the header
-  array<int, 4> index = {-1, -1, -1, -1};
+  array<int, 4> index;
+  index.fill(-1);
 
   while (headerLength)  {
     uint32 b = input->getByte();

--- a/RawSpeed/LJpegDecompressor.h
+++ b/RawSpeed/LJpegDecompressor.h
@@ -170,7 +170,7 @@ protected:
   uint32 offX, offY;  // Offset into image where decoding should start
   uint32 skipX, skipY;   // Tile is larger than output, skip these border pixels
   array<HuffmanTable*, 4> huff {}; // 4 pointers into the store
-  vector<HuffmanTable> huffmanTableStore;
+  vector<unique_ptr<HuffmanTable>> huffmanTableStore; // vector of unique HTs
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/LJpegPlain.cpp
+++ b/RawSpeed/LJpegPlain.cpp
@@ -160,7 +160,7 @@ void LJpegPlain::decodeScanLeftGeneric() {
   uint32 pixGroup = 0;   // How many pixels per group.
 
   for (uint32 i = 0; i < comps; i++) {
-    dctbl[i] = &huff[frame.compInfo[i].dcTblNo];
+    dctbl[i] = huff[frame.compInfo[i].dcTblNo];
     samplesH[i] = frame.compInfo[i].superH;
     if (!isPowerOfTwo(samplesH[i]))
       ThrowRDE("LJpegPlain::decodeScanLeftGeneric: Horizontal sampling is not power of two.");
@@ -334,9 +334,9 @@ void LJpegPlain::decodeScanLeft4_2_0() {
   _ASSERTE(frame.cps == COMPS);
   _ASSERTE(skipX == 0);
 
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = &huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = &huff[frame.compInfo[2].dcTblNo];
+  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
+  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
+  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
 
   ushort16 *predict;      // Prediction pointer
 
@@ -478,9 +478,9 @@ void LJpegPlain::decodeScanLeft4_2_2() {
   _ASSERTE(frame.cps == COMPS);
   _ASSERTE(skipX == 0);
 
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = &huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = &huff[frame.compInfo[2].dcTblNo];
+  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
+  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
+  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
 
   mRaw->metadata.subsampling.x = 2;
   mRaw->metadata.subsampling.y = 1;
@@ -605,8 +605,8 @@ void LJpegPlain::decodeScanLeft2Comps() {
 
   uchar8 *draw = mRaw->getData();
   // First line
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = &huff[frame.compInfo[1].dcTblNo];
+  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
+  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
 
   //Prepare slices (for CR2)
   uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
@@ -706,9 +706,9 @@ void LJpegPlain::decodeScanLeft2Comps() {
 void LJpegPlain::decodeScanLeft3Comps() {
   uchar8 *draw = mRaw->getData();
   // First line
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = &huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = &huff[frame.compInfo[2].dcTblNo];
+  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
+  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
+  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
 
   //Prepare slices (for CR2)
   uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
@@ -812,10 +812,10 @@ void LJpegPlain::decodeScanLeft3Comps() {
 
 void LJpegPlain::decodeScanLeft4Comps() {
   // First line
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = &huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = &huff[frame.compInfo[2].dcTblNo];
-  HuffmanTable *dctbl4 = &huff[frame.compInfo[3].dcTblNo];
+  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
+  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
+  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
+  HuffmanTable *dctbl4 = huff[frame.compInfo[3].dcTblNo];
 
   if (mCanonDoubleHeight) {
     frame.h *= 2;

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -32,9 +32,9 @@ NikonDecompressor::NikonDecompressor(FileMap* file, RawImage img) :
 
 void NikonDecompressor::initTable(uint32 huffSelect) {
   if (huffmanTableStore.empty())
-    huffmanTableStore.emplace_back();
+    huffmanTableStore.emplace_back(make_unique<HuffmanTable>());
 
-  huff[0] = &huffmanTableStore.back();
+  huff[0] = huffmanTableStore.back().get();
 
   uint32 count = huff[0]->setNCodesPerLength(Buffer(nikon_tree[huffSelect], 16));
   huff[0]->setCodeValues(Buffer(nikon_tree[huffSelect]+16, count));

--- a/RawSpeed/NikonDecompressor.h
+++ b/RawSpeed/NikonDecompressor.h
@@ -37,7 +37,6 @@ public:
   bool uncorrectedRawValues;
 private:
   void initTable(uint32 huffSelect);
-  int HuffDecodeNikon(BitPumpMSB& bits);
 };
 
 static const uchar8 nikon_tree[][32] = {

--- a/RawSpeed/PentaxDecompressor.h
+++ b/RawSpeed/PentaxDecompressor.h
@@ -2,7 +2,6 @@
 #define PENTAX_DECOMPRESSOR_H
 
 #include "LJpegDecompressor.h"
-#include "BitPumpMSB.h"
 #include "TiffIFD.h"
 
 /* 
@@ -29,15 +28,11 @@
 
 namespace RawSpeed {
 
-class PentaxDecompressor :
-  public LJpegDecompressor
+class PentaxDecompressor final : public LJpegDecompressor
 {
 public:
-  PentaxDecompressor(FileMap* file, RawImage img);
-  virtual ~PentaxDecompressor(void);
-  int HuffDecodePentax();
+  using LJpegDecompressor::LJpegDecompressor;
   void decodePentax(TiffIFD *root, uint32 offset, uint32 size);
-  BitPumpMSB *pentaxBits;
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/StdAfx.h
+++ b/RawSpeed/StdAfx.h
@@ -106,6 +106,7 @@ extern "C" {
 #include <memory>
 #include <array>
 #include <algorithm>
+#include <numeric>
 using namespace std;
 
 #ifdef HAVE_ZLIB

--- a/RawSpeed/StdAfx.h
+++ b/RawSpeed/StdAfx.h
@@ -104,6 +104,8 @@ extern "C" {
 #include <map>
 #include <list>
 #include <memory>
+#include <array>
+#include <algorithm>
 using namespace std;
 
 #ifdef HAVE_ZLIB


### PR DESCRIPTION
This is pretty much a rewrite of all Huffman decoding related code.

The PR size is a lot smaller than the 'big' one recently even though it is still relatively big. There was simply no meaningful way to reduce that further. It is basically just a single new implementation in HuffmanTable.h and then the removal of all the former implementations and minor adoptions to the calling code where necessary.

For details about the changes see https://github.com/darktable-org/rawspeed/commit/b213eafc6b3d4a565e52aa97b95872adebcc1879.

TL;DR: less code + faster code => better code