### PR TITLE
Remove the usage of invalid CFA_GREEN2

### DIFF
--- a/src/librawspeed/decoders/AriDecoder.cpp
+++ b/src/librawspeed/decoders/AriDecoder.cpp
@@ -104,7 +104,7 @@ void AriDecoder::checkSupportInternal(CameraMetaData *meta) {
 }
 
 void AriDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_GREEN, CFA_RED, CFA_BLUE, CFA_GREEN2);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_GREEN, CFA_RED, CFA_BLUE, CFA_GREEN);
   mRaw->metadata.wbCoeffs[0] = mWB[0];
   mRaw->metadata.wbCoeffs[1] = mWB[1];
   mRaw->metadata.wbCoeffs[2] = mWB[2];

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -319,7 +319,7 @@ void ArwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   //Default
   int iso = 0;
 
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -190,7 +190,7 @@ void Cr2Decoder::checkSupportInternal(CameraMetaData *meta) {
 
 void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -123,7 +123,7 @@ static float canonEv(const long in) {
 
 void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
   vector<CiffIFD*> data = mRootIFD->getIFDsWithTag(CIFF_MAKEMODEL);
   if (data.empty())
     ThrowRDE("CRW Support check: Model name not found");

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -428,7 +428,7 @@ string NefDecoder::getExtendedMode(const string &mode) {
 
 void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
 
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -107,7 +107,7 @@ void PefDecoder::checkSupportInternal(CameraMetaData *meta) {
 
 void PefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
+  mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -205,8 +205,9 @@ void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model,
   mRaw->whitePoint = sensor->mWhiteLevel;
   mRaw->blackAreas = cam->blackAreas;
   if (mRaw->blackAreas.empty() && !sensor->mBlackLevelSeparate.empty()) {
-    if (mRaw->isCFA && mRaw->cfa.size.area() <= sensor->mBlackLevelSeparate.size()) {
-      for (uint32 i = 0; i < mRaw->cfa.size.area(); i++) {
+    auto cfaArea = mRaw->cfa.getSize().area();
+    if (mRaw->isCFA && cfaArea <= sensor->mBlackLevelSeparate.size()) {
+      for (uint32 i = 0; i < cfaArea; i++) {
         mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
       }
     } else if (!mRaw->isCFA && mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -84,15 +84,15 @@ void Camera::parseCFA(const xml_node &cur) {
     try {
       if (name(c) == "ColorRow") {
         int y = c.attribute("y").as_int(-1);
-        if (y < 0 || y >= cfa.size.y) {
+        if (y < 0 || y >= cfa.getSize().y) {
           ThrowCME("Invalid y coordinate in CFA array of camera %s %s",
                    make.c_str(), model.c_str());
         }
         string key = c.child_value();
-        if ((int)key.size() != cfa.size.x) {
+        if ((int)key.size() != cfa.getSize().x) {
           ThrowCME("Invalid number of colors in definition for row %d in "
                    "camera %s %s. Expected %d, found %zu.",
-                   y, make.c_str(), model.c_str(), cfa.size.x, key.size());
+                   y, make.c_str(), model.c_str(), cfa.getSize().x, key.size());
         }
         const map<char, CFAColor> char2enum = {
             {'g', CFA_GREEN},      {'r', CFA_RED},  {'b', CFA_BLUE},
@@ -105,13 +105,13 @@ void Camera::parseCFA(const xml_node &cur) {
         }
       } else if (name(c) == "Color") {
         int x = c.attribute("x").as_int(-1);
-        if (x < 0 || x >= cfa.size.x) {
+        if (x < 0 || x >= cfa.getSize().x) {
           ThrowCME("Invalid x coordinate in CFA array of camera %s %s",
                    make.c_str(), model.c_str());
         }
 
         int y = c.attribute("y").as_int(-1);
-        if (y < 0 || y >= cfa.size.y) {
+        if (y < 0 || y >= cfa.getSize().y) {
           ThrowCME("Invalid y coordinate in CFA array of camera %s %s",
                    make.c_str(), model.c_str());
         }

--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -173,8 +173,6 @@ std::string ColorFilterArray::colorToString(CFAColor c) {
       return string("GREEN");
     case CFA_BLUE:
       return string("BLUE");
-    case CFA_GREEN2:
-      return string("GREEN2");
     case CFA_CYAN:
       return string("CYAN");
     case CFA_MAGENTA:
@@ -235,7 +233,7 @@ CFAColor ColorFilterArray::toRawspeedColor( uint32 dcrawColor )
     case 0: return CFA_RED;
     case 1: return CFA_GREEN;
     case 2: return CFA_BLUE;
-    case 3: return CFA_GREEN2;
+    case 3: return CFA_INVALID;
     default: return CFA_UNKNOWN;
   }
 }
@@ -250,7 +248,7 @@ RawSpeed::uint32 ColorFilterArray::toDcrawColor( CFAColor c )
     case CFA_CYAN:
     case CFA_BLUE: return 2;
     case CFA_YELLOW:
-    case CFA_GREEN2: return 3;
+    case CFA_INVALID: return 3;
     default: return 0;
   }
 }

--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -25,6 +25,7 @@
 #include <cstdarg>                        // for va_arg, va_end, va_list
 #include <cstdio>                         // for NULL
 #include <cstring>                        // for memcpy, memset
+#include <map>                            // for map
 #include <string>                         // for string
 
 using namespace std;
@@ -32,75 +33,32 @@ using namespace std;
 namespace RawSpeed {
 
 ColorFilterArray::ColorFilterArray(const iPoint2D &_size) {
-  cfa = nullptr;
   setSize(_size);
 }
 
-ColorFilterArray::ColorFilterArray() : size(0, 0) { cfa = nullptr; }
-
-ColorFilterArray::ColorFilterArray( const ColorFilterArray& other )
+void ColorFilterArray::setSize(const iPoint2D& _size)
 {
-  cfa = nullptr;
-  setSize(other.size);
-  if (cfa)
-    memcpy(cfa, other.cfa, size.area()*sizeof(CFAColor));
-}
-
-// FC macro from dcraw outputs, given the filters definition, the dcraw color
-// number for that given position in the CFA pattern
-#define FC(filters,row,col) ((filters) >> ((((row) << 1 & 14) + ((col) & 1)) << 1) & 3)
-ColorFilterArray::ColorFilterArray( const uint32 filters) :
-size(8,2)
-{
-  cfa = nullptr;
-  setSize(size);
-
-  for (int x = 0; x < 8; x++) {
-    for (int y = 0; y < 2; y++) {
-      CFAColor c = toRawspeedColor(FC(filters,y,x));
-      setColorAt(iPoint2D(x,y), c);
-    }
-  }
-}
-
-ColorFilterArray& ColorFilterArray::operator=(const ColorFilterArray& other )
-{
-  setSize(other.size);
-  if (cfa)
-    memcpy(cfa, other.cfa, size.area()*sizeof(CFAColor));
-  return *this;
-}
-
-void ColorFilterArray::setSize(const iPoint2D &_size) {
   size = _size;
-  if (cfa)
-    delete[] cfa;
-  cfa = nullptr;
   if (size.area() > 100)
-    ThrowRDE("ColorFilterArray:setSize if your CFA pattern is really %d pixels in area we may as well give up now", size.area());
+    ThrowRDE("ColorFilterArray:setSize if your CFA pattern is really %d pixels "
+             "in area we may as well give up now",
+             size.area());
   if (size.area() <= 0)
     return;
-  cfa = new CFAColor[size.area()];
-  if (!cfa)
-    ThrowRDE("ColorFilterArray:setSize Unable to allocate memory");
-  memset(cfa, CFA_UNKNOWN, size.area()*sizeof(CFAColor));
+  cfa.resize(size.area());
+  fill(cfa.begin(), cfa.end(), CFA_UNKNOWN);
 }
 
-ColorFilterArray::~ColorFilterArray() {
-  if (cfa)
-    delete[] cfa;
-  cfa = nullptr;
-}
-
-CFAColor ColorFilterArray::getColorAt( uint32 x, uint32 y )
+CFAColor ColorFilterArray::getColorAt( int x, int y ) const
 {
-  if (!cfa)
+  if (cfa.empty())
     ThrowRDE("ColorFilterArray:getColorAt: No CFA size set");
-  if (x >= (uint32)size.x || y >= (uint32)size.y) {
-    x = x%size.x;
-    y = y%size.y;
-  }
-  return cfa[x+y*size.x];
+
+  // calculate the positive modulo [0 .. size-1]
+  x = (x % size.x + size.x) % size.x;
+  y = (y % size.y + size.y) % size.y;
+
+  return cfa[x + y * size.x];
 }
 
 void ColorFilterArray::setCFA( iPoint2D in_size, ... )
@@ -117,43 +75,41 @@ void ColorFilterArray::setCFA( iPoint2D in_size, ... )
 }
 
 void ColorFilterArray::shiftLeft(int n) {
-  if (!size.x) {
+  if (cfa.empty())
     ThrowRDE("ColorFilterArray:shiftLeft: No CFA size set (or set to zero)");
-  }
+
   writeLog(DEBUG_PRIO_EXTRA, "Shift left:%d\n", n);
-  int shift = n % size.x;
-  if (0 == shift)
+  n %= size.x;
+  if (n == 0)
     return;
-  auto *tmp = new CFAColor[size.x];
-  for (int y = 0; y < size.y; y++) {
-    CFAColor *old = &cfa[y*size.x];
-    memcpy(tmp, &old[shift], (size.x-shift)*sizeof(CFAColor));
-    memcpy(&tmp[size.x-shift], old, shift*sizeof(CFAColor));
-    memcpy(old, tmp, size.x * sizeof(CFAColor));
+
+  vector<CFAColor> tmp(size.area());
+  for (int y = 0; y < size.y; ++y) {
+    for (int x = 0; x < size.x; ++x) {
+      tmp[x + y * size.x] = getColorAt(x+n, y);
+    }
   }
-  delete[] tmp;
+  cfa = tmp;
 }
 
 void ColorFilterArray::shiftDown(int n) {
-  if (!size.y) {
+  if (cfa.empty())
     ThrowRDE("ColorFilterArray:shiftDown: No CFA size set (or set to zero)");
-  }
+
   writeLog(DEBUG_PRIO_EXTRA, "Shift down:%d\n", n);
-  int shift = n % size.y;
-  if (0 == shift)
+  n %= size.y;
+  if (n == 0)
     return;
-  auto *tmp = new CFAColor[size.y];
-  for (int x = 0; x < size.x; x++) {
-    CFAColor *old = &cfa[x];
-    for (int y = 0; y < size.y; y++)
-      tmp[y] = old[((y+shift)%size.y)*size.x];
-    for (int y = 0; y < size.y; y++)
-      old[y*size.x] = tmp[y];
+  vector<CFAColor> tmp(size.area());
+  for (int y = 0; y < size.y; ++y) {
+    for (int x = 0; x < size.x; ++x) {
+      tmp[x + y * size.x] = getColorAt(x, y+n);
+    }
   }
-  delete[] tmp;
+  cfa = tmp;
 }
 
-std::string ColorFilterArray::asString() {
+string ColorFilterArray::asString() const {
   string dst;
   for (int y = 0; y < size.y; y++) {
     for (int x = 0; x < size.x; x++) {
@@ -164,30 +120,48 @@ std::string ColorFilterArray::asString() {
   return dst;
 }
 
+uint32 ColorFilterArray::shiftDcrawFilter(uint32 filter, int x, int y)
+{
+  // filter is a series of 4 bytes that describe a 2x8 matrix. 2 is the width,
+  // 8 is the height. each byte describes a 2x2 pixel block. so each pixel has
+  // 2 bits of information. This allows to distinguish 4 different colors.
 
-std::string ColorFilterArray::colorToString(CFAColor c) {
-  switch (c) {
-    case CFA_RED:
-      return string("RED");
-    case CFA_GREEN:
-      return string("GREEN");
-    case CFA_BLUE:
-      return string("BLUE");
-    case CFA_CYAN:
-      return string("CYAN");
-    case CFA_MAGENTA:
-      return string("MAGENTA");
-    case CFA_YELLOW:
-      return string("YELLOW");
-    case CFA_WHITE:
-      return string("WHITE");
-    case CFA_FUJI_GREEN:
-      return string("FUJIGREEN");
-    default:
-      return string("UNKNOWN");
+  if (std::abs(x) & 1) {
+    // A shift in x direction means swapping the first and second half of each
+    // nibble.
+    // see http://graphics.stanford.edu/~seander/bithacks.html#SwappingBitsXOR
+    for (int n = 0; n < 8; ++n) {
+      int i = n * 4;
+      int j = i + 2;
+      uint32 t = ((filter >> i) ^ (filter >> j)) & ((1U << 2) - 1);
+      filter = filter ^ ((t << i) | (t << j));
+    }
   }
+
+  // A shift in y direction means rotating the whole int by 4 bits.
+  y *= 4;
+  y = y >= 0 ? y % 32 : -((-y) % 32);
+  filter = (filter >> y) | (filter << (32 - y));
+
+  return filter;
 }
 
+const static map<CFAColor, string> color2String = {
+    {CFA_RED, "RED"},         {CFA_GREEN, "GREEN"},
+    {CFA_BLUE, "BLUE"},       {CFA_CYAN, "CYAN"},
+    {CFA_MAGENTA, "MAGENTA"}, {CFA_YELLOW, "YELLOW"},
+    {CFA_WHITE, "WHITE"},     {CFA_FUJI_GREEN, "FUJIGREEN"},
+    {CFA_UNKNOWN, "UNKNOWN"}
+};
+
+string ColorFilterArray::colorToString(CFAColor c)
+{
+  try {
+    return color2String.at(c);
+  } catch (std::out_of_range&) {
+    ThrowRDE("ColorFilterArray: Unsupported CFA Color: %u", c);
+  }
+}
 
 void ColorFilterArray::setColorAt(iPoint2D pos, CFAColor c) {
   if (pos.x >= size.x || pos.x < 0)
@@ -197,21 +171,32 @@ void ColorFilterArray::setColorAt(iPoint2D pos, CFAColor c) {
   cfa[pos.x+pos.y*size.x] = c;
 }
 
-RawSpeed::uint32 ColorFilterArray::getDcrawFilter()
+static uint32 toDcrawColor( CFAColor c )
+{
+  switch (c) {
+  case CFA_FUJI_GREEN:
+  case CFA_RED: return 0;
+  case CFA_MAGENTA:
+  case CFA_GREEN: return 1;
+  case CFA_CYAN:
+  case CFA_BLUE: return 2;
+  case CFA_YELLOW: return 3;
+  default: return 0;
+  }
+}
+
+uint32 ColorFilterArray::getDcrawFilter() const
 {
   //dcraw magic
   if (size.x == 6 && size.y == 6)
     return 9;
 
-  if (size.x > 8 || size.y > 2 || nullptr == cfa)
-    return 1;
-
-  if (!isPowerOfTwo(size.x))
+  if (cfa.empty() || size.x > 2 || size.y > 8 || !isPowerOfTwo(size.y))
     return 1;
 
   uint32 ret = 0;
-  for (int x = 0; x < 8; x++) {
-    for (int y = 0; y < 2; y++) {
+  for (int x = 0; x < 2; x++) {
+    for (int y = 0; y < 8; y++) {
       uint32 c = toDcrawColor(getColorAt(x,y));
       int g = (x >> 1) * 8;
       ret |= c << ((x&1)*2 + y*4 + g);
@@ -226,32 +211,5 @@ RawSpeed::uint32 ColorFilterArray::getDcrawFilter()
   writeLog(DEBUG_PRIO_EXTRA, "DCRAW filter:%x\n",ret);
   return ret;
 }
-
-CFAColor ColorFilterArray::toRawspeedColor( uint32 dcrawColor )
-{
-  switch (dcrawColor) {
-    case 0: return CFA_RED;
-    case 1: return CFA_GREEN;
-    case 2: return CFA_BLUE;
-    case 3: return CFA_INVALID;
-    default: return CFA_UNKNOWN;
-  }
-}
-
-RawSpeed::uint32 ColorFilterArray::toDcrawColor( CFAColor c )
-{
-  switch (c) {
-    case CFA_FUJI_GREEN:
-    case CFA_RED: return 0;
-    case CFA_MAGENTA:
-    case CFA_GREEN: return 1;
-    case CFA_CYAN:
-    case CFA_BLUE: return 2;
-    case CFA_YELLOW:
-    case CFA_INVALID: return 3;
-    default: return 0;
-  }
-}
-
 
 } // namespace RawSpeed

--- a/src/librawspeed/metadata/ColorFilterArray.h
+++ b/src/librawspeed/metadata/ColorFilterArray.h
@@ -27,16 +27,15 @@
 namespace RawSpeed {
 
 enum CFAColor {
-  CFA_COLOR_MIN = 0,
+  // see also DngDecoder
   CFA_RED = 0,
   CFA_GREEN = 1,
   CFA_BLUE = 2,
-  CFA_GREEN2 = 3,
+  CFA_INVALID = 3, // keep the unit tests happy
   CFA_CYAN = 4,
   CFA_MAGENTA = 5,
   CFA_YELLOW = 6,
   CFA_WHITE = 7,
-  CFA_COLOR_MAX = 8,
   CFA_FUJI_GREEN = 9,
   CFA_UNKNOWN = 255
 };

--- a/src/librawspeed/metadata/ColorFilterArray.h
+++ b/src/librawspeed/metadata/ColorFilterArray.h
@@ -42,6 +42,8 @@ enum CFAColor {
 
 class ColorFilterArray
 {
+  iPoint2D size;
+
 public:
   ColorFilterArray();
   ColorFilterArray(const ColorFilterArray& other );
@@ -58,10 +60,11 @@ public:
   virtual void shiftLeft(int n = 1);
   virtual void shiftDown(int n = 1);
   virtual std::string asString();
+  iPoint2D getSize() const { return size; }
+
   static std::string colorToString(CFAColor c);
   uint32 toDcrawColor(CFAColor c);
   CFAColor toRawspeedColor(uint32 dcrawColor);
-  iPoint2D size;
 protected:
   CFAColor *cfa;
 };

--- a/src/librawspeed/metadata/ColorFilterArray.h
+++ b/src/librawspeed/metadata/ColorFilterArray.h
@@ -31,42 +31,40 @@ enum CFAColor {
   CFA_RED = 0,
   CFA_GREEN = 1,
   CFA_BLUE = 2,
-  CFA_INVALID = 3, // keep the unit tests happy
-  CFA_CYAN = 4,
-  CFA_MAGENTA = 5,
-  CFA_YELLOW = 6,
-  CFA_WHITE = 7,
-  CFA_FUJI_GREEN = 9,
+  CFA_CYAN = 3,
+  CFA_MAGENTA = 4,
+  CFA_YELLOW = 5,
+  CFA_WHITE = 6,
+  CFA_FUJI_GREEN = 7,
   CFA_UNKNOWN = 255
 };
 
 class ColorFilterArray
 {
+  std::vector<CFAColor> cfa;
   iPoint2D size;
 
 public:
-  ColorFilterArray();
-  ColorFilterArray(const ColorFilterArray& other );
-  ColorFilterArray& operator= (const ColorFilterArray& other);
-  ColorFilterArray(const iPoint2D &size);
-  ColorFilterArray(uint32 dcrawFilters);
-  virtual ~ColorFilterArray();
+  ColorFilterArray() = default;
+  ColorFilterArray(const iPoint2D& size);
 
-  virtual void setSize(const iPoint2D &size);
+  void setSize(const iPoint2D& size);
   void setColorAt(iPoint2D pos, CFAColor c);
-  virtual void setCFA(iPoint2D size, ...);
-  virtual CFAColor getColorAt(uint32 x, uint32 y);
-  virtual uint32 getDcrawFilter();
-  virtual void shiftLeft(int n = 1);
-  virtual void shiftDown(int n = 1);
-  virtual std::string asString();
+  void setCFA(iPoint2D size, ...);
+  void shiftLeft(int n = 1);
+  void shiftDown(int n = 1);
+
+  CFAColor getColorAt(int x, int y) const;
+  uint32 getDcrawFilter() const;
+  std::string asString() const;
   iPoint2D getSize() const { return size; }
 
   static std::string colorToString(CFAColor c);
-  uint32 toDcrawColor(CFAColor c);
-  CFAColor toRawspeedColor(uint32 dcrawColor);
-protected:
-  CFAColor *cfa;
+  static uint32 shiftDcrawFilter(uint32 filter, int x, int y);
 };
+
+// FC macro from dcraw outputs, given the filters definition, the dcraw color
+// number for that given position in the CFA pattern
+// #define FC(filters,row,col) ((filters) >> ((((row) << 1 & 14) + ((col) & 1)) << 1) & 3)
 
 } // namespace RawSpeed

--- a/src/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/src/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -43,16 +43,6 @@ TEST(ColorFilterArrayTestBasic, Constructor) {
     ColorFilterArray cfa((uint32)0);
     ASSERT_EQ(cfa.size.area(), 8 * 2);
   });
-
-  ASSERT_NO_THROW({
-    unique_ptr<ColorFilterArray> cfa(new ColorFilterArray(square));
-    ASSERT_EQ(cfa->size.area(), square.area());
-  });
-
-  ASSERT_NO_THROW({
-    unique_ptr<ColorFilterArray> cfa(new ColorFilterArray((uint32)0));
-    ASSERT_EQ(cfa->size.area(), 8 * 2);
-  });
 }
 
 TEST(ColorFilterArrayTestBasic, SetSize) {
@@ -63,21 +53,9 @@ TEST(ColorFilterArrayTestBasic, SetSize) {
   });
 
   ASSERT_NO_THROW({
-    unique_ptr<ColorFilterArray> cfa(new ColorFilterArray);
-    cfa->setSize(square);
-    ASSERT_EQ(cfa->size.area(), square.area());
-  });
-
-  ASSERT_NO_THROW({
     ColorFilterArray cfa(iPoint2D(1, 1));
     cfa.setSize(square);
     ASSERT_EQ(cfa.size.area(), square.area());
-  });
-
-  ASSERT_NO_THROW({
-    unique_ptr<ColorFilterArray> cfa(new ColorFilterArray(iPoint2D(1, 1)));
-    cfa->setSize(square);
-    ASSERT_EQ(cfa->size.area(), square.area());
   });
 }
 

--- a/src/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/src/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -170,6 +170,6 @@ TEST_P(ColorFilterArrayTest, AsString) {
     string dsc = cfa.asString();
 
     ASSERT_GT(dsc.size(), 15);
-    ASSERT_LE(dsc.size(), 28);
+    ASSERT_LE(dsc.size(), 32);
   });
 }

--- a/src/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/src/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -49,13 +49,13 @@ TEST(ColorFilterArrayTestBasic, SetSize) {
   ASSERT_NO_THROW({
     ColorFilterArray cfa;
     cfa.setSize(square);
-    ASSERT_EQ(cfa.size.area(), square.area());
+    ASSERT_EQ(cfa.getSize().area(), square.area());
   });
 
   ASSERT_NO_THROW({
     ColorFilterArray cfa(iPoint2D(1, 1));
     cfa.setSize(square);
-    ASSERT_EQ(cfa.size.area(), square.area());
+    ASSERT_EQ(cfa.getSize().area(), square.area());
   });
 }
 


### PR DESCRIPTION
This fixes #34. The actual number '3' is still kept as a dummy tag to
keep the ColorFilterArrayTest.ToDcrawAndBack unit test happy.

The string output of this dummy tag is now "UNKNOWN" therefore the
string length check unit test had to be slightly adjusted.

This change 'breaks' 3 files in rstest by actually fixing them: the old
"GREEN2" color is now reported as "GREEN".