### PR TITLE
Cr2Decoder cleanup (continuation)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8844,9 +8844,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="old_format" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="KODAK" model="EOSDCS1B        FILE VERSION 3">
 		<ID make="Kodak" model="EOS DCS 1">Kodak EOSDCS1</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -974,7 +974,7 @@
 			<Hint name="wb_offset" value="142"/>
 		</Hints>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS-1D" decoder_version="5">
+	<Camera make="Canon" model="Canon EOS-1D" decoder_version="8">
 		<ID make="Canon" model="EOS-1D">Canon EOS-1D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -984,12 +984,8 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3588"/>
-		<Hints>
-			<Hint name="old_format" value=""/>
-			<Hint name="double_line_ljpeg" value=""/>
-		</Hints>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS-1DS" decoder_version="5">
+	<Camera make="Canon" model="Canon EOS-1DS" decoder_version="8">
 		<ID make="Canon" model="EOS-1Ds">Canon EOS-1Ds</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -999,12 +995,8 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3500"/>
-		<Hints>
-			<Hint name="old_format" value=""/>
-			<Hint name="double_line_ljpeg" value=""/>
-		</Hints>
 	</Camera>
-	<Camera make="Canon" model="EOS D2000C" decoder_version="5">
+	<Camera make="Canon" model="EOS D2000C" decoder_version="8">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -1013,9 +1005,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="96" white="4095"/>
-		<Hints>
-			<Hint name="old_format" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">
 		<ID make="Canon" model="EOS-1D Mark II">Canon EOS-1D Mark II</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -384,7 +384,7 @@
 				<Horizontal y="0" height="33"/>
 			</BlackAreas>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" decoder_version="7">
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" decoder_version="8">
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="28" y="10" width="0" height="0"/>
 			<Sensor black="0" white="48816" iso_list="320 640 1250 2500 5000"/>
@@ -395,7 +395,6 @@
 			<Hints>
 				<Hint name="sraw_new" value=""/>
 				<Hint name="invert_sraw_wb" value=""/>
-				<Hint name="wrapped_cr2_slices" value=""/>
 			</Hints>
 		</Camera>
 		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2" decoder_version="7">

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -291,7 +291,6 @@
       <xs:maxLength value="26"/>
       <xs:enumeration value="coolpixmangled"/>
       <xs:enumeration value="coolpixsplit"/>
-      <xs:enumeration value="double_line_ljpeg"/>
       <xs:enumeration value="double_width_unpacked"/>
       <xs:enumeration value="easyshare_offset_hack"/>
       <xs:enumeration value="filesize"/>
@@ -305,7 +304,6 @@
       <xs:enumeration value="nikon_wb_adjustment"/>
       <xs:enumeration value="no_decompressed_lowbits"/>
       <xs:enumeration value="offset"/>
-      <xs:enumeration value="old_format"/>
       <xs:enumeration value="packed_with_control"/>
       <xs:enumeration value="pixel_aspect_ratio"/>
       <xs:enumeration value="real_bpp"/>
@@ -316,7 +314,6 @@
       <xs:enumeration value="swapped_wb"/>
       <xs:enumeration value="wb_mangle"/>
       <xs:enumeration value="wb_offset"/>
-      <xs:enumeration value="wrapped_cr2_slices"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="HintType">

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -222,15 +222,13 @@ RawImage Cr2Decoder::decodeNewFormat() {
   mRaw->createData();
 
   vector<int> s_width;
-  if (raw->hasEntry(CANONCR2SLICE)) {
-    TiffEntry *ss = raw->getEntry(CANONCR2SLICE);
-    for (int i = 0; i < ss->getShort(0); i++) {
-      s_width.push_back(ss->getShort(1));
-    }
-    s_width.push_back(ss->getShort(2));
-  } else {
-    s_width.push_back(slices[0].w);
+  TiffEntry* cr2SliceEntry = raw->getEntryRecursive(CANONCR2SLICE);
+  if (cr2SliceEntry && cr2SliceEntry->getShort(0) > 0) {
+    for (int i = 0; i < cr2SliceEntry->getShort(0); i++)
+      s_width.push_back(cr2SliceEntry->getShort(1));
+    s_width.push_back(cr2SliceEntry->getShort(2));
   }
+
   uint32 offY = 0;
 
   _RPT1(0,"Org slices:%d\n", s_width.size());

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -242,7 +242,7 @@ RawImage Cr2Decoder::decodeNewFormat() {
 
 RawImage Cr2Decoder::decodeRawInternal() {
   try {
-    if (hints.find("old_format") != hints.end())
+    if (mRootIFD->getSubIFDs().size() < 4)
       return decodeOldFormat();
 
     return decodeNewFormat();

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -241,8 +241,6 @@ RawImage Cr2Decoder::decodeNewFormat() {
   }
   uint32 offY = 0;
 
-  if (s_width.size() > 15)
-    ThrowRDE("CR2 Decoder: No more than 15 slices supported");
   _RPT1(0,"Org slices:%d\n", s_width.size());
   for (uint32 i = 0; i < slices.size(); i++) {
     Cr2Slice slice = slices[i];

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -118,9 +118,6 @@ RawImage Cr2Decoder::decodeOldFormat() {
 // for technical details about Cr2 mRAW/sRAW, see http://lclevy.free.fr/cr2/
 
 RawImage Cr2Decoder::decodeNewFormat() {
-  if (mRootIFD->getSubIFDs().size() < 4)
-    ThrowRDE("CR2 Decoder: No image data found");
-
   TiffEntry* sensorInfoE = mRootIFD->getEntryRecursive(CANON_SENSOR_INFO);
   if (!sensorInfoE)
     ThrowTPE("Cr2Decoder: failed to get SensorInfo from MakerNote");
@@ -129,9 +126,8 @@ RawImage Cr2Decoder::decodeNewFormat() {
   int componentsPerPixel = 1;
   TiffIFD* raw = mRootIFD->getSubIFDs()[3].get();
   if (raw->hasEntry(CANON_SRAWTYPE) &&
-      raw->getEntry(CANON_SRAWTYPE)->getInt() == 4) {
+      raw->getEntry(CANON_SRAWTYPE)->getInt() == 4)
     componentsPerPixel = 3;
-  }
 
   mRaw = RawImage::create(dim, TYPE_USHORT16, componentsPerPixel);
 
@@ -165,15 +161,10 @@ RawImage Cr2Decoder::decodeNewFormat() {
 }
 
 RawImage Cr2Decoder::decodeRawInternal() {
-  try {
-    if (mRootIFD->getSubIFDs().size() < 4)
-      return decodeOldFormat();
-
+  if (mRootIFD->getSubIFDs().size() < 4)
+    return decodeOldFormat();
+  else
     return decodeNewFormat();
-  } catch (TiffParserException &) {
-    ThrowRDE("CR2 Decoder: Unsupported format.");
-    return nullptr; // silence the -Wreturn-type warning
-  }
 }
 
 void Cr2Decoder::checkSupportInternal(CameraMetaData *meta) {

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -85,11 +85,11 @@ RawImage Cr2Decoder::decodeOldFormat() {
 
   mRaw = RawImage::create({width, height});
 
-  LJpegPlain l(mFile, mRaw);
+  LJpegPlain l(*mFile, offset, mRaw);
   l.addSlices({width});
 
   try {
-    l.decode(offset, mFile->getSize()-offset, 0, 0);
+    l.decode(0, 0);
   } catch (IOException& e) {
     mRaw->setError(e.what());
   }
@@ -142,11 +142,11 @@ RawImage Cr2Decoder::decodeNewFormat() {
   TiffEntry* offsets = raw->getEntry(STRIPOFFSETS);
   TiffEntry* counts = raw->getEntry(STRIPBYTECOUNTS);
 
-  LJpegPlain l(mFile, mRaw);
+  LJpegPlain l(*mFile, offsets->getInt(), counts->getInt(), mRaw);
   l.addSlices(s_width);
 
   try {
-    l.decode(offsets->getInt(), counts->getInt(), 0, 0);
+    l.decode(0, 0);
   } catch (RawDecoderException &e) {
     mRaw->setError(e.what());
   } catch (IOException &e) {

--- a/src/librawspeed/decoders/DngDecoderSlices.cpp
+++ b/src/librawspeed/decoders/DngDecoderSlices.cpp
@@ -382,12 +382,12 @@ void DngDecoderSlices::decodeDeflate(const DngSliceElement &e,
 void DngDecoderSlices::decodeSlice(DngDecoderThread* t) {
   if (compression == 7) {
     while (!t->slices.empty()) {
-      LJpegPlain l(mFile, mRaw);
-      l.mDNGCompatible = mFixLjpeg;
       DngSliceElement e = t->slices.front();
       t->slices.pop();
+      LJpegPlain l(*mFile, e.byteOffset, e.byteCount, mRaw);
+      l.mDNGCompatible = mFixLjpeg;
       try {
-        l.decode(e.byteOffset, e.byteCount, e.offX, e.offY);
+        l.decode(e.offX, e.offY);
       } catch (RawDecoderException &err) {
         mRaw->setError(err.what());
       } catch (IOException &err) {

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -76,7 +76,7 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
 
-  HasselbladDecompressor l(mFile, mRaw);
+  HasselbladDecompressor l(*mFile, off, mRaw);
   // We cannot use fully decoding huffman table,
   // because values are packed two pixels at the time.
   l.mFullDecodeHT = false;
@@ -87,7 +87,7 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   }
 
   try {
-    l.decode(off, mFile->getSize() - off, 0, 0);
+    l.decode(0, 0);
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -55,7 +55,7 @@ inline static int getBits(BitPumpMSB32& bs, int len) {
 
 void HasselbladDecompressor::decodeScan()
 {
-  BitPumpMSB32 bitStream(*input);
+  BitPumpMSB32 bitStream(input);
   // Pixels are packed two at a time, not like LJPEG:
   // [p1_length_as_huffman][p2_length_as_huffman][p0_diff_with_length][p1_diff_with_length]|NEXT PIXELS
   for (uint32 y = 0; y < frame.h; y++) {
@@ -71,7 +71,7 @@ void HasselbladDecompressor::decodeScan()
       dest[x+1] = p2;
     }
   }
-  input->skipBytes(bitStream.getBufferPosition());
+  input.skipBytes(bitStream.getBufferPosition());
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -93,6 +93,9 @@ void LJpegDecompressor::parseSOF(SOFInfo* sof) {
       ThrowRDE("LJpegDecompressor: Quantized components not supported.");
   }
   sof->initialized = true;
+
+  mRaw->metadata.subsampling.x = sof->compInfo[0].superH;
+  mRaw->metadata.subsampling.y = sof->compInfo[0].superV;
 }
 
 void LJpegDecompressor::parseSOS() {

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -36,32 +36,6 @@ LJpegDecompressor::~LJpegDecompressor() {
   delete input;
 }
 
-void LJpegDecompressor::getSOF(SOFInfo* sof, uint32 offset, uint32 size) {
-  if (!mFile->isValid(offset, size))
-    ThrowRDE("LJpegDecompressor::getSOF: Start offset plus size is longer than file. Truncated file.");
-  try {
-    // JPEG is big endian
-    input = new ByteStream(mFile, offset, size, getHostEndianness() == big);
-
-    if (getNextMarker(false) != M_SOI)
-      ThrowRDE("LJpegDecompressor::getSOF: Image did not start with SOI. Probably not an LJPEG");
-
-    while (true) {
-      JpegMarker m = getNextMarker(true);
-      if (M_SOF3 == m) {
-        parseSOF(sof);
-        return;
-      }
-      if (M_EOI == m) {
-        ThrowRDE("LJpegDecompressor: Could not locate Start of Frame.");
-        return;
-      }
-    }
-  } catch (IOException &) {
-    ThrowRDE("LJpegDecompressor: IO exception, read outside file. Corrupt File.");
-  }
-}
-
 void LJpegDecompressor::decode(uint32 offset, uint32 size, uint32 offsetX, uint32 offsetY) {
   if (!mFile->isValid(offset, size))
     ThrowRDE("LJpegDecompressor: Start offset plus size is longer than file. Truncated file.");

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -151,9 +151,6 @@ public:
 
   bool mDNGCompatible = false;  // DNG v1.0.x compatibility
   bool mFullDecodeHT = true;    // FullDecode Huffman
-  bool mCanonFlipDim = false;   // Fix Canon 6D mRaw where width/height is flipped
-  bool mCanonDoubleHeight = false; // Fix Canon double height on 4 components (EOS 5DS R)
-  bool mWrappedCr2Slices = false;  // Fix Canon 80D mRaw where the slices are wrapped
 
 protected:
   void parseSOF(SOFInfo* i);
@@ -172,7 +169,6 @@ protected:
   uint32 pred = 0;
   uint32 Pt = 0;
   uint32 offX = 0, offY = 0;  // Offset into image where decoding should start
-  uint32 skipX = 0, skipY = 0;   // Tile is larger than output, skip these border pixels
   std::array<HuffmanTable*, 4> huff {}; // 4 pointers into the store
   std::vector<std::unique_ptr<HuffmanTable>> huffmanTableStore; // std::vector of unique HTs
 };

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -144,7 +144,6 @@ public:
       : mFile(file), mRaw(img) {}
   virtual ~LJpegDecompressor();
   void decode(uint32 offset, uint32 size, uint32 offsetX, uint32 offsetY);
-  void getSOF(SOFInfo* i, uint32 offset, uint32 size);
   void addSlices(std::vector<int> slices) {
     slicesW = std::move(slices);
   } // CR2 slices.

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -137,7 +137,7 @@ void LJpegPlain::decodeN_X_Y() {
   for (int i = 0; i < N_COMP; ++i)
     p[i] = (1 << (frame.prec - Pt - 1));
 
-  BitPumpJPEG bitStream(*input);
+  BitPumpJPEG bitStream(input);
   uint32 pixelPitch = mRaw->pitch / 2; // Pitch in pixel
   if (frame.cps != 3 && frame.w * frame.cps > 2 * frame.h) {
     // Fix Canon double height issue where Canon doubled the width and halfed
@@ -218,7 +218,7 @@ void LJpegPlain::decodeN_X_Y() {
       processedLineSlices += yStepSize;
     }
   }
-  input->skipBytes(bitStream.getBufferPosition());
+  input.skipBytes(bitStream.getBufferPosition());
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -151,7 +151,6 @@ inline void unroll_loop(const Lambda& f) {
 
 template<int N_COMP, int X_S_F, int Y_S_F>
 void LJpegPlain::decodeN_X_Y() {
-  _ASSERTE(slicesW.size() < 16);  // We only have 4 bits for slice number.
   _ASSERTE(!(slicesW.size() > 1 && skipX));
   _ASSERTE(frame.compInfo[0].superH == X_S_F);
   _ASSERTE(frame.compInfo[0].superV == Y_S_F);

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -55,12 +55,8 @@ void LJpegPlain::decodeScan() {
   if (frame.h == 0 || frame.w == 0)
     ThrowRDE("LJpegPlain::decodeScan: Image width or height set to zero");
 
-  /* Correct wrong slice count (Canon G16) */
-  if (slicesW.size() == 1)
-    slicesW[0] = frame.w * frame.cps;
-
   if (slicesW.empty())
-    slicesW.push_back(frame.w*frame.cps);
+    slicesW.push_back(frame.w * frame.cps);
 
   bool isSubSampled = false;
   for (uint32 i = 0; i < frame.cps;  i++)

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -132,9 +132,6 @@ void LJpegPlain::decodeN_X_Y() {
   for (int i = 0; i < N_COMP; ++i)
     ht[i] = huff[frame.compInfo[i].dcTblNo];
 
-  mRaw->metadata.subsampling.x = X_S_F;
-  mRaw->metadata.subsampling.y = Y_S_F;
-
   // Initialize predictors
   int p[N_COMP];
   for (int i = 0; i < N_COMP; ++i)

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -142,7 +142,7 @@ void LJpegPlain::decodeN_X_Y() {
 
   BitPumpJPEG bitStream(*input);
   uint32 pixelPitch = mRaw->pitch / 2; // Pitch in pixel
-  if (frame.cps == 4 && frame.w > frame.h) {
+  if (frame.cps != 3 && frame.w * frame.cps > 2 * frame.h) {
     // Fix Canon double height issue where Canon doubled the width and halfed
     // the height (e.g. with 5Ds), ask Canon. frame.w needs to stay as is here
     // because the number of pixels after which the predictor gets updated is

--- a/src/librawspeed/decompressors/LJpegPlain.cpp
+++ b/src/librawspeed/decompressors/LJpegPlain.cpp
@@ -43,33 +43,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #include <string>
 #include <vector>
 
+using namespace std;
+
 namespace RawSpeed {
 
 void LJpegPlain::decodeScan() {
 
   if (pred != 1)
     ThrowRDE("LJpegDecompressor::decodeScan: Unsupported prediction direction.");
-
-  // Fix for Canon 6D mRaw, which has flipped width & height for some part of the image
-  // We temporarily swap width and height for cropping.
-  if (mCanonFlipDim) {
-    uint32 w = frame.w;
-    frame.w = frame.h;
-    frame.h = w;
-  }
-
-  // If image attempts to decode beyond the image bounds, strip it.
-  if ((frame.w * frame.cps + offX * mRaw->getCpp()) > mRaw->dim.x * mRaw->getCpp())
-    skipX = ((frame.w * frame.cps + offX * mRaw->getCpp()) - mRaw->dim.x * mRaw->getCpp()) / frame.cps;
-  if (frame.h + offY > (uint32)mRaw->dim.y)
-    skipY = frame.h + offY - mRaw->dim.y;
-
-  // Swap back (see above)
-  if (mCanonFlipDim) {
-    uint32 w = frame.w;
-    frame.w = frame.h;
-    frame.h = w;
-  }
 
   if (frame.h == 0 || frame.w == 0)
     ThrowRDE("LJpegPlain::decodeScan: Image width or height set to zero");
@@ -98,19 +79,13 @@ void LJpegPlain::decodeScan() {
         frame.compInfo[2].superH != 1 || frame.compInfo[2].superV != 1)
       ThrowRDE("LJpegDecompressor::decodeScan: Unsupported subsampling");
 
-    if (frame.compInfo[0].superV == 2) {
+    if (frame.compInfo[0].superV == 2)
       // Something like Cr2 sRaw1, use fast decoder
       decodeN_X_Y<3, 2, 2>();
-    } else { // frame.compInfo[0].superV == 1
-      if (mCanonFlipDim)
-        ThrowRDE("LJpegDecompressor::decodeScan: Cannot flip non 4:2:2 subsampled images.");
+    else // frame.compInfo[0].superV == 1
       // Something like Cr2 sRaw2, use fast decoder
       decodeN_X_Y<3, 2, 1>();
-    }
   } else {
-    if (mCanonFlipDim)
-      ThrowRDE("LJpegDecompressor::decodeScan: Cannot flip non subsampled images.");
-
     if (frame.cps == 2)
       decodeN_X_Y<2, 1, 1>();
     else if (frame.cps == 4)
@@ -151,25 +126,11 @@ inline void unroll_loop(const Lambda& f) {
 
 template<int N_COMP, int X_S_F, int Y_S_F>
 void LJpegPlain::decodeN_X_Y() {
-  _ASSERTE(!(slicesW.size() > 1 && skipX));
   _ASSERTE(frame.compInfo[0].superH == X_S_F);
   _ASSERTE(frame.compInfo[0].superV == Y_S_F);
   _ASSERTE(frame.compInfo[1].superH == 1);
   _ASSERTE(frame.compInfo[1].superV == 1);
   _ASSERTE(frame.cps == N_COMP);
-  _ASSERTE(skipX == 0 || X_S_F == 1);
-
-  // old code said this is only relevant for full-res raws
-  mCanonDoubleHeight &= Y_S_F == 1 && X_S_F == 1;
-  // old code said this is only relevant for s/mRaws
-  mCanonFlipDim &= X_S_F == 2;
-
-  if (mCanonDoubleHeight) {
-    mRaw->destroyData();
-    frame.h *= 2;
-    mRaw->dim = iPoint2D(frame.w * 2, frame.h);
-    mRaw->createData();
-  }
 
   HuffmanTable *ht[N_COMP] = {nullptr};
   for (int i = 0; i < N_COMP; ++i)
@@ -178,94 +139,92 @@ void LJpegPlain::decodeN_X_Y() {
   mRaw->metadata.subsampling.x = X_S_F;
   mRaw->metadata.subsampling.y = Y_S_F;
 
-  // Fix for Canon 6D mRaw, which has flipped width & height
-  uint32 real_h = mCanonFlipDim ? frame.w : frame.h;
-
   // Initialize predictors
   int p[N_COMP];
   for (int i = 0; i < N_COMP; ++i)
     p[i] = (1 << (frame.prec - Pt - 1));
 
-  uint32 cw = (frame.w - skipX);
-  uint32 ch = (frame.h - skipY);
-
-  if (mCanonDoubleHeight)
-    ch = frame.h / 2;
-
-  // Fix for Canon 80D mraw format.
-  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
-  // Consequently, the slices in `frame` wrap around (this is taken care of by
-  // `offset`) and must be decoded fully (without skipY) to fill the image
-  if (mWrappedCr2Slices)
-    ch = frame.h;
-
   BitPumpJPEG bitStream(*input);
-  uint32 pixel_pitch = mRaw->pitch / 2; // Pitch in pixel
+  uint32 pixelPitch = mRaw->pitch / 2; // Pitch in pixel
+  if (frame.cps == 4 && frame.w > frame.h) {
+    // Fix Canon double height issue where Canon doubled the width and halfed
+    // the height (e.g. with 5Ds), ask Canon. frame.w needs to stay as is here
+    // because the number of pixels after which the predictor gets updated is
+    // still the doubled width.
+    // see: FIX_CANON_HALF_HEIGHT_DOUBLE_WIDTH
+    frame.h *= 2;
+  }
+  // Fix for Canon 6D mRaw, which has flipped width & height
+  // see FIX_CANON_FLIPPED_WIDTH_AND_HEIGHT
+  uint32 sliceH = frame.cps == 3 ? min(frame.w, frame.h) : frame.h;
+
+  if (X_S_F == 2 && Y_S_F == 1)
+    // fix the inconsistent slice width in sRaw mode, ask Canon.
+    for (auto& sliceW : slicesW)
+      sliceW = sliceW * 3 / 2;
 
   // To understand the CR2 slice handling and sampling factor behavior, see
   // https://github.com/lclevy/libcraw2/blob/master/docs/cr2_lossless.pdf?raw=true
 
-  uint32 t_s = 0, t_x = 0, t_y = 0;
-  constexpr int div = X_S_F == 2 ? Y_S_F+1 : N_COMP;
-  // in full raw (<N,1,1>) the width of a slice is the number of raw pixels,
-  // i.e. frame.w * frame.cps
-  uint32 pixInSlicedLine = 0;
-  auto *dest = (ushort16 *)mRaw->getDataUncropped(offX, offY);
+  // inner loop decodes one group of pixels at a time
+  //  * for <N,1,1>: N  = N*1*1 (full raw)
+  //  * for <3,2,1>: 6  = 3*2*1
+  //  * for <3,2,2>: 12 = 3*2*2
+  // and advances x by N_COMP*X_S_F and y by Y_S_F
+  constexpr int xStepSize = N_COMP * X_S_F;
+  constexpr int yStepSize = Y_S_F;
 
-  for (uint32 y = 0; y < ch; y += Y_S_F) {
-    const ushort16* predict = dest;
-    for (uint32 x = 0; x < cw; x += X_S_F) {
-      // inner loop decodes one group of pixels at a time
-      //  * for <N,1,1>: N  = N*1*1 (full raw)
-      //  * for <3,2,1>: 6  = 3*2*1
-      //  * for <3,2,2>: 12 = 3*2*2
+  unsigned processedPixels = 0;
+  unsigned processedLineSlices = 0;
+  auto nextPredictor = (ushort16*)mRaw->getDataUncropped(offX/mRaw->getCpp(), offY);
+  for (unsigned sliceW : slicesW) {
+    for (unsigned y = 0; y < sliceH; y += yStepSize) {
+      // Fix for Canon 80D mraw format.
+      // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+      // Consequently, the slices in `frame` wrap around plus there are few
+      // 'extra' sliced lines because sum(slicesW) * sliceH > mRaw->dim.area()
+      // Those would overflow, hence the break.
+      // see FIX_CANON_FRAME_VS_IMAGE_SIZE_MISMATCH
+      unsigned destX = processedLineSlices / mRaw->dim.y * slicesW[0];
+      unsigned destY = processedLineSlices % mRaw->dim.y;
+      if (destX + offX >= mRaw->dim.x * mRaw->getCpp())
+        break;
+      auto dest = (ushort16*)mRaw->getDataUncropped((destX + offX)/mRaw->getCpp(), destY + offY);
+      for (unsigned x = 0; x < sliceW; x += xStepSize) {
 
-      if (pixInSlicedLine == 0) { // Next slice
-        pixInSlicedLine = slicesW[t_s] / div;
-        dest = (ushort16*)mRaw->getDataUncropped(t_x + offX, t_y + offY);
-        if (x == 0 && y != 0)
-          predict = dest;
-
-        t_y += Y_S_F;
-        if (t_y >= (real_h - skipY)) {
-          t_y = 0;
-          if (X_S_F == 2)
-            t_x += slicesW[t_s] / div;
-          else
-            t_x += slicesW[t_s];
-          ++t_s;
+        // check if we processed one full raw row worth of pixels
+        if (processedPixels == frame.w) {
+          // if yes -> update predictor by going back exactly one row,
+          // no matter where we are right now.
+          // makes no sense from an image compression point of view, ask Canon.
+          unroll_loop<N_COMP>([&](int i) {
+            p[i] = nextPredictor[i];
+          });
+          nextPredictor = dest;
+          processedPixels = 0;
         }
+
+        if (X_S_F == 1) { // will be optimized out
+          unroll_loop<N_COMP>([&](int i) {
+            *dest++ = p[i] += ht[i]->decodeNext(bitStream);
+          });
+        } else {
+          unroll_loop<Y_S_F>([&](int i) {
+            dest[0 + i*pixelPitch] = p[0] += ht[0]->decodeNext(bitStream);
+            dest[3 + i*pixelPitch] = p[0] += ht[0]->decodeNext(bitStream);
+          });
+
+          dest[1] = p[1] += ht[1]->decodeNext(bitStream);
+          dest[2] = p[2] += ht[2]->decodeNext(bitStream);
+
+          dest += xStepSize;
+        }
+
+        processedPixels += X_S_F;
       }
-
-      if (X_S_F == 1) { // will be optimized out
-        unroll_loop<N_COMP>([&](int i) {
-          *dest++ = p[i] += ht[i]->decodeNext(bitStream);
-        });
-      } else {
-        unroll_loop<Y_S_F>([&](int i) {
-          dest[0 + i*pixel_pitch] = p[0] += ht[0]->decodeNext(bitStream);
-          dest[3 + i*pixel_pitch] = p[0] += ht[0]->decodeNext(bitStream);
-        });
-
-        dest[1] = p[1] += ht[1]->decodeNext(bitStream);
-        dest[2] = p[2] += ht[2]->decodeNext(bitStream);
-
-        dest += 3 * sizeof(ushort16);
-      }
-
-      pixInSlicedLine -= X_S_F;
+      processedLineSlices += yStepSize;
     }
-
-    if (X_S_F == 1) // will be optimized out
-      for (uint32 i = 0; i < skipX; i++)
-        unroll_loop<N_COMP>([&](int j) { ht[j]->decodeNext(bitStream); });
-
-    // Update predictors
-    unroll_loop<N_COMP>([&](int i) {
-      p[i] = predict[i];
-    });
   }
-
   input->skipBytes(bitStream.getBufferPosition());
 }
 

--- a/src/librawspeed/tiff/TiffTag.h
+++ b/src/librawspeed/tiff/TiffTag.h
@@ -322,6 +322,7 @@ enum TiffTag {
   OPCODELIST3 = 0xC742,
   NOISEPROFILE = 0xC761,
   CANONCR2SLICE                   = 0xC640,   // CANON CR2
+  CANON_SRAWTYPE                  = 0xC6C5,
 
   CALIBRATIONILLUMINANT1          = 0xC65A, // IFD0
   CALIBRATIONILLUMINANT2          = 0xC65B, // IFD0

--- a/src/librawspeed/tiff/TiffTag.h
+++ b/src/librawspeed/tiff/TiffTag.h
@@ -322,7 +322,8 @@ enum TiffTag {
   OPCODELIST3 = 0xC742,
   NOISEPROFILE = 0xC761,
   CANONCR2SLICE                   = 0xC640,   // CANON CR2
-  CANON_SRAWTYPE                  = 0xC6C5,
+  CANON_SRAWTYPE                  = 0xC6C5, // IFD3
+  CANON_SENSOR_INFO               = 0x00E0, // MakerNote
 
   CALIBRATIONILLUMINANT1          = 0xC65A, // IFD0
   CALIBRATIONILLUMINANT2          = 0xC65B, // IFD0

--- a/src/librawspeed/tiff/TiffTag.h
+++ b/src/librawspeed/tiff/TiffTag.h
@@ -324,6 +324,7 @@ enum TiffTag {
   CANONCR2SLICE                   = 0xC640,   // CANON CR2
   CANON_SRAWTYPE                  = 0xC6C5, // IFD3
   CANON_SENSOR_INFO               = 0x00E0, // MakerNote
+  CANON_RAW_DATA_OFFSET           = 0x0081, // MakerNote TIF
 
   CALIBRATIONILLUMINANT1          = 0xC65A, // IFD0
   CALIBRATIONILLUMINANT2          = 0xC65B, // IFD0


### PR DESCRIPTION
Highlights:
 * remove/simplify lots of Cr2Decoder code and Canon quirk special handling
 * convert all required Canon related hints (related to quirks) to auto-detection
 * fixing #51 and #49 

Note: There is no 80D mRaw file in the sample set but the code has been tested with some samples found online. The owner has been contacted to upload them to raw.pixls.us, no reply, yet.