### PR TITLE
LJpegCompressor and subclass cleanup

### DIFF
--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -71,7 +71,7 @@ RawImage Cr2Decoder::decodeOldFormat() {
   mRaw->createData();
   LJpegPlain l(mFile, mRaw);
   try {
-    l.startDecoder(off, mFile->getSize()-off, 0, 0);
+    l.decode(off, mFile->getSize()-off, 0, 0);
   } catch (IOException& e) {
     mRaw->setError(e.what());
   }
@@ -229,11 +229,10 @@ RawImage Cr2Decoder::decodeNewFormat() {
     try {
       LJpegPlain l(mFile, mRaw);
       l.addSlices(s_width);
-      l.mUseBigtable = true;
       l.mCanonFlipDim = flipDims;
       l.mCanonDoubleHeight = doubleHeight;
       l.mWrappedCr2Slices = wrappedCr2Slices;
-      l.startDecoder(slice.offset, slice.size, 0, offY);
+      l.decode(slice.offset, slice.size, 0, offY);
     } catch (RawDecoderException &e) {
       if (i == 0)
         throw;

--- a/RawSpeed/DngDecoderSlices.cpp
+++ b/RawSpeed/DngDecoderSlices.cpp
@@ -356,10 +356,9 @@ void DngDecoderSlices::decodeSlice(DngDecoderThread* t) {
       LJpegPlain l(mFile, mRaw);
       l.mDNGCompatible = mFixLjpeg;
       DngSliceElement e = t->slices.front();
-      l.mUseBigtable = e.mUseBigtable;
       t->slices.pop();
       try {
-        l.startDecoder(e.byteOffset, e.byteCount, e.offX, e.offY);
+        l.decode(e.byteOffset, e.byteCount, e.offX, e.offY);
       } catch (RawDecoderException &err) {
         mRaw->setError(err.what());
       } catch (IOException &err) {

--- a/RawSpeed/HasselbladDecompressor.h
+++ b/RawSpeed/HasselbladDecompressor.h
@@ -2,13 +2,12 @@
 #define HASSELBLAD_DECOMPRESSOR_H
 
 #include "LJpegDecompressor.h"
-#include "BitPumpMSB.h"
-#include "TiffIFD.h"
 
 /*
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -29,21 +28,14 @@
 
 namespace RawSpeed {
 
-class HasselbladDecompressor :
-  public LJpegDecompressor
+class HasselbladDecompressor final : public LJpegDecompressor
 {
+  virtual void decodeScan();
+
 public:
-  HasselbladDecompressor(FileMap *file, const RawImage &img);
-  virtual ~HasselbladDecompressor(void);
-  int HuffDecodeHasselblad();
-  void decodeHasselblad(TiffIFD *root, uint32 offset, uint32 size);
-  int pixelBaseOffset;
-protected:
-  int HuffGetLength();
-  virtual void parseSOS();
-  void decodeScanHasselblad();
-  inline int getBits(int len);
-  BitPumpMSB32* ph1_bits;  // Phase One has unescaped bits.
+  using LJpegDecompressor::LJpegDecompressor;
+
+  int pixelBaseOffset = 0;
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/LJpegPlain.cpp
+++ b/RawSpeed/LJpegPlain.cpp
@@ -4,6 +4,7 @@
 RawSpeed - RAW file decoder.
 
 Copyright (C) 2009-2014 Klaus Post
+Copyright (C) 2017 Axel Waggershauser
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -18,28 +19,14 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
-http://www.klauspost.com
 */
 
 namespace RawSpeed {
 
-LJpegPlain::LJpegPlain(FileMap *file, const RawImage &img)
-    : LJpegDecompressor(file, img) {
-  offset = 0;
-  slice_width = 0;
-}
-
-LJpegPlain::~LJpegPlain(void) {
-  if (offset)
-    delete[](offset);
-  offset = 0;
-  if (slice_width)
-    delete[](slice_width);
-  slice_width = 0;
-}
-
 void LJpegPlain::decodeScan() {
+
+  if (pred != 1)
+    ThrowRDE("LJpegDecompressor::decodeScan: Unsupported prediction direction.");
 
   // Fix for Canon 6D mRaw, which has flipped width & height for some part of the image
   // We temporarily swap width and height for cropping.
@@ -62,823 +49,127 @@ void LJpegPlain::decodeScan() {
     frame.h = w;
   }
 
+  if (frame.h == 0 || frame.w == 0)
+    ThrowRDE("LJpegPlain::decodeScan: Image width or height set to zero");
+
   /* Correct wrong slice count (Canon G16) */
   if (slicesW.size() == 1)
     slicesW[0] = frame.w * frame.cps;
 
- if (slicesW.empty())
+  if (slicesW.empty())
     slicesW.push_back(frame.w*frame.cps);
 
-  if ( 0 == frame.h || 0 == frame.w)
-    ThrowRDE("LJpegPlain::decodeScan: Image width or height set to zero");
+  bool isSubSampled = false;
+  for (uint32 i = 0; i < frame.cps;  i++)
+    isSubSampled |= frame.compInfo[i].superH != 1 || frame.compInfo[i].superV != 1;
 
-  for (uint32 i = 0; i < frame.cps;  i++) {
-    if (frame.compInfo[i].superH != 1 || frame.compInfo[i].superV != 1) {
-      if (mRaw->isCFA)
-        ThrowRDE("LJpegDecompressor::decodeScan: Cannot decode subsampled image to CFA data");
+  if (isSubSampled) {
+    if (mRaw->isCFA)
+      ThrowRDE("LJpegDecompressor::decodeScan: Cannot decode subsampled image to CFA data");
 
-      if (mRaw->getCpp() != frame.cps)
-        ThrowRDE("LJpegDecompressor::decodeScan: Subsampled component count does not match image.");
+    if (mRaw->getCpp() != frame.cps)
+      ThrowRDE("LJpegDecompressor::decodeScan: Subsampled component count does not match image.");
 
-      if (pred == 1) {
-        if (frame.compInfo[0].superH == 2 && frame.compInfo[0].superV == 2 &&
-            frame.compInfo[1].superH == 1 && frame.compInfo[1].superV == 1 &&
-            frame.compInfo[2].superH == 1 && frame.compInfo[2].superV == 1) {
-          // Something like Cr2 sRaw1, use fast decoder
-          decodeScanLeft4_2_0();
-          return;
-        } else if (frame.compInfo[0].superH == 2 && frame.compInfo[0].superV == 1 &&
-                   frame.compInfo[1].superH == 1 && frame.compInfo[1].superV == 1 &&
-                   frame.compInfo[2].superH == 1 && frame.compInfo[2].superV == 1) {
-          // Something like Cr2 sRaw2, use fast decoder
-          if (mCanonFlipDim)
-            ThrowRDE("LJpegDecompressor::decodeScan: Cannot flip non 4:2:2 subsampled images.");
-          decodeScanLeft4_2_2();
-          return;
-        } else {
-          ThrowRDE("LJpegDecompressor::decodeScan: Unsupported subsampling");
-          decodeScanLeftGeneric();
-          return;
-        }
-      } else {
-        ThrowRDE("LJpegDecompressor::decodeScan: Unsupported prediction direction.");
-      }
+    if (frame.cps != 3 || frame.compInfo[0].superH != 2 ||
+        (frame.compInfo[0].superV != 2 && frame.compInfo[0].superV != 1) ||
+        frame.compInfo[1].superH != 1 || frame.compInfo[1].superV != 1 ||
+        frame.compInfo[2].superH != 1 || frame.compInfo[2].superV != 1)
+      ThrowRDE("LJpegDecompressor::decodeScan: Unsupported subsampling");
+
+    if (frame.compInfo[0].superV == 2) {
+      // Something like Cr2 sRaw1, use fast decoder
+      decodeN_X_Y<3, 2, 2>();
+    } else { // frame.compInfo[0].superV == 1
+      if (mCanonFlipDim)
+        ThrowRDE("LJpegDecompressor::decodeScan: Cannot flip non 4:2:2 subsampled images.");
+      // Something like Cr2 sRaw2, use fast decoder
+      decodeN_X_Y<3, 2, 1>();
     }
-  }
-
-  if (pred == 1) {
+  } else {
     if (mCanonFlipDim)
       ThrowRDE("LJpegDecompressor::decodeScan: Cannot flip non subsampled images.");
-    if (mRaw->dim.y * mRaw->pitch >= 1<<28) {
-      decodeScanLeftGeneric();
-      return;
-    }
+
     if (frame.cps == 2)
-      decodeScanLeft2Comps();
-    else if (frame.cps == 3)
-      decodeScanLeft3Comps();
+      decodeN_X_Y<2, 1, 1>();
     else if (frame.cps == 4)
-      decodeScanLeft4Comps();
+      decodeN_X_Y<4, 1, 1>();
     else
       ThrowRDE("LJpegDecompressor::decodeScan: Unsupported component direction count.");
-    return;
   }
-  ThrowRDE("LJpegDecompressor::decodeScan: Unsupported prediction direction.");
 }
 
-/**
-*  CR2 Slice handling:
-*  In the following code, canon slices are handled in-place, to avoid having to
-*  copy the entire frame afterwards.
-*  The "offset" array is created to easily map slice positions on to the output image.
-*  The offset array size is the number of slices multiplied by height.
-*  Each of these offsets are an offset into the destination image, and it also contains the
-*  slice number (shifted up 28 bits), so it is possible to retrieve the width of each slice.
-*  Every time "components" pixels has been processed the slice size is tested, and output offset
-*  is adjusted if needed. This makes slice handling very "light", since it involves a single
-*  counter, and a predictable branch.
-*  For unsliced images, add one slice with the width of the image.
-**/
+// little 'forced' loop unrolling helper tool, example:
+//   unroll_loop<N>([&](int i) {
+//     func(i);
+//   });
+// will translate to:
+//   func(0); func(1); func(2); ... func(N-1);
 
-void LJpegPlain::decodeScanLeftGeneric() {
-  _ASSERTE(slicesW.size() < 16);  // We only have 4 bits for slice number.
-  _ASSERTE(!(slicesW.size() > 1 && skipX)); // Check if this is a valid state
-
-  uint32 comps = frame.cps;  // Components
-  HuffmanTable *dctbl[4];   // Tables for up to 4 components
-  ushort16 *predict;         // Prediction pointer
-  /* Fast access to supersampling component settings
-  * this is the number of components in a given block.
-  */
-  uint32 samplesH[4];
-  uint32 samplesV[4];
-
-  uchar8 *draw = mRaw->getData();
-  uint32 maxSuperH = 1;
-  uint32 maxSuperV = 1;
-  uint32 samplesComp[4]; // How many samples per group does this component have
-  uint32 pixGroup = 0;   // How many pixels per group.
-
-  for (uint32 i = 0; i < comps; i++) {
-    dctbl[i] = huff[frame.compInfo[i].dcTblNo];
-    samplesH[i] = frame.compInfo[i].superH;
-    if (!isPowerOfTwo(samplesH[i]))
-      ThrowRDE("LJpegPlain::decodeScanLeftGeneric: Horizontal sampling is not power of two.");
-    maxSuperH = max(samplesH[i], maxSuperH);
-    samplesV[i] = frame.compInfo[i].superV;
-    if (!isPowerOfTwo(samplesV[i]))
-      ThrowRDE("LJpegPlain::decodeScanLeftGeneric: Vertical sampling is not power of two.");
-    maxSuperV = max(samplesV[i], maxSuperV);
-    samplesComp[i] = samplesV[i] * samplesH[i];
-    pixGroup += samplesComp[i];
+template <typename Lambda, size_t N>
+struct unroll_loop_t {
+  inline static void repeat(const Lambda& f) {
+    unroll_loop_t<Lambda, N-1>::repeat(f);
+    f(N-1);
   }
+};
 
-  mRaw->metadata.subsampling.x = maxSuperH;
-  mRaw->metadata.subsampling.y = maxSuperV;
+template <typename Lambda>
+struct unroll_loop_t<Lambda, 0> {
+  inline static void repeat(const Lambda& f) {}
+};
 
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (frame.h - skipY) / maxSuperV;
-  ushort16** imagePos = new ushort16*[slices+1];
-  int* sliceWidth = new int[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  uint32 pitch_s = mRaw->pitch / 2;  // Pitch in shorts
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / pixGroup / maxSuperH; // This is a guess, but works for sRaw1+2.
-
-  if (skipX && (maxSuperV > 1 || maxSuperH > 1)) {
-    ThrowRDE("LJpegPlain::decodeScanLeftGeneric: Cannot skip right border in subsampled mode");
-  }
-  if (skipX) {
-    slice_width[slicesW.size()-1] -= skipX;
-  }
-
-  for (slice = 0; slice < slices; slice++) {
-    imagePos[slice] = (ushort16*)&draw[(t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)];
-    sliceWidth[slice] = slice_width[t_s];
-    t_y += maxSuperV;
-    if (t_y >= (frame.h - skipY)) {
-      t_y = 0;
-      t_x += slice_width[t_s++];
-    }
-  }
-  delete[] slice_width;
-  slice_width = NULL;
-
-  // We check the final position. If bad slice sizes are given we risk writing outside the image
-  if (imagePos[slices-1] >= (ushort16*)&mRaw->getData()[mRaw->pitch * mRaw->dim.y]) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-  imagePos[slices] = imagePos[slices-1];      // Extra offset to avoid branch in loop.
-  sliceWidth[slices] = sliceWidth[slices-1];        // Extra offset to avoid branch in loop.
-
-  // Predictors for components
-  int p[4];
-  ushort16 *dest = imagePos[0];
-
-  // Always points to next slice
-  slice = 1;
-  uint32 pixInSlice = sliceWidth[0];
-
-  // Initialize predictors and decode one group.
-  uint32 x = 0;
-  predict = dest;
-  for (uint32 i = 0; i < comps; i++) {
-    for (uint32 y2 = 0; y2 < samplesV[i]; y2++) {
-      for (uint32 x2 = 0; x2 < samplesH[i]; x2++) {
-        // First pixel is not predicted, all other are.
-        if (y2 == 0 && x2 == 0) {
-          *dest = p[i] = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl[i]);
-        } else {
-          p[i] += HuffDecode(dctbl[i]);
-          _ASSERTE(p[i] >= 0 && p[i] < 65536);
-          dest[x2*comps+y2*pitch_s] = p[i];
-        }
-      }
-    }
-    // Set predictor for this component
-    // Next component
-    dest++;
-  }
-
-  // Increment destination to next group
-  dest += (maxSuperH - 1) * comps;
-  x = maxSuperH;
-  pixInSlice -= maxSuperH;
-
-
-  uint32 cw = (frame.w - skipX);
-  uint32 ch = (frame.h - skipY);
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
-  for (uint32 y = 0;y < ch;y += maxSuperV) {
-    for (; x < cw ; x += maxSuperH) {
-
-      if (0 == pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        pixInSlice = sliceWidth[slice];
-        dest = imagePos[slice];  // Adjust destination for next pixel
-
-        slice++;
-        // If new are at the start of a new line, also update predictors.
-        if (x == 0)
-          predict = dest;
-      }
-
-      for (uint32 i = 0; i < comps; i++) {
-        for (uint32 y2 = 0; y2 < samplesV[i]; y2++) {
-          for (uint32 x2 = 0; x2 < samplesH[i]; x2++) {
-            p[i] += HuffDecode(dctbl[i]);
-            _ASSERTE(p[i] >= 0 && p[i] < 65536);
-            dest[x2*comps+y2*pitch_s] = p[i];
-          }
-        }
-        dest++;
-      }
-      dest += (maxSuperH * comps) - comps;
-      pixInSlice -= maxSuperH;
-    }
-
-    if (skipX) {
-      for (uint32 sx = 0; sx < skipX; sx++) {
-        for (uint32 i = 0; i < comps; i++) {
-          HuffDecode(dctbl[i]);
-        }
-      }
-    }
-
-    // Update predictors
-    for (uint32 i = 0; i < comps; i++) {
-      p[i] = predict[i];
-      // Ensure, that there is a slice shift at new line
-      if (!(pixInSlice == 0 || maxSuperV == 1))
-        ThrowRDE("LJpegPlain::decodeScanLeftGeneric: Slice not placed at new line");
-    }
-    // Check if we are still within the file.
-    bits->checkPos();
-    predict = dest;
-    x = 0;
-  }
-  delete[] imagePos;
-  delete[] sliceWidth;
+template <size_t N, typename Lambda>
+inline void unroll_loop(const Lambda& f) {
+  unroll_loop_t<Lambda, N>::repeat(f);
 }
 
-#define COMPS 3
-/*************************************************************************/
-/* These are often used compression schemes, heavily optimized to decode */
-/* that specfic kind of images.                                          */
-/*************************************************************************/
+// N_COMP == number of components (2, 3 or 4)
+// X_S_F  == x/horizontal sampling factor (1 or 2)
+// Y_S_F  == y/vertical   sampling factor (1 or 2)
 
-void LJpegPlain::decodeScanLeft4_2_0() {
+template<int N_COMP, int X_S_F, int Y_S_F>
+void LJpegPlain::decodeN_X_Y() {
   _ASSERTE(slicesW.size() < 16);  // We only have 4 bits for slice number.
-  _ASSERTE(!(slicesW.size() > 1 && skipX)); // Check if this is a valid state
-  _ASSERTE(frame.compInfo[0].superH == 2);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[0].superV == 2);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[1].superH == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[1].superV == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[2].superH == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[2].superV == 1);   // Check if this is a valid state
-  _ASSERTE(frame.cps == COMPS);
-  _ASSERTE(skipX == 0);
+  _ASSERTE(!(slicesW.size() > 1 && skipX));
+  _ASSERTE(frame.compInfo[0].superH == X_S_F);
+  _ASSERTE(frame.compInfo[0].superV == Y_S_F);
+  _ASSERTE(frame.compInfo[1].superH == 1);
+  _ASSERTE(frame.compInfo[1].superV == 1);
+  _ASSERTE(frame.cps == N_COMP);
+  _ASSERTE(skipX == 0 || X_S_F == 1);
 
-  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
+  // old code said this is only relevant for full-res raws
+  mCanonDoubleHeight &= Y_S_F == 1 && X_S_F == 1;
+  // old code said this is only relevant for s/mRaws
+  mCanonFlipDim &= X_S_F == 2;
 
-  ushort16 *predict;      // Prediction pointer
+  if (mCanonDoubleHeight) {
+    mRaw->destroyData();
+    frame.h *= 2;
+    mRaw->dim = iPoint2D(frame.w * 2, frame.h);
+    mRaw->createData();
+  }
 
-  mRaw->metadata.subsampling.x = 2;
-  mRaw->metadata.subsampling.y = 2;
+  HuffmanTable* ht[N_COMP] = {0};
+  for (int i = 0; i < N_COMP; ++i)
+    ht[i] = huff[frame.compInfo[i].dcTblNo];
 
-  uchar8 *draw = mRaw->getData();
+  mRaw->metadata.subsampling.x = X_S_F;
+  mRaw->metadata.subsampling.y = Y_S_F;
+
   // Fix for Canon 6D mRaw, which has flipped width & height
   uint32 real_h = mCanonFlipDim ? frame.w : frame.h;
 
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (real_h - skipY) / 2;
-  offset = new uint32[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  uint32 pitch_s = mRaw->pitch / 2;  // Pitch in shorts
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / COMPS;
-
-  for (slice = 0; slice < slices; slice++) {
-    offset[slice] = ((t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)) | (t_s << 28);
-    _ASSERTE((offset[slice]&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-    t_y += 2;
-    if (t_y >= (real_h- skipY)) {
-      t_y = 0;
-      t_x += slice_width[t_s++];
-    }
-  }
-
-  // We check the final position. If bad slice sizes are given we risk writing outside the image
-  if ((offset[slices-1]&0x0fffffff) >= mRaw->pitch*mRaw->dim.y) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-
-  offset[slices] = offset[slices-1];        // Extra offset to avoid branch in loop.
-
-  if (skipX)
-    slice_width[slicesW.size()-1] -= skipX;
-
-  // Predictors for components
-  ushort16 *dest = (ushort16*) & draw[offset[0] & 0x0fffffff];
-
-  // Always points to next slice
-  slice = 1;
-  uint32 pixInSlice = slice_width[0];
-
-  // Initialize predictors and decode one group.
-  uint32 x = 0;
-  int p1;
-  int p2;
-  int p3;
-  // First pixel is not predicted, all other are.
-  *dest = p1 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl1);
-  p1 = dest[COMPS] = p1 + HuffDecode(dctbl1);
-  p1 = dest[pitch_s] = p1 + HuffDecode(dctbl1);
-  p1 = dest[COMPS+pitch_s] = p1 + HuffDecode(dctbl1);
-  predict = dest;
-
-  dest[1] = p2 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl2);
-  dest[2] = p3 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl3);
-
-  // Skip next
-  dest += COMPS * 2;
-
-  x = 2;
-  pixInSlice -= 2;
+  // Initialize predictors
+  int p[N_COMP];
+  for (int i = 0; i < N_COMP; ++i)
+    p[i] = (1 << (frame.prec - Pt - 1));
 
   uint32 cw = (frame.w - skipX);
   uint32 ch = (frame.h - skipY);
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
-  for (uint32 y = 0;y < ch;y += 2) {
-    for (; x < cw ; x += 2) {
-
-      if (0 == pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        uint32 o = offset[slice++];
-        dest = (ushort16*) & draw[o&0x0fffffff];  // Adjust destination for next pixel
-        _ASSERTE((o&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-        if((o&0x0fffffff) > mRaw->pitch*mRaw->dim.y)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Offset out of bounds");
-        pixInSlice = slice_width[o>>28];
-
-        // If new are at the start of a new line, also update predictors.
-        if (x == 0) {
-          predict = dest;
-        }
-      }
-      p1 += HuffDecode(dctbl1);
-      *dest = p1;
-      p1 += HuffDecode(dctbl1);
-      dest[COMPS] = p1;
-      p1 += HuffDecode(dctbl1);
-      dest[pitch_s] = p1;
-      p1 += HuffDecode(dctbl1);
-      dest[pitch_s+COMPS] = p1;
-
-      dest[1] = p2 = p2 + HuffDecode(dctbl2);
-      dest[2] = p3 = p3 + HuffDecode(dctbl3);
-
-      dest += COMPS * 2;
-      pixInSlice -= 2;
-    }
-
-    // Update predictors
-    p1 = predict[0];
-    p2 = predict[1];
-    p3 = predict[2];
-    _ASSERTE(pixInSlice == 0);  // Ensure, that there is a slice shift at new line
-    // Check if we are still within the file.
-    bits->checkPos();
-
-    x = 0;
-  }
-}
-
-void LJpegPlain::decodeScanLeft4_2_2() {
-  _ASSERTE(slicesW.size() < 16);  // We only have 4 bits for slice number.
-  _ASSERTE(!(slicesW.size() > 1 && skipX)); // Check if this is a valid state
-  _ASSERTE(frame.compInfo[0].superH == 2);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[0].superV == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[1].superH == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[1].superV == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[2].superH == 1);   // Check if this is a valid state
-  _ASSERTE(frame.compInfo[2].superV == 1);   // Check if this is a valid state
-  _ASSERTE(frame.cps == COMPS);
-  _ASSERTE(skipX == 0);
-
-  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
-
-  mRaw->metadata.subsampling.x = 2;
-  mRaw->metadata.subsampling.y = 1;
-
-  ushort16 *predict;      // Prediction pointer
-
-  uchar8 *draw = mRaw->getData();
-
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
-  offset = new uint32[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / 2;
-
-  for (slice = 0; slice < slices; slice++) {
-    offset[slice] = ((t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)) | (t_s << 28);
-    _ASSERTE((offset[slice]&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-    t_y ++;
-    if (t_y >= (frame.h - skipY)) {
-      t_y = 0;
-      t_x += slice_width[t_s++];
-    }
-  }
-  if ((offset[slices-1]&0x0fffffff) >= mRaw->pitch*mRaw->dim.y) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-
-  offset[slices] = offset[slices-1];        // Extra offset to avoid branch in loop.
-
-  if (skipX)
-    slice_width[slicesW.size()-1] -= skipX;
-
-  // Predictors for components
-  ushort16 *dest = (ushort16*) & draw[offset[0] & 0x0fffffff];
-
-  // Always points to next slice
-  slice = 1;
-  uint32 pixInSlice = slice_width[0];
-
-  // Initialize predictors and decode one group.
-  uint32 x = 0;
-  int p1;
-  int p2;
-  int p3;
-  // First pixel is not predicted, all other are.
-  *dest = p1 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl1);
-  p1 = dest[COMPS] = p1 + HuffDecode(dctbl1);
-  predict = dest;
-
-  dest[1] = p2 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl2);
-  dest[2] = p3 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl3);
-
-  // Skip to next
-  dest += COMPS * 2;
-
-  x = 2;
-  pixInSlice -= 2;
-
-  uint32 cw = (frame.w - skipX);
-  uint32 ch = (frame.h - skipY);
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
-  for (uint32 y = 0;y < ch;y++) {
-    for (; x < cw ; x += 2) {
-
-      if (0 == pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        uint32 o = offset[slice++];
-        dest = (ushort16*) & draw[o&0x0fffffff];  // Adjust destination for next pixel
-        if((o&0x0fffffff) > mRaw->pitch*mRaw->dim.y)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Offset out of bounds");
-        pixInSlice = slice_width[o>>28];
-
-        // If new are at the start of a new line, also update predictors.
-        if (x == 0) {
-          predict = dest;
-        }
-      }
-      p1 += HuffDecode(dctbl1);
-      *dest = p1;
-      p1 += HuffDecode(dctbl1);
-      dest[COMPS] = p1;
-
-      dest[1] = p2 = p2 + HuffDecode(dctbl2);
-      dest[2] = p3 = p3 + HuffDecode(dctbl3);
-
-      dest += COMPS * 2;
-      pixInSlice -= 2;
-    }
-
-    // Update predictors
-    p1 = predict[0];
-    p2 = predict[1];
-    p3 = predict[2];
-    predict = dest;
-    x = 0;
-    // Check if we are still within the file.
-    bits->checkPos();
-  }
-}
-
-#undef COMPS
-#define COMPS 2
-void LJpegPlain::decodeScanLeft2Comps() {
-  _ASSERTE(slicesW.size() < 16);  // We only have 4 bits for slice number.
-  _ASSERTE(!(slicesW.size() > 1 && skipX)); // Check if this is a valid state
-
-  uchar8 *draw = mRaw->getData();
-  // First line
-  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
-
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
-  offset = new uint32[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  uint32 cw = (frame.w - skipX);
-  for (slice = 0; slice < slices; slice++) {
-    offset[slice] = ((t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)) | (t_s << 28);
-    _ASSERTE((offset[slice]&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-    t_y++;
-    if (t_y == (frame.h - skipY)) {
-      t_y = 0;
-      t_x += slicesW[t_s++];
-    }
-  }
-  // We check the final position. If bad slice sizes are given we risk writing outside the image
-  if ((offset[slices-1]&0x0fffffff) >= mRaw->pitch*mRaw->dim.y) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-  offset[slices] = offset[slices-1];        // Extra offset to avoid branch in loop.
-
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / COMPS;
-
-  if (skipX)
-    slice_width[slicesW.size()-1] -= skipX;
-
-  // First pixels are obviously not predicted
-  int p1;
-  int p2;
-  ushort16 *dest = (ushort16*) & draw[offset[0] & 0x0fffffff];
-  ushort16 *predict = dest;
-  *dest++ = p1 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl1);
-  *dest++ = p2 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl2);
-
-  slice = 1;    // Always points to next slice
-  uint32 pixInSlice = slice_width[0] - 1;  // Skip first pixel
-
-  uint32 x = 1;                            // Skip first pixels on first line.
-  uint32 ch = (frame.h - skipY);
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
-  for (uint32 y = 0;y < ch;y++) {
-    for (; x < cw ; x++) {
-      int diff = HuffDecode(dctbl1);
-      p1 += diff;
-      *dest++ = (ushort16)p1;
-  //    _ASSERTE(p1 >= 0 && p1 < 65536);
-
-      diff = HuffDecode(dctbl2);
-      p2 += diff;
-      *dest++ = (ushort16)p2;
-//      _ASSERTE(p2 >= 0 && p2 < 65536);
-
-      if (0 == --pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        uint32 o = offset[slice++];
-        dest = (ushort16*) & draw[o&0x0fffffff];  // Adjust destination for next pixel
-        if((o&0x0fffffff) > mRaw->pitch*mRaw->dim.y)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Offset out of bounds");
-        pixInSlice = slice_width[o>>28];
-      }
-    }
-
-    if (skipX) {
-      for (uint32 i = 0; i < skipX; i++) {
-        HuffDecode(dctbl1);
-        HuffDecode(dctbl2);
-      }
-    }
-
-    p1 = predict[0];  // Predictors for next row
-    p2 = predict[1];
-    predict = dest;  // Adjust destination for next prediction
-    x = 0;
-    bits->checkPos();
-  }
-}
-
-#undef COMPS
-#define COMPS 3
-
-void LJpegPlain::decodeScanLeft3Comps() {
-  uchar8 *draw = mRaw->getData();
-  // First line
-  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
-
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
-  offset = new uint32[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  for (slice = 0; slice < slices; slice++) {
-    offset[slice] = ((t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)) | (t_s << 28);
-    _ASSERTE((offset[slice]&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-    t_y++;
-    if (t_y == (frame.h - skipY)) {
-      t_y = 0;
-      t_x += slicesW[t_s++];
-    }
-  }
-  // We check the final position. If bad slice sizes are given we risk writing outside the image
-  if ((offset[slices-1]&0x0fffffff) >= mRaw->pitch*mRaw->dim.y) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-
-  offset[slices] = offset[slices-1];        // Extra offset to avoid branch in loop.
-
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / COMPS;
-
-  if (skipX)
-    slice_width[slicesW.size()-1] -= skipX;
-
-  // First pixels are obviously not predicted
-  int p1;
-  int p2;
-  int p3;
-  ushort16 *dest = (ushort16*) & draw[offset[0] & 0x0fffffff];
-  ushort16 *predict = dest;
-  *dest++ = p1 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl1);
-  *dest++ = p2 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl2);
-  *dest++ = p3 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl3);
-
-  slice = 1;
-  uint32 pixInSlice = slice_width[0] - 1;
-
-  uint32 cw = (frame.w - skipX);
-  uint32 x = 1;                            // Skip first pixels on first line.
-  uint32 ch = (frame.h - skipY);
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
-  for (uint32 y = 0;y < ch;y++) {
-    for (; x < cw ; x++) {
-      p1 += HuffDecode(dctbl1);
-      *dest++ = (ushort16)p1;
-
-      p2 += HuffDecode(dctbl2);
-      *dest++ = (ushort16)p2;
-
-      p3 += HuffDecode(dctbl3);
-      *dest++ = (ushort16)p3;
-
-      if (0 == --pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        uint32 o = offset[slice++];
-        dest = (ushort16*) & draw[o&0x0fffffff];  // Adjust destination for next pixel
-        if((o&0x0fffffff) > mRaw->pitch*mRaw->dim.y)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Offset out of bounds");
-        _ASSERTE((o >> 28) < slicesW.size());
-        pixInSlice = slice_width[o>>28];
-      }
-    }
-
-    if (skipX) {
-      for (uint32 i = 0; i < skipX; i++) {
-        HuffDecode(dctbl1);
-        HuffDecode(dctbl2);
-        HuffDecode(dctbl3);
-      }
-    }
-
-    p1 = predict[0];  // Predictors for next row
-    p2 = predict[1];
-    p3 = predict[2];  // Predictors for next row
-    predict = dest;  // Adjust destination for next prediction
-    x = 0;
-    bits->checkPos();
-  }
-}
-
-#undef COMPS
-#define COMPS 4
-
-void LJpegPlain::decodeScanLeft4Comps() {
-  // First line
-  HuffmanTable *dctbl1 = huff[frame.compInfo[0].dcTblNo];
-  HuffmanTable *dctbl2 = huff[frame.compInfo[1].dcTblNo];
-  HuffmanTable *dctbl3 = huff[frame.compInfo[2].dcTblNo];
-  HuffmanTable *dctbl4 = huff[frame.compInfo[3].dcTblNo];
-
-  if (mCanonDoubleHeight) {
-    frame.h *= 2;
-    mRaw->dim = iPoint2D(frame.w * 2, frame.h);
-    mRaw->destroyData();
-    mRaw->createData();
-  }
-  uchar8 *draw = mRaw->getData();
-
-  //Prepare slices (for CR2)
-  uint32 slices = (uint32)slicesW.size() * (frame.h - skipY);
-  offset = new uint32[slices+1];
-
-  uint32 t_y = 0;
-  uint32 t_x = 0;
-  uint32 t_s = 0;
-  uint32 slice = 0;
-  for (slice = 0; slice < slices; slice++) {
-    offset[slice] = ((t_x + offX) * mRaw->getBpp() + ((offY + t_y) * mRaw->pitch)) | (t_s << 28);
-    _ASSERTE((offset[slice]&0x0fffffff) < mRaw->pitch*mRaw->dim.y);
-    t_y++;
-    if (t_y == (frame.h - skipY)) {
-      t_y = 0;
-      t_x += slicesW[t_s++];
-    }
-  }
-  // We check the final position. If bad slice sizes are given we risk writing outside the image
-  if ((offset[slices-1]&0x0fffffff) >= mRaw->pitch*mRaw->dim.y) {
-    ThrowRDE("LJpegPlain::decodeScanLeft: Last slice out of bounds");
-  }
-  offset[slices] = offset[slices-1];        // Extra offset to avoid branch in loop.
-
-  slice_width = new int[slices];
-
-  // This is divided by comps, since comps pixels are processed at the time
-  for (uint32 i = 0 ; i <  slicesW.size(); i++)
-    slice_width[i] = slicesW[i] / COMPS;
-
-  if (skipX)
-    slice_width[slicesW.size()-1] -= skipX;
-
-  // First pixels are obviously not predicted
-  int p1;
-  int p2;
-  int p3;
-  int p4;
-  ushort16 *dest = (ushort16*) & draw[offset[0] & 0x0fffffff];
-  ushort16 *predict = dest;
-  *dest++ = p1 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl1);
-  *dest++ = p2 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl2);
-  *dest++ = p3 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl3);
-  *dest++ = p4 = (1 << (frame.prec - Pt - 1)) + HuffDecode(dctbl4);
-
-  slice = 1;
-  uint32 pixInSlice = slice_width[0] - 1;
-
-  uint32 cw = (frame.w - skipX);
-  uint32 x = 1;                            // Skip first pixels on first line.
 
   if (mCanonDoubleHeight)
-    skipY = frame.h >> 1;
-
-  uint32 ch = (frame.h - skipY);
+    ch = frame.h / 2;
 
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
@@ -887,46 +178,76 @@ void LJpegPlain::decodeScanLeft4Comps() {
   if (mWrappedCr2Slices)
     ch = frame.h;
 
-  for (uint32 y = 0;y < ch;y++) {
-    for (; x < cw ; x++) {
-      p1 += HuffDecode(dctbl1);
-      *dest++ = (ushort16)p1;
+  BitPumpJPEG bitStream(*input);
+  uint32 pixel_pitch = mRaw->pitch / 2; // Pitch in pixel
 
-      p2 += HuffDecode(dctbl2);
-      *dest++ = (ushort16)p2;
+  // To understand the CR2 slice handling and sampling factor behavior, see
+  // https://github.com/lclevy/libcraw2/blob/master/docs/cr2_lossless.pdf?raw=true
 
-      p3 += HuffDecode(dctbl3);
-      *dest++ = (ushort16)p3;
+  uint32 t_s = 0, t_x = 0, t_y = 0;
+  constexpr int div = X_S_F == 2 ? Y_S_F+1 : N_COMP;
+  // in full raw (<N,1,1>) the width of a slice is the number of raw pixels,
+  // i.e. frame.w * frame.cps
+  uint32 pixInSlicedLine = 0;
+  ushort16* dest = (ushort16*)mRaw->getDataUncropped(offX, offY);
 
-      p4 += HuffDecode(dctbl4);
-      *dest++ = (ushort16)p4;
+  for (uint32 y = 0; y < ch; y += Y_S_F) {
+    const ushort16* predict = dest;
+    for (uint32 x = 0; x < cw; x += X_S_F) {
+      // inner loop decodes one group of pixels at a time
+      //  * for <N,1,1>: N  = N*1*1 (full raw)
+      //  * for <3,2,1>: 6  = 3*2*1
+      //  * for <3,2,2>: 12 = 3*2*2
 
-      if (0 == --pixInSlice) { // Next slice
-        if (slice > slices)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Ran out of slices");
-        uint32 o = offset[slice++];
-        dest = (ushort16*) & draw[o&0x0fffffff];  // Adjust destination for next pixel
-        if((o&0x0fffffff) > mRaw->pitch*mRaw->dim.y)
-          ThrowRDE("LJpegPlain::decodeScanLeft: Offset out of bounds");
-        pixInSlice = slice_width[o>>28];
+      if (pixInSlicedLine == 0) { // Next slice
+        pixInSlicedLine = slicesW[t_s] / div;
+        dest = (ushort16*)mRaw->getDataUncropped(t_x + offX, t_y + offY);
+        if (x == 0 && y != 0)
+          predict = dest;
+
+        t_y += Y_S_F;
+        if (t_y >= (real_h - skipY)) {
+          t_y = 0;
+          if (X_S_F == 2)
+            t_x += slicesW[t_s] / div;
+          else
+            t_x += slicesW[t_s];
+          ++t_s;
+        }
       }
-    }
-    if (skipX) {
-      for (uint32 i = 0; i < skipX; i++) {
-        HuffDecode(dctbl1);
-        HuffDecode(dctbl2);
-        HuffDecode(dctbl3);
-        HuffDecode(dctbl4);
+
+      if (X_S_F == 1) { // will be optimized out
+        unroll_loop<N_COMP>([&](int i) {
+          *dest++ = p[i] += ht[i]->decodeNext(bitStream);
+        });
+      } else {
+        unroll_loop<Y_S_F>([&](int i) {
+          dest[0 + i*pixel_pitch] = p[0] += ht[0]->decodeNext(bitStream);
+          dest[3 + i*pixel_pitch] = p[0] += ht[0]->decodeNext(bitStream);
+        });
+
+        dest[1] = p[1] += ht[1]->decodeNext(bitStream);
+        dest[2] = p[2] += ht[2]->decodeNext(bitStream);
+
+        dest += 3 * sizeof(ushort16);
       }
+
+      pixInSlicedLine -= X_S_F;
     }
-    bits->checkPos();
-    p1 = predict[0];  // Predictors for next row
-    p2 = predict[1];
-    p3 = predict[2];  // Predictors for next row
-    p4 = predict[3];
-    predict = dest;  // Adjust destination for next prediction
-    x = 0;
+
+    if (X_S_F == 1) // will be optimized out
+      for (uint32 i = 0; i < skipX; i++)
+        unroll_loop<N_COMP>([&](int i) {
+          ht[i]->decodeNext(bitStream);
+        });
+
+    // Update predictors
+    unroll_loop<N_COMP>([&](int i) {
+      p[i] = predict[i];
+    });
   }
+
+  input->skipBytes(bitStream.getBufferPosition());
 }
 
 } // namespace RawSpeed

--- a/RawSpeed/LJpegPlain.h
+++ b/RawSpeed/LJpegPlain.h
@@ -2,11 +2,11 @@
 #define LJPEG_PLAIN_H
 
 #include "LJpegDecompressor.h"
-#include "BitPumpMSB.h"
 /* 
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -27,27 +27,15 @@
 
 namespace RawSpeed {
 
-/******************
- * Decompresses Lossless non subsampled JPEGs, with 2-4 components
- *****************/
+// Decompresses Lossless JPEGs, with 2-4 components and optional X/Y subsampling
 
-class LJpegPlain :
-  public LJpegDecompressor
+class LJpegPlain final : public LJpegDecompressor
 {
-public:
-  LJpegPlain(FileMap *file, const RawImage &img);
-  virtual ~LJpegPlain(void);
-protected:
   virtual void decodeScan();
-private:
-  void decodeScanLeft4Comps();
-  void decodeScanLeft2Comps();
-  void decodeScanLeft3Comps();
-  void decodeScanLeftGeneric();
-  void decodeScanLeft4_2_0();
-  void decodeScanLeft4_2_2();
-  uint32 *offset;
-  int* slice_width;
+  template<int N_COMP, int X_S_F, int Y_S_F> void decodeN_X_Y();
+
+public:
+  using LJpegDecompressor::LJpegDecompressor;
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -107,11 +107,8 @@ RawImage NefDecoder::decodeRawInternal() {
   }
 
   try {
-    NikonDecompressor decompressor(mFile, mRaw);
-    decompressor.uncorrectedRawValues = uncorrectedRawValues;
-    ByteStream bs(meta->getData());
-
-    decompressor.DecompressNikon(&bs, width, height, bitPerPixel, offsets->getInt(), counts->getInt());
+    decompressNikon(mRaw, ByteStream(mFile, offsets->getInt(), counts->getInt()),
+                    meta->getData(), width, height, bitPerPixel, uncorrectedRawValues);
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -1,6 +1,7 @@
 #include "StdAfx.h"
 #include "NikonDecompressor.h"
 #include "BitPumpMSB.h"
+#include "HuffmanTable.h"
 
 /*
     RawSpeed - RAW file decoder.
@@ -26,42 +27,49 @@
 
 namespace RawSpeed {
 
-NikonDecompressor::NikonDecompressor(FileMap *file, const RawImage &img)
-    : LJpegDecompressor(file, img) {}
+static const uchar8 nikon_tree[][32] = {
+  { 0,1,5,1,1,1,1,1,1,2,0,0,0,0,0,0,	/* 12-bit lossy */
+  5,4,3,6,2,7,1,0,8,9,11,10,12 },
+  { 0,1,5,1,1,1,1,1,1,2,0,0,0,0,0,0,	/* 12-bit lossy after split */
+  0x39,0x5a,0x38,0x27,0x16,5,4,3,2,1,0,11,12,12 },
+  { 0,1,4,2,3,1,2,0,0,0,0,0,0,0,0,0,  /* 12-bit lossless */
+  5,4,6,3,7,2,8,1,9,0,10,11,12 },
+  { 0,1,4,3,1,1,1,1,1,2,0,0,0,0,0,0,	/* 14-bit lossy */
+  5,6,4,7,8,3,9,2,1,0,10,11,12,13,14 },
+  { 0,1,5,1,1,1,1,1,1,1,2,0,0,0,0,0,	/* 14-bit lossy after split */
+  8,0x5c,0x4b,0x3a,0x29,7,6,5,4,3,2,1,0,13,14 },
+  { 0,1,4,2,2,3,1,2,0,0,0,0,0,0,0,0,	/* 14-bit lossless */
+  7,6,8,5,9,4,10,3,11,12,2,0,1,13,14 } };
 
-void NikonDecompressor::initTable(uint32 huffSelect) {
-  if (huffmanTableStore.empty())
-    huffmanTableStore.emplace_back(make_unique<HuffmanTable>());
 
-  huff[0] = huffmanTableStore.back().get();
-
-  uint32 count = huff[0]->setNCodesPerLength(Buffer(nikon_tree[huffSelect], 16));
-  huff[0]->setCodeValues(Buffer(nikon_tree[huffSelect]+16, count));
-
-  huff[0]->setup(mUseBigtable, false);
+static HuffmanTable createHuffmanTable(uint32 huffSelect) {
+  HuffmanTable ht;
+  uint32 count = ht.setNCodesPerLength(Buffer(nikon_tree[huffSelect], 16));
+  ht.setCodeValues(Buffer(nikon_tree[huffSelect]+16, count));
+  ht.setup(true, false);
+  return ht;
 }
 
-void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h, uint32 bitsPS, uint32 offset, uint32 size) {
-  uint32 v0 = metadata->getByte();
-  uint32 v1 = metadata->getByte();
+void decompressNikon(RawImage& mRaw, ByteStream&& data, ByteStream metadata, uint32 w, uint32 h, uint32 bitsPS, bool uncorrectedRawValues) {
+  uint32 v0 = metadata.getByte();
+  uint32 v1 = metadata.getByte();
   uint32 huffSelect = 0;
   uint32 split = 0;
   int pUp1[2];
   int pUp2[2];
-  mUseBigtable = true;
 
   _RPT2(0, "Nef version v0:%u, v1:%u\n", v0, v1);
 
   if (v0 == 73 || v1 == 88)
-    metadata->skipBytes(2110);
+    metadata.skipBytes(2110);
 
   if (v0 == 70) huffSelect = 2;
   if (bitsPS == 14) huffSelect += 3;
 
-  pUp1[0] = metadata->getShort();
-  pUp1[1] = metadata->getShort();
-  pUp2[0] = metadata->getShort();
-  pUp2[1] = metadata->getShort();
+  pUp1[0] = metadata.getShort();
+  pUp1[1] = metadata.getShort();
+  pUp2[0] = metadata.getShort();
+  pUp2[1] = metadata.getShort();
 
   // 'curve' will hold a peace wise linearly interpolated function.
   // there are 'csize' segements, each is 'step' values long.
@@ -73,58 +81,55 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
     curve[i] = i;
 
   uint32 step = 0;
-  uint32 csize = metadata->getShort();
+  uint32 csize = metadata.getShort();
   if (csize  > 1)
     step = curve.size() / (csize - 1);
   if (v0 == 68 && v1 == 32 && step > 0) {
     for (size_t i = 0; i < csize; i++)
-      curve[i*step] = metadata->getShort();
+      curve[i*step] = metadata.getShort();
     for (size_t i = 0; i < curve.size()-1; i++)
       curve[i] = (curve[i-i%step] * (step - i % step) +
                   curve[i-i%step+step] * (i % step)) / step;
-    metadata->setPosition(562);
-    split = metadata->getShort();
+    metadata.setPosition(562);
+    split = metadata.getShort();
   } else if (v0 != 70 && csize <= 0x4001) {
     curve.resize(csize + 1UL);
     for (uint32 i = 0; i < csize; i++) {
-      curve[i] = metadata->getShort();
+      curve[i] = metadata.getShort();
     }
   }
-  initTable(huffSelect);
+
+  HuffmanTable ht = createHuffmanTable(huffSelect);
 
   if (!uncorrectedRawValues) {
     mRaw->setTable(&curve[0], curve.size()-1, true);
   }
 
-  uint32 x, y;
-  ByteStream input(mFile, offset, size);
-  BitPumpMSB bits(input);
+  BitPumpMSB bits(data);
   uchar8 *draw = mRaw->getData();
-  ushort16 *dest;
   uint32 pitch = mRaw->pitch;
 
-  HuffmanTable *htbl = huff[0];
   int pLeft1 = 0;
   int pLeft2 = 0;
   uint32 cw = w / 2;
   uint32 random = bits.peekBits(24);
   //allow gcc to devirtualize the calls below
   RawImageDataU16* rawdata = (RawImageDataU16*)mRaw.get();
-  for (y = 0; y < h; y++) {
+  for (uint32 y = 0; y < h; y++) {
     if (split && y == split) {
-      initTable(huffSelect + 1);
+      ht = createHuffmanTable(huffSelect + 1);
     }
-    dest = (ushort16*) & draw[y*pitch];  // Adjust destination
-    pUp1[y&1] += htbl->decodeNext(bits);
-    pUp2[y&1] += htbl->decodeNext(bits);
+    ushort16* dest = (ushort16*) & draw[y*pitch];  // Adjust destination
+    pUp1[y&1] += ht.decodeNext(bits);
+    pUp2[y&1] += ht.decodeNext(bits);
     pLeft1 = pUp1[y&1];
     pLeft2 = pUp2[y&1];
     rawdata->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
     rawdata->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
-    for (x = 1; x < cw; x++) {
+    for (uint32 x = 1; x < cw; x++) {
       bits.checkPos();
-      pLeft1 += htbl->decodeNext(bits);
-      pLeft2 += htbl->decodeNext(bits);
+      pLeft1 += ht.decodeNext(bits);
+      pLeft2 += ht.decodeNext(bits);
       rawdata->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
       rawdata->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
     }

--- a/RawSpeed/NikonDecompressor.h
+++ b/RawSpeed/NikonDecompressor.h
@@ -1,8 +1,9 @@
 #ifndef NIKON_DECOMPRESSOR_H
 #define NIKON_DECOMPRESSOR_H
 
-#include "LJpegDecompressor.h"
-#include "BitPumpMSB.h"
+#include "RawImage.h"
+#include "Buffer.h"
+#include "ByteStream.h"
 /* 
     RawSpeed - RAW file decoder.
 
@@ -27,32 +28,7 @@
 
 namespace RawSpeed {
 
-class NikonDecompressor :
-  public LJpegDecompressor
-{
-public:
-  NikonDecompressor(FileMap *file, const RawImage &img);
-
-public:
-  void DecompressNikon(ByteStream *meta, uint32 w, uint32 h, uint32 bitsPS, uint32 offset, uint32 size);
-  bool uncorrectedRawValues;
-private:
-  void initTable(uint32 huffSelect);
-};
-
-static const uchar8 nikon_tree[][32] = {
-  { 0,1,5,1,1,1,1,1,1,2,0,0,0,0,0,0,	/* 12-bit lossy */
-  5,4,3,6,2,7,1,0,8,9,11,10,12 },
-  { 0,1,5,1,1,1,1,1,1,2,0,0,0,0,0,0,	/* 12-bit lossy after split */
-  0x39,0x5a,0x38,0x27,0x16,5,4,3,2,1,0,11,12,12 },
-  { 0,1,4,2,3,1,2,0,0,0,0,0,0,0,0,0,  /* 12-bit lossless */
-  5,4,6,3,7,2,8,1,9,0,10,11,12 },
-  { 0,1,4,3,1,1,1,1,1,2,0,0,0,0,0,0,	/* 14-bit lossy */
-  5,6,4,7,8,3,9,2,1,0,10,11,12,13,14 },
-  { 0,1,5,1,1,1,1,1,1,1,2,0,0,0,0,0,	/* 14-bit lossy after split */
-  8,0x5c,0x4b,0x3a,0x29,7,6,5,4,3,2,1,0,13,14 },
-  { 0,1,4,2,2,3,1,2,0,0,0,0,0,0,0,0,	/* 14-bit lossless */
-  7,6,8,5,9,4,10,3,11,12,2,0,1,13,14 } };
+void decompressNikon(RawImage& mRaw, ByteStream&& data, ByteStream meta, uint32 w, uint32 h, uint32 bitsPS, bool uncorrectedRawValues);
   
 } // namespace RawSpeed
 

--- a/RawSpeed/PefDecoder.cpp
+++ b/RawSpeed/PefDecoder.cpp
@@ -71,8 +71,7 @@ RawImage PefDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
   try {
-    PentaxDecompressor l(mFile, mRaw);
-    l.decodePentax(mRootIFD, offsets->getInt(), counts->getInt());
+    decodePentax(mRaw, ByteStream(mFile, offsets->getInt(), counts->getInt()), mRootIFD);
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/RawSpeed/PentaxDecompressor.h
+++ b/RawSpeed/PentaxDecompressor.h
@@ -1,13 +1,16 @@
 #ifndef PENTAX_DECOMPRESSOR_H
 #define PENTAX_DECOMPRESSOR_H
 
-#include "LJpegDecompressor.h"
 #include "TiffIFD.h"
+#include "RawImage.h"
+#include "Buffer.h"
+#include "ByteStream.h"
 
 /* 
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -28,12 +31,7 @@
 
 namespace RawSpeed {
 
-class PentaxDecompressor final : public LJpegDecompressor
-{
-public:
-  using LJpegDecompressor::LJpegDecompressor;
-  void decodePentax(TiffIFD *root, uint32 offset, uint32 size);
-};
+void decodePentax(RawImage& mRaw, ByteStream&& data, TiffIFD* root);
 
 } // namespace RawSpeed
 

--- a/RawSpeed/ThreefrDecoder.cpp
+++ b/RawSpeed/ThreefrDecoder.cpp
@@ -49,9 +49,11 @@ RawImage ThreefrDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile, off);
 
   HasselbladDecompressor l(mFile, mRaw);
+  // We cannot use fully decoding huffman table,
+  // because values are packed two pixels at the time.
+  l.mFullDecodeHT = false;
   map<string,string>::iterator pixelOffset = hints.find("pixelBaseOffset");
   if (pixelOffset != hints.end()) {
     stringstream convert((*pixelOffset).second);
@@ -59,7 +61,7 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   }
 
   try {
-    l.decodeHasselblad(mRootIFD, off, mFile->getSize() - off);
+    l.decode(off, mFile->getSize() - off, 0, 0);
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.


### PR DESCRIPTION
The recent HuffmanTable functionality extraction from LJpegDecompressor allowed to untangle two former subclasses. The bulky part of this pr is the third commit that removes about 800 lines of pretty much duplicated code from LJpegPlain.

Details see the individual commit messages.