### PR TITLE
TiffParser.cpp: fix leak on throw

### DIFF
--- a/RawSpeed/TiffParser.cpp
+++ b/RawSpeed/TiffParser.cpp
@@ -150,6 +150,8 @@ RawDecoder* makeDecoder(TiffRootIFDOwner _root, Buffer &data) {
     }
   }
 
+  delete root;
+
   throw TiffParserException("No decoder found. Sorry.");
   return nullptr;
 }


### PR DESCRIPTION
This got introduced in the interface between the new unique_ptr based
TiffIFDRoot and the yet to be updated Tiff based decoder code.