### PR TITLE
Continue several open ends of the infrastructure cleanup effort

### DIFF
--- a/src/librawspeed/common/Common.h
+++ b/src/librawspeed/common/Common.h
@@ -128,7 +128,8 @@ inline Endianness getHostEndianness() {
 # define BSWAP64(A) __builtin_bswap64(A)
 #endif
 
-template<typename T> inline T loadMem(const void* data, bool bswap) {
+template<typename T> inline T getByteSwapped(const void* data, bool bswap)
+{
   T ret;
   // all interesting compilers optimize this memcpy into a single move
   // this is the most effective way to load some bytes without running into alignmen issues
@@ -144,15 +145,27 @@ template<typename T> inline T loadMem(const void* data, bool bswap) {
   return ret;
 }
 
-#define get2BE(data, pos)                                                      \
-  (loadMem<ushort16>((data) + (pos), getHostEndianness() == little))
-#define get2LE(data, pos)                                                      \
-  (loadMem<ushort16>((data) + (pos), getHostEndianness() == big))
+// The following functions may be used to get a multi-byte sized tyoe from some
+// memory location converted to the native byte order of the host.
+// 'BE' suffix: source byte order is known to be big endian
+// 'LE' suffix: source byte order is known to be little endian
+// Note: these functions should be avoided if higher level acess from
+// Buffer/DataBuffer classes is available.
 
-#define get4BE(data, pos)                                                      \
-  (loadMem<uint32>((data) + (pos), getHostEndianness() == little))
-#define get4LE(data, pos)                                                      \
-  (loadMem<uint32>((data) + (pos), getHostEndianness() == big))
+template <typename T> inline T getBE(const void* data)
+{
+  return getByteSwapped<T>(data, getHostEndianness() == little);
+}
+
+template <typename T> inline T getLE(const void* data)
+{
+  return getByteSwapped<T>(data, getHostEndianness() == big);
+}
+
+inline ushort16 getU16BE(const void* data) { return getBE<ushort16>(data); }
+inline ushort16 getU16LE(const void* data) { return getLE<ushort16>(data); }
+inline uint32 getU32BE(const void* data)   { return getBE<uint32>(data); }
+inline uint32 getU32LE(const void* data)   { return getLE<uint32>(data); }
 
 #ifdef _MSC_VER
 // See http://tinyurl.com/hqfuznc

--- a/src/librawspeed/common/Common.h
+++ b/src/librawspeed/common/Common.h
@@ -213,4 +213,29 @@ enum BitOrder {
   BitOrder_Jpeg32, /* Same as above, but 32 bits at the time */
 };
 
+// little 'forced' loop unrolling helper tool, example:
+//   unroll_loop<N>([&](int i) {
+//     func(i);
+//   });
+// will translate to:
+//   func(0); func(1); func(2); ... func(N-1);
+
+template <typename Lambda, size_t N>
+struct unroll_loop_t {
+  inline static void repeat(const Lambda& f) {
+    unroll_loop_t<Lambda, N-1>::repeat(f);
+    f(N-1);
+  }
+};
+
+template <typename Lambda>
+struct unroll_loop_t<Lambda, 0> {
+  inline static void repeat(const Lambda& f) {}
+};
+
+template <size_t N, typename Lambda>
+inline void unroll_loop(const Lambda& f) {
+  unroll_loop_t<Lambda, N>::repeat(f);
+}
+
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/AbstractTiffDecoder.h
+++ b/src/librawspeed/decoders/AbstractTiffDecoder.h
@@ -35,6 +35,31 @@ public:
     : RawDecoder(file), mRootIFD(std::move(root)) {}
 
   TiffIFD *getRootIFD() final { return mRootIFD.get(); }
+
+  inline bool checkCameraSupported(CameraMetaData* meta, const TiffID& id,
+                                   const std::string& mode)
+  {
+      return RawDecoder::checkCameraSupported(meta, id.make, id.model, mode);
+  }
+
+  using RawDecoder::setMetaData;
+
+  inline void setMetaData(CameraMetaData* meta, const TiffID& id,
+                          const std::string& mode, int iso_speed)
+  {
+      setMetaData(meta, id.make, id.model, mode, iso_speed);
+  }
+
+  inline void setMetaData(CameraMetaData* meta, const std::string& mode,
+                          int iso_speed)
+  {
+      setMetaData(meta, mRootIFD->getID(), mode, iso_speed);
+  }
+
+  inline void checkSupportInternal(CameraMetaData *meta) override
+  {
+      checkCameraSupported(meta, mRootIFD->getID(), "");
+  }
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/AbstractTiffDecoder.h
+++ b/src/librawspeed/decoders/AbstractTiffDecoder.h
@@ -1,8 +1,7 @@
 /*
     RawSpeed - RAW file decoder.
 
-    Copyright (C) 2009-2014 Klaus Post
-    Copyright (C) 2014 Pedro Côrte-Real
+    Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -21,25 +20,21 @@
 
 #pragma once
 
-#include "common/RawImage.h"     // for RawImage
-#include "decoders/AbstractTiffDecoder.h"
+#include "decoders/RawDecoder.h" // for RawDecoder
 #include "io/FileMap.h"          // for FileMap
+#include "tiff/TiffIFD.h"        // for TiffRootIFDOwner
 
 namespace RawSpeed {
 
-class CameraMetaData;
-
-class ErfDecoder final : public AbstractTiffDecoder
+class AbstractTiffDecoder : public RawDecoder
 {
-public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
-
-  RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
-  void decodeMetaDataInternal(CameraMetaData *meta) override;
-
 protected:
-  int getDecoderVersion() const override { return 0; }
+  TiffRootIFDOwner mRootIFD;
+public:
+  AbstractTiffDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : RawDecoder(file), mRootIFD(std::move(root)) {}
+
+  TiffIFD *getRootIFD() final { return mRootIFD.get(); }
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/AriDecoder.h
+++ b/src/librawspeed/decoders/AriDecoder.h
@@ -43,6 +43,7 @@ public:
   static bool isARI(FileMap* input);
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   uint32 mWidth, mHeight, mIso;
   std::string mModel;
   std::string mEncoder;

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -45,7 +45,6 @@ namespace RawSpeed {
 ArwDecoder::ArwDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
   mShiftDownScale = 0;
-  decoderVersion = 1;
 }
 
 ArwDecoder::~ArwDecoder() {

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -42,17 +42,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-ArwDecoder::ArwDecoder(TiffIFD *rootIFD, FileMap* file) :
-    RawDecoder(file), mRootIFD(rootIFD) {
-  mShiftDownScale = 0;
-}
-
-ArwDecoder::~ArwDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage ArwDecoder::decodeRawInternal() {
   TiffIFD *raw = nullptr;
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -23,26 +23,23 @@
 
 #include "common/Common.h"       // for uint32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder, RawDecoderThread (ptr o...
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class ByteStream;
 class CameraMetaData;
-class TiffIFD;
 
-class ArwDecoder :
-  public RawDecoder
+class ArwDecoder final : public AbstractTiffDecoder
 {
 public:
-  ArwDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~ArwDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void decodeThreaded(RawDecoderThread *t) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 protected:
   int getDecoderVersion() const override { return 1; }
@@ -51,9 +48,8 @@ protected:
   void DecodeUncompressed(TiffIFD* raw);
   void SonyDecrypt(uint32 *buffer, uint32 len, uint32 key);
   void GetWB();
-  TiffIFD *mRootIFD;
   ByteStream *in;
-  int mShiftDownScale;
+  int mShiftDownScale = 0;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -45,6 +45,7 @@ public:
   TiffIFD *getRootIFD() override { return mRootIFD; }
 
 protected:
+  int getDecoderVersion() const override { return 1; }
   void DecodeARW(ByteStream &input, uint32 w, uint32 h);
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
   void DecodeUncompressed(TiffIFD* raw);

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -40,7 +40,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void decodeThreaded(RawDecoderThread *t) override;
 

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -34,7 +34,10 @@ class CameraMetaData;
 class ArwDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  ArwDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -49,7 +49,6 @@ namespace RawSpeed {
 
 Cr2Decoder::Cr2Decoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 8;
 }
 
 Cr2Decoder::~Cr2Decoder() {

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -157,36 +157,23 @@ RawImage Cr2Decoder::decodeRawInternal() {
 }
 
 void Cr2Decoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("CR2 Support check: Model name not found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("CR2 Support: Make name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-
+  auto id = mRootIFD->getID();
   // Check for sRaw mode
   if (mRootIFD->getSubIFDs().size() == 4) {
     TiffEntry* typeE = mRootIFD->getSubIFDs()[3]->getEntryRecursive(CANON_SRAWTYPE);
     if (typeE && typeE->getInt() == 4) {
-      this->checkCameraSupported(meta, make, model, "sRaw1");
+      checkCameraSupported(meta, id, "sRaw1");
       return;
     }
   }
 
-  this->checkCameraSupported(meta, make, model, "");
+  checkCameraSupported(meta, id, "");
 }
 
 void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
-  if (data.empty())
-    ThrowRDE("CR2 Meta Decoder: Model name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
   string mode;
 
   if (mRaw->metadata.subsampling.y == 2 && mRaw->metadata.subsampling.x == 2)
@@ -243,7 +230,7 @@ void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
     mRaw->setError(e.what());
     // We caught an exception reading WB, just ignore it
   }
-  setMetaData(meta, make, model, mode, iso);
+  setMetaData(meta, mode, iso);
 }
 
 int Cr2Decoder::getHue() {

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -47,16 +47,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-Cr2Decoder::Cr2Decoder(TiffIFD *rootIFD, FileMap* file) :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-Cr2Decoder::~Cr2Decoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage Cr2Decoder::decodeOldFormat() {
   uint32 offset = 0;
   if (mRootIFD->getEntryRecursive(CANON_RAW_DATA_OFFSET))

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "decoders/Cr2Decoder.h"
+#include "decompressors/Cr2Decompressor.h"
 #include "common/Common.h"
 #include "common/Point.h"
 #include "tiff/TiffEntry.h"
@@ -74,11 +75,9 @@ RawImage Cr2Decoder::decodeOldFormat() {
 
   mRaw = RawImage::create({width, height});
 
-  LJpegPlain l(*mFile, offset, mRaw);
-  l.addSlices({width});
-
+  Cr2Decompressor l(*mFile, offset, mRaw);
   try {
-    l.decode(0, 0);
+    l.decode({width});
   } catch (IOException& e) {
     mRaw->setError(e.what());
   }
@@ -131,11 +130,10 @@ RawImage Cr2Decoder::decodeNewFormat() {
   TiffEntry* offsets = raw->getEntry(STRIPOFFSETS);
   TiffEntry* counts = raw->getEntry(STRIPBYTECOUNTS);
 
-  LJpegPlain l(*mFile, offsets->getInt(), counts->getInt(), mRaw);
-  l.addSlices(s_width);
+  Cr2Decompressor d(*mFile, offsets->getInt(), counts->getInt(), mRaw);
 
   try {
-    l.decode(0, 0);
+    d.decode(s_width);
   } catch (RawDecoderException &e) {
     mRaw->setError(e.what());
   } catch (IOException &e) {

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -28,7 +28,10 @@ namespace RawSpeed {
 class Cr2Decoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  Cr2Decoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "decoders/AbstractTiffDecoder.h"
-#include "decompressors/LJpegPlain.h"
 
 namespace RawSpeed {
 

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -20,22 +20,19 @@
 
 #pragma once
 
-#include "decoders/RawDecoder.h"
+#include "decoders/AbstractTiffDecoder.h"
 #include "decompressors/LJpegPlain.h"
-#include "tiff/TiffIFD.h"
 
 namespace RawSpeed {
 
-class Cr2Decoder final :
-  public RawDecoder
+class Cr2Decoder final : public AbstractTiffDecoder
 {
 public:
-  Cr2Decoder(TiffIFD *rootIFD, FileMap* file);
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
-  ~Cr2Decoder() override;
 
 protected:
   int sraw_coeffs[3];
@@ -51,7 +48,6 @@ protected:
   void interpolate_420_v1(int w, int h, int start_h, int end_h);
   void interpolate_422_v2(int w, int h, int start_h, int end_h);
   void interpolate_420_v2(int w, int h, int start_h, int end_h);
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -40,6 +40,7 @@ public:
 protected:
   int sraw_coeffs[3];
 
+  int getDecoderVersion() const override { return 8; }
   RawImage decodeOldFormat();
   RawImage decodeNewFormat();
   void sRawInterpolate();

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -49,7 +49,6 @@ class CameraMetaData;
 
 CrwDecoder::CrwDecoder(CiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
   mHuff[0] = nullptr;
   mHuff[1] = nullptr;
 }

--- a/src/librawspeed/decoders/CrwDecoder.h
+++ b/src/librawspeed/decoders/CrwDecoder.h
@@ -44,6 +44,7 @@ public:
   ~CrwDecoder() override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   CiffIFD *mRootIFD;
   void makeDecoder(int n, const uchar8 *source);
   void initHuffTables (uint32 table);

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -166,26 +166,8 @@ void DcrDecoder::decodeKodak65000Segment(ByteStream &input, ushort16 *out, uint3
   }
 }
 
-void DcrDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("DCR Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void DcrDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("DCR Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("DCR Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -38,12 +38,6 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-DcrDecoder::DcrDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-DcrDecoder::~DcrDecoder() { delete mRootIFD; }
-
 RawImage DcrDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(CFAPATTERN);
 

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -40,7 +40,6 @@ class CameraMetaData;
 
 DcrDecoder::DcrDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 DcrDecoder::~DcrDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/DcrDecoder.h
+++ b/src/librawspeed/decoders/DcrDecoder.h
@@ -23,7 +23,7 @@
 
 #include "common/Common.h"       // for uint32, ushort16
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
@@ -32,21 +32,17 @@ class ByteStream;
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class DcrDecoder :
-  public RawDecoder
+class DcrDecoder final : public AbstractTiffDecoder
 {
 public:
-  DcrDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~DcrDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
   int getDecoderVersion() const override { return 0; }
-  TiffIFD *mRootIFD;
   void decodeKodak65000(ByteStream &input, uint32 w, uint32 h);
   void decodeKodak65000Segment(ByteStream &input, ushort16 *out, uint32 bsize);
 };

--- a/src/librawspeed/decoders/DcrDecoder.h
+++ b/src/librawspeed/decoders/DcrDecoder.h
@@ -35,7 +35,10 @@ class CameraMetaData;
 class DcrDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  DcrDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/DcrDecoder.h
+++ b/src/librawspeed/decoders/DcrDecoder.h
@@ -45,6 +45,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
   void decodeKodak65000(ByteStream &input, uint32 w, uint32 h);
   void decodeKodak65000Segment(ByteStream &input, ushort16 *out, uint32 bsize);

--- a/src/librawspeed/decoders/DcrDecoder.h
+++ b/src/librawspeed/decoders/DcrDecoder.h
@@ -41,7 +41,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -40,7 +40,6 @@ class CameraMetaData;
 
 DcsDecoder::DcsDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 DcsDecoder::~DcsDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -90,26 +90,8 @@ RawImage DcsDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void DcsDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("DCS Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void DcsDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("DCS Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("DCS Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -38,12 +38,6 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-DcsDecoder::DcsDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-DcsDecoder::~DcsDecoder() { delete mRootIFD; }
-
 RawImage DcsDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(IMAGEWIDTH);
 

--- a/src/librawspeed/decoders/DcsDecoder.h
+++ b/src/librawspeed/decoders/DcsDecoder.h
@@ -22,27 +22,24 @@
 #pragma once
 
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class CameraMetaData;
-class TiffIFD;
 
-class DcsDecoder :
-  public RawDecoder
+class DcsDecoder final : public AbstractTiffDecoder
 {
 public:
-  DcsDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~DcsDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
   int getDecoderVersion() const override { return 0; }
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/DcsDecoder.h
+++ b/src/librawspeed/decoders/DcsDecoder.h
@@ -32,7 +32,10 @@ class CameraMetaData;
 class DcsDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  DcsDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/DcsDecoder.h
+++ b/src/librawspeed/decoders/DcsDecoder.h
@@ -38,7 +38,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/DcsDecoder.h
+++ b/src/librawspeed/decoders/DcsDecoder.h
@@ -41,6 +41,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -454,7 +454,14 @@ void DngDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if (mRootIFD->hasEntryRecursive(ISOSPEEDRATINGS))
     mRaw->metadata.isoSpeed = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
-  auto id = mRootIFD->getID();
+  TiffID id;
+
+  try {
+    id = mRootIFD->getID();
+  } catch (...) {
+    // not all dngs have MAKE/MODEL entries,
+    // will be dealt with by using UNIQUECAMERAMODEL below
+  }
 
   // Set the make and model
   mRaw->metadata.make = id.make;

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -196,13 +196,14 @@ void DngDecoder::decodeData(TiffIFD* raw) {
     TiffEntry* offsets = raw->getEntry(STRIPOFFSETS);
     TiffEntry* counts = raw->getEntry(STRIPBYTECOUNTS);
 
-    uint32 yPerSlice = raw->getEntry(ROWSPERSTRIP)->getInt();
-
     if (counts->count != offsets->count) {
       ThrowRDE("DNG Decoder: Byte count number does not match strip size: "
                "count:%u, stips:%u ",
                counts->count, offsets->count);
     }
+
+    uint32 yPerSlice = raw->hasEntry(ROWSPERSTRIP) ?
+          raw->getEntry(ROWSPERSTRIP)->getInt() : mRaw->dim.y;
 
     if (yPerSlice == 0 || yPerSlice > (uint32)mRaw->dim.y)
       ThrowRDE("DNG Decoder: Invalid y per slice");

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -42,7 +42,9 @@ using namespace std;
 
 namespace RawSpeed {
 
-DngDecoder::DngDecoder(TiffIFD *rootIFD, FileMap* file) : RawDecoder(file), mRootIFD(rootIFD) {
+DngDecoder::DngDecoder(TiffRootIFDOwner&& rootIFD, FileMap* file)
+  : AbstractTiffDecoder(move(rootIFD), file)
+{
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(DNGVERSION);
   const uchar8* v = data[0]->getEntry(DNGVERSION)->getData(4);
 
@@ -55,12 +57,6 @@ DngDecoder::DngDecoder(TiffIFD *rootIFD, FileMap* file) : RawDecoder(file), mRoo
     mFixLjpeg = true;
   else
     mFixLjpeg = false;
-}
-
-DngDecoder::~DngDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
 }
 
 void DngDecoder::dropUnsuportedChunks(vector<TiffIFD*>& data) {

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -49,6 +49,7 @@ private:
 
 protected:
   TiffIFD *mRootIFD;
+  int getDecoderVersion() const override { return 0; }
   bool mFixLjpeg;
   void dropUnsuportedChunks(std::vector<TiffIFD*>& data);
   void parseCFA(TiffIFD* raw);

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -22,25 +22,22 @@
 
 #include "common/Common.h"       // for uint32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 #include <vector>                // for vector
 
 namespace RawSpeed {
 
 class CameraMetaData;
-class TiffIFD;
 
-class DngDecoder :
-  public RawDecoder
+class DngDecoder final : public AbstractTiffDecoder
 {
 public:
-  DngDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~DngDecoder() override;
+  DngDecoder(TiffRootIFDOwner&& rootIFD, FileMap* file);
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
   uint32 sample_format{1};
@@ -48,7 +45,6 @@ private:
   int compression;
 
 protected:
-  TiffIFD *mRootIFD;
   int getDecoderVersion() const override { return 0; }
   bool mFixLjpeg;
   void dropUnsuportedChunks(std::vector<TiffIFD*>& data);

--- a/src/librawspeed/decoders/DngDecoderSlices.cpp
+++ b/src/librawspeed/decoders/DngDecoderSlices.cpp
@@ -23,6 +23,7 @@
 #include "common/Memory.h" // for alignedMallocArray, alignedFree
 #include "common/Point.h"
 #include "decompressors/DeflateDecompressor.h"
+#include "decompressors/LJpegDecompressor.h"
 #include "decompressors/JpegDecompressor.h"
 #include "decompressors/UncompressedDecompressor.h"
 #include "io/IOException.h"
@@ -158,10 +159,9 @@ void DngDecoderSlices::decodeSlice(DngDecoderThread* t) {
     while (!t->slices.empty()) {
       DngSliceElement e = t->slices.front();
       t->slices.pop();
-      LJpegPlain l(*mFile, e.byteOffset, e.byteCount, mRaw);
-      l.mDNGCompatible = mFixLjpeg;
+      LJpegDecompressor d(*mFile, e.byteOffset, e.byteCount, mRaw);
       try {
-        l.decode(e.offX, e.offY);
+        d.decode(e.offX, e.offY, mFixLjpeg);
       } catch (RawDecoderException &err) {
         mRaw->setError(err.what());
       } catch (IOException &err) {

--- a/src/librawspeed/decoders/DngDecoderSlices.h
+++ b/src/librawspeed/decoders/DngDecoderSlices.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "decoders/RawDecoder.h"
-#include "decompressors/LJpegPlain.h"
 #include <queue>
 
 namespace RawSpeed {

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -63,26 +63,8 @@ RawImage ErfDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void ErfDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("ERF Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void ErfDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("ERF Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("ERF Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 
   if (mRootIFD->hasEntryRecursive(EPSONWB)) {
     TiffEntry *wb = mRootIFD->getEntryRecursive(EPSONWB);

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -39,7 +39,6 @@ class CameraMetaData;
 
 ErfDecoder::ErfDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 ErfDecoder::~ErfDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -37,12 +37,6 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-ErfDecoder::ErfDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-ErfDecoder::~ErfDecoder() { delete mRootIFD; }
-
 RawImage ErfDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
 

--- a/src/librawspeed/decoders/ErfDecoder.h
+++ b/src/librawspeed/decoders/ErfDecoder.h
@@ -32,7 +32,10 @@ class CameraMetaData;
 class ErfDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  ErfDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/ErfDecoder.h
+++ b/src/librawspeed/decoders/ErfDecoder.h
@@ -38,7 +38,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/ErfDecoder.h
+++ b/src/librawspeed/decoders/ErfDecoder.h
@@ -42,6 +42,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -77,26 +77,8 @@ RawImage KdcDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void KdcDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("KDC Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void KdcDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("KDC Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("KDC Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 
   // Try the kodak hidden IFD for WB
   if (mRootIFD->hasEntryRecursive(KODAK_IFD2)) {

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -39,7 +39,6 @@ namespace RawSpeed {
 
 KdcDecoder::KdcDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 KdcDecoder::~KdcDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -37,12 +37,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-KdcDecoder::KdcDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-KdcDecoder::~KdcDecoder() { delete mRootIFD; }
-
 RawImage KdcDecoder::decodeRawInternal() {
   if (!mRootIFD->hasEntryRecursive(COMPRESSION))
     ThrowRDE("KDC Decoder: Couldn't find compression setting");

--- a/src/librawspeed/decoders/KdcDecoder.h
+++ b/src/librawspeed/decoders/KdcDecoder.h
@@ -32,7 +32,10 @@ class CameraMetaData;
 class KdcDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  KdcDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/KdcDecoder.h
+++ b/src/librawspeed/decoders/KdcDecoder.h
@@ -38,7 +38,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/KdcDecoder.h
+++ b/src/librawspeed/decoders/KdcDecoder.h
@@ -22,27 +22,24 @@
 #pragma once
 
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class CameraMetaData;
-class TiffIFD;
 
-class KdcDecoder :
-  public RawDecoder
+class KdcDecoder final : public AbstractTiffDecoder
 {
 public:
-  KdcDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~KdcDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
   int getDecoderVersion() const override { return 0; }
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/KdcDecoder.h
+++ b/src/librawspeed/decoders/KdcDecoder.h
@@ -41,6 +41,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -35,12 +35,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-MefDecoder::MefDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-MefDecoder::~MefDecoder() { delete mRootIFD; }
-
 RawImage MefDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
 

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -61,26 +61,8 @@ RawImage MefDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void MefDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("MEF Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void MefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("MEF Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("MEF Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -37,7 +37,6 @@ namespace RawSpeed {
 
 MefDecoder::MefDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 MefDecoder::~MefDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/MefDecoder.h
+++ b/src/librawspeed/decoders/MefDecoder.h
@@ -32,7 +32,10 @@ class CameraMetaData;
 class MefDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  MefDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/MefDecoder.h
+++ b/src/librawspeed/decoders/MefDecoder.h
@@ -22,27 +22,24 @@
 #pragma once
 
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class CameraMetaData;
-class TiffIFD;
 
-class MefDecoder :
-  public RawDecoder
+class MefDecoder final : public AbstractTiffDecoder
 {
 public:
-  MefDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~MefDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
   int getDecoderVersion() const override { return 0; }
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/MefDecoder.h
+++ b/src/librawspeed/decoders/MefDecoder.h
@@ -38,7 +38,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/MefDecoder.h
+++ b/src/librawspeed/decoders/MefDecoder.h
@@ -41,6 +41,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -40,8 +40,9 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-MosDecoder::MosDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
+MosDecoder::MosDecoder(TiffRootIFDOwner&& rootIFD, FileMap* file)
+  : AbstractTiffDecoder(move(rootIFD), file)
+{
   black_level = 0;
 
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MAKE);
@@ -57,8 +58,6 @@ MosDecoder::MosDecoder(TiffIFD *rootIFD, FileMap* file)  :
     model = getXMPTag(xmpText, "Model");
   }
 }
-
-MosDecoder::~MosDecoder() { delete mRootIFD; }
 
 string MosDecoder::getXMPTag(const string &xmp, const string &tag) {
   string::size_type start = xmp.find("<tiff:"+tag+">");

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -42,7 +42,6 @@ class CameraMetaData;
 
 MosDecoder::MosDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
   black_level = 0;
 
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MAKE);

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -45,10 +45,10 @@ MosDecoder::MosDecoder(TiffRootIFDOwner&& rootIFD, FileMap* file)
 {
   black_level = 0;
 
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MAKE);
-  if (!data.empty()) {
-    make = data[0]->getEntry(MAKE)->getString();
-    model = data[0]->getEntry(MODEL)->getString();
+  if (mRootIFD->getEntryRecursive(MAKE)) {
+    auto id = mRootIFD->getID();
+    make = id.make;
+    model = id.model;
   } else {
     TiffEntry *xmp = mRootIFD->getEntryRecursive(XMP);
     if (!xmp)
@@ -191,11 +191,11 @@ void MosDecoder::DecodePhaseOneC(uint32 data_offset, uint32 strip_offset, uint32
 }
 
 void MosDecoder::checkSupportInternal(CameraMetaData *meta) {
-  this->checkCameraSupported(meta, make, model, "");
+  RawDecoder::checkCameraSupported(meta, make, model, "");
 }
 
 void MosDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  setMetaData(meta, make, model, "", 0);
+  RawDecoder::setMetaData(meta, make, model, "", 0);
 
   // Fetch the white balance (see dcraw.c parse_mos for more metadata that can be gotten)
   if (mRootIFD->hasEntryRecursive(LEAFMETADATA)) {

--- a/src/librawspeed/decoders/MosDecoder.h
+++ b/src/librawspeed/decoders/MosDecoder.h
@@ -44,6 +44,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   uint32 black_level;
   TiffIFD *mRootIFD;
   std::string make, model;

--- a/src/librawspeed/decoders/MosDecoder.h
+++ b/src/librawspeed/decoders/MosDecoder.h
@@ -23,7 +23,7 @@
 
 #include "common/Common.h"       // for uint32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 #include <string>                // for string
 
@@ -31,14 +31,11 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class MosDecoder :
-  public RawDecoder
+class MosDecoder final : public AbstractTiffDecoder
 {
 public:
-  MosDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~MosDecoder() override;
+  MosDecoder(TiffRootIFDOwner&& rootIFD, FileMap* file);
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
@@ -46,7 +43,6 @@ public:
 protected:
   int getDecoderVersion() const override { return 0; }
   uint32 black_level;
-  TiffIFD *mRootIFD;
   std::string make, model;
   std::string getXMPTag(const std::string &xmp, const std::string &tag);
   void DecodePhaseOneC(uint32 data_offset, uint32 strip_offset, uint32 width, uint32 height);

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -59,7 +59,7 @@ void MrwDecoder::parseHeader() {
     ThrowRDE("This isn't actually a MRW file, why are you calling me?");
 
   const unsigned char* data = mFile->getData(0,8);
-  data_offset = get4BE(data,4)+8;
+  data_offset = getU32BE(data + 4) + 8;
   data = mFile->getData(0,data_offset);
 
   if (!mFile->isValid(data_offset))
@@ -71,17 +71,17 @@ void MrwDecoder::parseHeader() {
 
   uint32 currpos = 8;
   // At most we read 20 bytes from currpos so check we don't step outside that
-  while (currpos+20 < data_offset) {
-    uint32 tag = get4BE(data,currpos);
-    uint32 len = get4BE(data,currpos+4);
+  while (currpos + 20 < data_offset) {
+    uint32 tag = getU32BE(data + currpos);
+    uint32 len = getU32BE(data + currpos + 4);
     switch(tag) {
     case 0x505244: // PRD
-      raw_height = get2BE(data,currpos+16);
-      raw_width = get2BE(data,currpos+18);
+      raw_height = getU16BE(data + currpos + 16);
+      raw_width = getU16BE(data + currpos + 18);
       packed = (data[currpos+24] == 12);
     case 0x574247: // WBG
-      for(uint32 i=0; i<4; i++)
-        wb_coeffs[i] = (float)get2BE(data, currpos+12+i*2);
+      for (uint32 i = 0; i < 4; i++)
+        wb_coeffs[i] = (float)getU16BE(data + currpos + 12 + i * 2);
       break;
     case 0x545457: // TTW
       // Base value for offsets needs to be at the beginning of the TIFF block, not the file

--- a/src/librawspeed/decoders/MrwDecoder.h
+++ b/src/librawspeed/decoders/MrwDecoder.h
@@ -42,6 +42,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   static int isMRW(FileMap* input);
 protected:
+  int getDecoderVersion() const override { return 0; }
   virtual void parseHeader();
   uint32 raw_width, raw_height, data_offset, packed;
   TiffIFD *tiff_meta;

--- a/src/librawspeed/decoders/MrwDecoder.h
+++ b/src/librawspeed/decoders/MrwDecoder.h
@@ -25,18 +25,17 @@
 #include "common/RawImage.h"     // for RawImage
 #include "decoders/RawDecoder.h" // for RawDecoder
 #include "io/FileMap.h"          // for FileMap
+#include "tiff/TiffIFD.h"
 
 namespace RawSpeed {
 
 class CameraMetaData;
-class TiffIFD;
 
 class MrwDecoder :
   public RawDecoder
 {
 public:
   MrwDecoder(FileMap* file);
-  ~MrwDecoder() override;
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
@@ -45,7 +44,7 @@ protected:
   int getDecoderVersion() const override { return 0; }
   virtual void parseHeader();
   uint32 raw_width, raw_height, data_offset, packed;
-  TiffIFD *tiff_meta;
+  TiffRootIFDOwner rootIFD;
   float wb_coeffs[4];
 };
 

--- a/src/librawspeed/decoders/NakedDecoder.h
+++ b/src/librawspeed/decoders/NakedDecoder.h
@@ -46,6 +46,7 @@ private:
   void parseHints();
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   Camera *cam;
 
   uint32 width{0};

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -49,16 +49,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-NefDecoder::NefDecoder(TiffIFD *rootIFD, FileMap* file) :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-NefDecoder::~NefDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage NefDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(CFAPATTERN);
 

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -517,18 +517,18 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
 
         // Finally set the WB coeffs
         uint32 off = (version == 0x204) ? 6 : 14;
-        mRaw->metadata.wbCoeffs[0] = (float)get2BE(buf, off);
-        mRaw->metadata.wbCoeffs[1] = (float)get2BE(buf, off+2);
-        mRaw->metadata.wbCoeffs[2] = (float)get2BE(buf, off+6);
+        mRaw->metadata.wbCoeffs[0] = (float)getU16BE(buf + off + 0);
+        mRaw->metadata.wbCoeffs[1] = (float)getU16BE(buf + off + 2);
+        mRaw->metadata.wbCoeffs[2] = (float)getU16BE(buf + off + 6);
       }
     }
   } else if (mRootIFD->hasEntryRecursive((TiffTag)0x0014)) {
     TiffEntry *wb = mRootIFD->getEntryRecursive((TiffTag)0x0014);
     auto *tmp = (uchar8 *)wb->getData(wb->count);
     if (wb->count == 2560 && wb->type == TIFF_UNDEFINED) {
-      mRaw->metadata.wbCoeffs[0] = (float) get2BE(tmp, 1248) / 256.0f;
+      mRaw->metadata.wbCoeffs[0] = (float) getU16BE(tmp + 1248) / 256.0f;
       mRaw->metadata.wbCoeffs[1] = 1.0f;
-      mRaw->metadata.wbCoeffs[2] = (float) get2BE(tmp, 1250) / 256.0f;
+      mRaw->metadata.wbCoeffs[2] = (float) getU16BE(tmp + 1250) / 256.0f;
     } else if (!strncmp((char *)tmp,"NRW ",4)) {
       uint32 offset = 0;
       if (strncmp((char *)tmp + 4, "0100", 4) != 0 && wb->count > 72)
@@ -538,9 +538,9 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
 
       if (offset) {
         tmp += offset;
-        mRaw->metadata.wbCoeffs[0] = (float) (get4LE(tmp,0) << 2);
-        mRaw->metadata.wbCoeffs[1] = (float) (get4LE(tmp,4) + get4LE(tmp,8));
-        mRaw->metadata.wbCoeffs[2] = (float) (get4LE(tmp,12) << 2);
+        mRaw->metadata.wbCoeffs[0] = (float)(getU32LE(tmp + 0) << 2);
+        mRaw->metadata.wbCoeffs[1] = (float)(getU32LE(tmp + 4) + getU32LE(tmp + 8));
+        mRaw->metadata.wbCoeffs[2] = (float)(getU32LE(tmp + 12) << 2);
       }
     }
   }

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -51,7 +51,6 @@ namespace RawSpeed {
 
 NefDecoder::NefDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 5;
 }
 
 NefDecoder::~NefDecoder() {

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -50,6 +50,7 @@ public:
   TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
+  int getDecoderVersion() const override { return 5; }
   bool D100IsCompressed(uint32 offset);
   bool NEFIsUncompressed(TiffIFD *raw);
   bool NEFIsUncompressedRGB(TiffIFD *raw);

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -22,7 +22,7 @@
 
 #include "common/Common.h"       // for uint32, ushort16
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 #include <string>                // for string
 #include <vector>                // for vector
@@ -33,21 +33,16 @@ class ByteStream;
 
 class CameraMetaData;
 
-class TiffIFD;
-
 class iPoint2D;
 
-class NefDecoder :
-  public RawDecoder
+class NefDecoder final : public AbstractTiffDecoder
 {
 public:
-  NefDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~NefDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *mRootIFD;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
   int getDecoderVersion() const override { return 5; }

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -38,7 +38,10 @@ class iPoint2D;
 class NefDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  NefDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -260,32 +260,14 @@ void OrfDecoder::decodeCompressed(ByteStream& s, uint32 w, uint32 h) {
   }
 }
 
-void OrfDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("ORF Support check: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("ORF Support: Make name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void OrfDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("ORF Meta Decoder: Model name found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
 
   if (mRootIFD->hasEntryRecursive(ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
-  setMetaData(meta, make, model, "", iso);
+  setMetaData(meta, "", iso);
 
   if (mRootIFD->hasEntryRecursive(OLYMPUSREDMULTIPLIER) &&
       mRootIFD->hasEntryRecursive(OLYMPUSBLUEMULTIPLIER)) {

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -46,16 +46,6 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-OrfDecoder::OrfDecoder(TiffIFD *rootIFD, FileMap* file):
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-OrfDecoder::~OrfDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage OrfDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
 

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -48,7 +48,6 @@ class CameraMetaData;
 
 OrfDecoder::OrfDecoder(TiffIFD *rootIFD, FileMap* file):
     RawDecoder(file), mRootIFD(rootIFD) {
-      decoderVersion = 3;
 }
 
 OrfDecoder::~OrfDecoder() {

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -35,7 +35,10 @@ class CameraMetaData;
 class OrfDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  OrfDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -42,7 +42,6 @@ public:
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
-  void checkSupportInternal(CameraMetaData *meta) override;
 
 private:
   int getDecoderVersion() const override { return 3; }

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -46,6 +46,7 @@ public:
   TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
+  int getDecoderVersion() const override { return 3; }
   void decodeCompressed(ByteStream& s,uint32 w, uint32 h);
   void decodeUncompressed(ByteStream& s, uint32 w, uint32 h, uint32 size);
   TiffIFD *mRootIFD;

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -23,7 +23,7 @@
 
 #include "common/Common.h"       // for uint32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
@@ -32,24 +32,19 @@ class ByteStream;
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class OrfDecoder :
-  public RawDecoder
+class OrfDecoder final : public AbstractTiffDecoder
 {
 public:
-  OrfDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~OrfDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
   int getDecoderVersion() const override { return 3; }
   void decodeCompressed(ByteStream& s,uint32 w, uint32 h);
   void decodeUncompressed(ByteStream& s, uint32 w, uint32 h, uint32 size);
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -82,35 +82,14 @@ RawImage PefDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void PefDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("PEF Support check: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("PEF Support: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void PefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("PEF Meta Decoder: Model name found");
-
-  TiffIFD* raw = data[0];
-
-  string make = raw->getEntry(MAKE)->getString();
-  string model = raw->getEntry(MODEL)->getString();
 
   if (mRootIFD->hasEntryRecursive(ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
-  setMetaData(meta, make, model, "", iso);
+  setMetaData(meta, "", iso);
 
   // Read black level
   if (mRootIFD->hasEntryRecursive((TiffTag)0x200)) {

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -40,7 +40,6 @@ namespace RawSpeed {
 
 PefDecoder::PefDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-      decoderVersion = 3;
 }
 
 PefDecoder::~PefDecoder() {

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -38,16 +38,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-PefDecoder::PefDecoder(TiffIFD *rootIFD, FileMap* file) :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-PefDecoder::~PefDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage PefDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
   if (data.empty())
@@ -83,7 +73,7 @@ RawImage PefDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
   try {
-    decodePentax(mRaw, ByteStream(mFile, offsets->getInt(), counts->getInt()), mRootIFD);
+    decodePentax(mRaw, ByteStream(mFile, offsets->getInt(), counts->getInt()), getRootIFD());
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/src/librawspeed/decoders/PefDecoder.h
+++ b/src/librawspeed/decoders/PefDecoder.h
@@ -40,6 +40,8 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
   TiffIFD *getRootIFD() override { return mRootIFD; }
+protected:
+  int getDecoderVersion() const override { return 3; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/PefDecoder.h
+++ b/src/librawspeed/decoders/PefDecoder.h
@@ -31,7 +31,10 @@ class CameraMetaData;
 class PefDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  PefDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/PefDecoder.h
+++ b/src/librawspeed/decoders/PefDecoder.h
@@ -38,7 +38,7 @@ public:
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
-  void checkSupportInternal(CameraMetaData *meta) override;
+
 protected:
   int getDecoderVersion() const override { return 3; }
 };

--- a/src/librawspeed/decoders/PefDecoder.h
+++ b/src/librawspeed/decoders/PefDecoder.h
@@ -21,28 +21,23 @@
 #pragma once
 
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class PefDecoder :
-  public RawDecoder
+class PefDecoder final : public AbstractTiffDecoder
 {
 public:
-  PefDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~PefDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 protected:
   int getDecoderVersion() const override { return 3; }
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -44,7 +44,6 @@ namespace RawSpeed {
 
 RafDecoder::RafDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 1;
   alt_layout = false;
 }
 RafDecoder::~RafDecoder() {

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -125,27 +125,11 @@ void RafDecoder::decodeThreaded(RawDecoderThread * t) {
 }
 
 void RafDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("RAF Support check: Model name found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  if (!this->checkCameraSupported(meta, make, model, ""))
+  if (!this->checkCameraSupported(meta, mRootIFD->getID(), ""))
      ThrowRDE("RAFDecoder: Unknown camera. Will not guess.");
 }
 
 void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  if (data.empty())
-    ThrowRDE("RAF Meta Decoder: Model name not found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("RAF Support: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-
   int iso = 0;
   if (mRootIFD->hasEntryRecursive(ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
@@ -153,9 +137,8 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
 
   // This is where we'd normally call setMetaData but since we may still need
   // to rotate the image for SuperCCD cameras we do everything ourselves
-  TrimSpaces(make);
-  TrimSpaces(model);
-  Camera *cam = meta->getCamera(make, model, "");
+  auto id = mRootIFD->getID();
+  Camera *cam = meta->getCamera(id.make, id.model, "");
   if (!cam)
     ThrowRDE("RAF Meta Decoder: Couldn't find camera");
 
@@ -243,8 +226,8 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   mRaw->metadata.canonical_model = cam->canonical_model;
   mRaw->metadata.canonical_alias = cam->canonical_alias;
   mRaw->metadata.canonical_id = cam->canonical_id;
-  mRaw->metadata.make = make;
-  mRaw->metadata.model = model;
+  mRaw->metadata.make = id.make;
+  mRaw->metadata.model = id.model;
 
   if (mRootIFD->hasEntryRecursive(FUJI_WB_GRBLEVELS)) {
     TiffEntry *wb = mRootIFD->getEntryRecursive(FUJI_WB_GRBLEVELS);

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -42,16 +42,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-RafDecoder::RafDecoder(TiffIFD *rootIFD, FileMap* file) :
-    RawDecoder(file), mRootIFD(rootIFD) {
-  alt_layout = false;
-}
-RafDecoder::~RafDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 bool RafDecoder::isRAF(FileMap* input) {
   static const char magic[] = "FUJIFILMCCD-RAW ";
   static const size_t magic_size = sizeof(magic) - 1; // excluding \0

--- a/src/librawspeed/decoders/RafDecoder.h
+++ b/src/librawspeed/decoders/RafDecoder.h
@@ -22,22 +22,18 @@
 #pragma once
 
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder, RawDecoderThread (ptr o...
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 
 namespace RawSpeed {
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class RafDecoder :
-  public RawDecoder
+class RafDecoder final : public AbstractTiffDecoder
 {
-  TiffIFD *mRootIFD;
 public:
-  RafDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~RafDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
@@ -47,7 +43,7 @@ protected:
   int getDecoderVersion() const override { return 1; }
   void decodeThreaded(RawDecoderThread *t) override;
   void DecodeRaf();
-  bool alt_layout;
+  bool alt_layout = false;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/RafDecoder.h
+++ b/src/librawspeed/decoders/RafDecoder.h
@@ -32,7 +32,10 @@ class CameraMetaData;
 class RafDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  RafDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/RafDecoder.h
+++ b/src/librawspeed/decoders/RafDecoder.h
@@ -44,6 +44,7 @@ public:
   static bool isRAF(FileMap* input);
 
 protected:
+  int getDecoderVersion() const override { return 1; }
   void decodeThreaded(RawDecoderThread *t) override;
   void DecodeRaf();
   bool alt_layout;

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -124,8 +124,6 @@ void RawDecoder::decodeUncompressed(TiffIFD *rawIFD, BitOrder order) {
 
 bool RawDecoder::checkCameraSupported(CameraMetaData *meta, string make,
                                       string model, const string &mode) {
-  TrimSpaces(make);
-  TrimSpaces(model);
   mRaw->metadata.make = make;
   mRaw->metadata.model = model;
   Camera* cam = meta->getCamera(make, model, mode);
@@ -155,8 +153,6 @@ bool RawDecoder::checkCameraSupported(CameraMetaData *meta, string make,
 void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model,
                              const string &mode, int iso_speed) {
   mRaw->metadata.isoSpeed = iso_speed;
-  TrimSpaces(make);
-  TrimSpaces(model);
   Camera *cam = meta->getCamera(make, model, mode);
   if (!cam) {
     writeLog(DEBUG_PRIO_INFO, "ISO:%d\n", iso_speed);

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -54,7 +54,6 @@ using namespace std;
 namespace RawSpeed {
 
 RawDecoder::RawDecoder(FileMap* file) : mRaw(RawImage::create()), mFile(file) {
-  decoderVersion = 0;
   failOnUnknown = false;
   interpolateBadPixels = true;
   applyStage1DngOpcodes = true;
@@ -146,7 +145,7 @@ bool RawDecoder::checkCameraSupported(CameraMetaData *meta, string make,
   if (!cam->supported)
     ThrowRDE("Camera not supported (explicit). Sorry.");
 
-  if (cam->decoderVersion > decoderVersion)
+  if (cam->decoderVersion > getDecoderVersion())
     ThrowRDE("Camera not supported in this version. Update RawSpeed for support.");
 
   hints = cam->hints;

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -170,12 +170,12 @@ protected:
   /* The Raw input file to be decoded */
   FileMap *mFile;
 
-  /* Decoder version - defaults to 0, but can be overridden by decoders */
+  /* Decoder version */
   /* This can be used to avoid newer version of an xml file to indicate that a file */
   /* can be decoded, when a specific version of the code is needed */
   /* Higher number in camera xml file: Files for this camera will not be decoded */
   /* Higher number in code than xml: Image will be decoded. */
-  int decoderVersion;
+  virtual int getDecoderVersion() const = 0;
 
   /* Hints set for the camera after checkCameraSupported has been called from the implementation*/
    std::map<std::string,std::string> hints;

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -47,7 +47,6 @@ class CameraMetaData;
 
 Rw2Decoder::Rw2Decoder(TiffIFD *rootIFD, FileMap *file)
     : RawDecoder(file), mRootIFD(rootIFD), input_start(nullptr) {
-  decoderVersion = 2;
 }
 Rw2Decoder::~Rw2Decoder() {
   if (input_start)

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -45,16 +45,10 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-Rw2Decoder::Rw2Decoder(TiffIFD *rootIFD, FileMap *file)
-    : RawDecoder(file), mRootIFD(rootIFD), input_start(nullptr) {
-}
 Rw2Decoder::~Rw2Decoder() {
   if (input_start)
     delete input_start;
   input_start = nullptr;
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
 }
 
 RawImage Rw2Decoder::decodeRawInternal() {

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -48,7 +48,10 @@ class PanaBitpump {
 class Rw2Decoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  Rw2Decoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
   ~Rw2Decoder() override;
 
   RawImage decodeRawInternal() override;

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -23,7 +23,7 @@
 
 #include "common/Common.h"       // for uint32, uchar8
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder, RawDecoderThread (ptr o...
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/FileMap.h"          // for FileMap
 #include <string>                // for string
 
@@ -32,8 +32,6 @@ namespace RawSpeed {
 class ByteStream;
 
 class CameraMetaData;
-
-class TiffIFD;
 
 class PanaBitpump {
   public:
@@ -47,17 +45,15 @@ class PanaBitpump {
   void skipBytes(int bytes);
 };
 
-class Rw2Decoder :
-  public RawDecoder
+class Rw2Decoder final : public AbstractTiffDecoder
 {
 public:
-  Rw2Decoder(TiffIFD *rootIFD, FileMap* file);
+  using AbstractTiffDecoder::AbstractTiffDecoder;
   ~Rw2Decoder() override;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *mRootIFD;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 protected:
   int getDecoderVersion() const override { return 2; }
@@ -66,7 +62,7 @@ protected:
 private:
   void DecodeRw2();
   std::string guessMode();
-  ByteStream* input_start;
+  ByteStream* input_start = nullptr;
   uint32 load_flags;
 };
 

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -60,6 +60,7 @@ public:
   TiffIFD *getRootIFD() override { return mRootIFD; }
 
 protected:
+  int getDecoderVersion() const override { return 2; }
   void decodeThreaded(RawDecoderThread *t) override;
 
 private:

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -43,7 +43,6 @@ namespace RawSpeed {
 
 SrwDecoder::SrwDecoder(TiffIFD *rootIFD, FileMap* file):
 RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 3;
 }
 
 SrwDecoder::~SrwDecoder() {

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -41,16 +41,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-SrwDecoder::SrwDecoder(TiffIFD *rootIFD, FileMap* file):
-RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-SrwDecoder::~SrwDecoder() {
-  if (mRootIFD)
-    delete mRootIFD;
-  mRootIFD = nullptr;
-}
-
 RawImage SrwDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
 

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -440,37 +440,25 @@ string SrwDecoder::getMode() {
 }
 
 void SrwDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("Srw Support check: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("SRW Support: Make name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
+  auto id = mRootIFD->getID();
   string mode = getMode();
-  if (meta->hasCamera(make, model, mode))
-    this->checkCameraSupported(meta, make, model, getMode());
+  if (meta->hasCamera(id.make, id.model, mode))
+    this->checkCameraSupported(meta, id, getMode());
   else
-    this->checkCameraSupported(meta, make, model, "");
+    this->checkCameraSupported(meta, id, "");
 }
 
 void SrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("SRW Meta Decoder: Model name found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-
   int iso = 0;
   if (mRootIFD->hasEntryRecursive(ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
+  auto id = mRootIFD->getID();
   string mode = getMode();
-  if (meta->hasCamera(make, model, mode))
-    setMetaData(meta, make, model, mode, iso);
+  if (meta->hasCamera(id.make, id.model, mode))
+    setMetaData(meta, id, mode, iso);
   else
-    setMetaData(meta, make, model, "", iso);
+    setMetaData(meta, id, "", iso);
 
   // Set the whitebalance
   if (mRootIFD->hasEntryRecursive(SAMSUNG_WB_RGGBLEVELSUNCORRECTED) &&

--- a/src/librawspeed/decoders/SrwDecoder.h
+++ b/src/librawspeed/decoders/SrwDecoder.h
@@ -50,6 +50,7 @@ private:
     uchar8 diffLen;
   };
 
+  int getDecoderVersion() const override { return 3; }
   void decodeCompressed(TiffIFD* raw);
   void decodeCompressed2(TiffIFD* raw, int bits);
   int32 samsungDiff (BitPumpMSB &pump, encTableItem *tbl);

--- a/src/librawspeed/decoders/SrwDecoder.h
+++ b/src/librawspeed/decoders/SrwDecoder.h
@@ -34,7 +34,10 @@ class CameraMetaData;
 class SrwDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  SrwDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/SrwDecoder.h
+++ b/src/librawspeed/decoders/SrwDecoder.h
@@ -22,7 +22,7 @@
 
 #include "common/Common.h"       // for uchar8, int32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/BitPumpMSB.h"       // for BitPumpMSB
 #include "io/FileMap.h"          // for FileMap
 #include <string>                // for string
@@ -31,18 +31,14 @@ namespace RawSpeed {
 
 class CameraMetaData;
 
-class TiffIFD;
-
-class SrwDecoder :
-  public RawDecoder
+class SrwDecoder final : public AbstractTiffDecoder
 {
 public:
-  SrwDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~SrwDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
   void checkSupportInternal(CameraMetaData *meta) override;
-  TiffIFD *getRootIFD() override { return mRootIFD; }
 
 private:
   struct encTableItem {
@@ -56,7 +52,6 @@ private:
   int32 samsungDiff (BitPumpMSB &pump, encTableItem *tbl);
   void decodeCompressed3(TiffIFD* raw, int bits);
   std::string getMode();
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -57,7 +57,6 @@ namespace RawSpeed {
 
 ThreefrDecoder::ThreefrDecoder(TiffIFD *rootIFD, FileMap* file)  :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 0;
 }
 
 ThreefrDecoder::~ThreefrDecoder() { delete mRootIFD; }

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -89,27 +89,10 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void ThreefrDecoder::checkSupportInternal(CameraMetaData *meta) {
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-  if (data.empty())
-    ThrowRDE("3FR Support check: Model name not found");
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  this->checkCameraSupported(meta, make, model, "");
-}
-
 void ThreefrDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN, CFA_BLUE);
-  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
-  if (data.empty())
-    ThrowRDE("3FR Decoder: Model name found");
-  if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("3FR Decoder: Make name not found");
-
-  string make = data[0]->getEntry(MAKE)->getString();
-  string model = data[0]->getEntry(MODEL)->getString();
-  setMetaData(meta, make, model, "", 0);
+  setMetaData(meta, "", 0);
 
   // Fetch the white balance
   if (mRootIFD->hasEntryRecursive(ASSHOTNEUTRAL)) {

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -55,12 +55,6 @@ using namespace std;
 
 namespace RawSpeed {
 
-ThreefrDecoder::ThreefrDecoder(TiffIFD *rootIFD, FileMap* file)  :
-    RawDecoder(file), mRootIFD(rootIFD) {
-}
-
-ThreefrDecoder::~ThreefrDecoder() { delete mRootIFD; }
-
 RawImage ThreefrDecoder::decodeRawInternal() {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
 

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -23,26 +23,24 @@
 
 #include "common/Common.h"       // for uchar8, int32
 #include "common/RawImage.h"     // for RawImage
-#include "decoders/RawDecoder.h" // for RawDecoder
+#include "decoders/AbstractTiffDecoder.h"
 #include "io/BitPumpMSB.h"       // for BitPumpMSB
 #include "io/FileMap.h"          // for FileMap
 #include <string>                // for string
 
 namespace RawSpeed {
 
-class ThreefrDecoder :
-  public RawDecoder
+class ThreefrDecoder final : public AbstractTiffDecoder
 {
 public:
-  ThreefrDecoder(TiffIFD *rootIFD, FileMap* file);
-  ~ThreefrDecoder() override;
+  using AbstractTiffDecoder::AbstractTiffDecoder;
+
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
   int getDecoderVersion() const override { return 0; }
-  TiffIFD *mRootIFD;
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -39,7 +39,6 @@ public:
     : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
-  void checkSupportInternal(CameraMetaData *meta) override;
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -33,7 +33,10 @@ namespace RawSpeed {
 class ThreefrDecoder final : public AbstractTiffDecoder
 {
 public:
-  using AbstractTiffDecoder::AbstractTiffDecoder;
+  // please revert _this_ commit, once IWYU can handle inheriting constructors
+  // using AbstractTiffDecoder::AbstractTiffDecoder;
+  ThreefrDecoder(TiffRootIFDOwner&& root, FileMap* file)
+    : AbstractTiffDecoder(move(root), file) {}
 
   RawImage decodeRawInternal() override;
   void checkSupportInternal(CameraMetaData *meta) override;

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -41,6 +41,7 @@ public:
   void decodeMetaDataInternal(CameraMetaData *meta) override;
 
 protected:
+  int getDecoderVersion() const override { return 0; }
   TiffIFD *mRootIFD;
 };
 

--- a/src/librawspeed/decoders/X3fDecoder.cpp
+++ b/src/librawspeed/decoders/X3fDecoder.cpp
@@ -126,16 +126,15 @@ bool X3fDecoder::readName() {
       if (i.getUInt() == 0x66697845) { // Match text 'Exif'
         try {
           TiffRootIFDOwner root = parseTiff(mFile->getSubView(cimg.dataOffset+12, i.getRemainSize()));
-
-          if (root->hasEntryRecursive(MAKE) && root->hasEntryRecursive(MODEL)) {
-            camera_model = root->getEntryRecursive(MODEL)->getString();
-            camera_make = root->getEntryRecursive(MAKE)->getString();
-            mProperties.props["CAMMANUF"] = root->getEntryRecursive(MAKE)->getString();
-            mProperties.props["CAMMODEL"] = root->getEntryRecursive(MODEL)->getString();
-            return true;
-          }
-        } catch (...) {}
-        return false;
+          auto id = root->getID();
+          camera_model = id.model;
+          camera_make = id.make;
+          mProperties.props["CAMMANUF"] = id.make;
+          mProperties.props["CAMMODEL"] = id.model;
+          return true;
+        } catch (...) {
+          return false;
+        }
       }
     }
   }

--- a/src/librawspeed/decoders/X3fDecoder.cpp
+++ b/src/librawspeed/decoders/X3fDecoder.cpp
@@ -44,7 +44,6 @@ using namespace std;
 namespace RawSpeed {
 
 X3fDecoder::X3fDecoder(FileMap *file) : RawDecoder(file), bytes(nullptr) {
-  decoderVersion = 1;
   huge_table = nullptr;
   line_offsets = nullptr;
   bytes = new ByteStream(file, 0, getHostEndianness() == little);

--- a/src/librawspeed/decoders/X3fDecoder.h
+++ b/src/librawspeed/decoders/X3fDecoder.h
@@ -52,6 +52,7 @@ public:
   X3fPropertyCollection mProperties;
 
 protected:
+  int getDecoderVersion() const override { return 1; }
   void decodeThreaded(RawDecoderThread *t) override;
   void readDirectory();
   std::string getId();

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
@@ -1,0 +1,187 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "decompressors/AbstractLJpegDecompressor.h"
+#include "common/Common.h"                // for uint32, getHostEndianness
+#include "common/Point.h"                 // for iPoint2D
+#include "decoders/RawDecoderException.h" // for ThrowRDE
+#include "decompressors/HuffmanTable.h"   // for HuffmanTable
+#include "io/ByteStream.h"                // for ByteStream
+#include "io/IOException.h"               // for IOException
+#include <array>                          // for array
+#include <memory>                         // for unique_ptr, allocator
+#include <vector>                         // for vector
+
+namespace RawSpeed {
+
+void AbstractLJpegDecompressor::decode() {
+  if (getNextMarker(false) != M_SOI)
+    ThrowRDE("LJpegDecompressor: Image did not start with SOI. Probably not an LJPEG");
+
+  JpegMarker m;
+  do {
+    m = getNextMarker(true);
+
+    switch (m) {
+    case M_DHT:  parseDHT(); break;
+    case M_SOF3: parseSOF(&frame); break;
+    case M_SOS:  parseSOS(); break;
+    case M_DQT:  ThrowRDE("LJpegDecompressor: Not a valid RAW file.");
+    default:  // Just let it skip to next marker
+      break;
+    }
+  } while (m != M_EOI);
+}
+
+void AbstractLJpegDecompressor::parseSOF(SOFInfo* sof) {
+  uint32 headerLength = input.getShort();
+  sof->prec = input.getByte();
+  sof->h = input.getShort();
+  sof->w = input.getShort();
+  sof->cps = input.getByte();
+
+  if (sof->h == 0 || sof->w == 0)
+    ThrowRDE("LJpegDecompressor: Frame width or height set to zero");
+
+  if (sof->prec > 16)
+    ThrowRDE("LJpegDecompressor: More than 16 bits per channel is not supported.");
+
+  if (sof->cps > 4 || sof->cps < 1)
+    ThrowRDE("LJpegDecompressor: Only from 1 to 4 components are supported.");
+
+  if (headerLength != 8 + sof->cps*3)
+    ThrowRDE("LJpegDecompressor: Header size mismatch.");
+
+  for (uint32 i = 0; i < sof->cps; i++) {
+    sof->compInfo[i].componentId = input.getByte();
+    uint32 subs = input.getByte();
+    frame.compInfo[i].superV = subs & 0xf;
+    frame.compInfo[i].superH = subs >> 4;
+    uint32 Tq = input.getByte();
+    if (Tq != 0)
+      ThrowRDE("LJpegDecompressor: Quantized components not supported.");
+  }
+  sof->initialized = true;
+
+  mRaw->metadata.subsampling.x = sof->compInfo[0].superH;
+  mRaw->metadata.subsampling.y = sof->compInfo[0].superV;
+}
+
+void AbstractLJpegDecompressor::parseSOS() {
+  if (!frame.initialized)
+    ThrowRDE("LJpegDecompressor::parseSOS: Frame not yet initialized (SOF Marker not parsed)");
+
+  uint32 headerLength = input.getShort();
+  if (headerLength != 3 + frame.cps * 2 + 3)
+    ThrowRDE("LJpegDecompressor::parseSOS: Invalid SOS header length.");
+
+  uint32 soscps = input.getByte();
+  if (frame.cps != soscps)
+    ThrowRDE("LJpegDecompressor::parseSOS: Component number mismatch.");
+
+  for (uint32 i = 0; i < frame.cps; i++) {
+    uint32 cs = input.getByte();
+    uint32 td = input.getByte() >> 4;
+
+    if (td > 3 || !huff[td])
+      ThrowRDE("LJpegDecompressor::parseSOS: Invalid Huffman table selection.");
+
+    int ciIndex = -1;
+    for (uint32 j = 0; j < frame.cps; ++j) {
+      if (frame.compInfo[j].componentId == cs)
+        ciIndex = j;
+    }
+
+    if (ciIndex == -1)
+        ThrowRDE("LJpegDecompressor::parseSOS: Invalid Component Selector");
+
+    frame.compInfo[ciIndex].dcTblNo = td;
+  }
+
+  // Get predictor, see table H.1 from the JPEG spec
+  predictorMode = input.getByte();
+  // The spec says predictoreMode is in [0..7], but Hasselblad uses '8'.
+  if (predictorMode > 8)
+    ThrowRDE("LJpegDecompressor::parseSOS: Invalid predictor mode.");
+
+  input.skipBytes(1);         // Se + Ah Not used in LJPEG
+  Pt = input.getByte() & 0xf; // Point Transform
+
+  decodeScan();
+}
+
+void AbstractLJpegDecompressor::parseDHT() {
+  uint32 headerLength = input.getShort() - 2; // Subtract myself
+
+  while (headerLength)  {
+    uint32 b = input.getByte();
+
+    uint32 htClass = b >> 4;
+    if (htClass != 0)
+      ThrowRDE("LJpegDecompressor::parseDHT: Unsupported Table class.");
+
+    uint32 htIndex = b & 0xf;
+    if (htIndex >= huff.size())
+      ThrowRDE("LJpegDecompressor::parseDHT: Invalid huffman table destination id.");
+
+    if (huff[htIndex] != nullptr)
+      ThrowRDE("LJpegDecompressor::parseDHT: Duplicate table definition");
+
+    auto ht = make_unique<HuffmanTable>();
+
+    // copy 16 bytes from input stream to number of codes per length table
+    uint32 nCodes = ht->setNCodesPerLength(input.getBuffer(16));
+    // spec says 16 different codes is max but Hasselblad violates that -> 17
+    if (nCodes > 17 || headerLength < 1 + 16 + nCodes)
+      ThrowRDE("LJpegDecompressor::parseDHT: Invalid DHT table.");
+
+    // copy nCodes bytes from input stream to code values table
+    ht->setCodeValues(input.getBuffer(nCodes));
+
+    // see if we already have a HuffmanTable with the same codes
+    for (const auto& i : huffmanTableStore)
+      if (*i == *ht)
+        huff[htIndex] = i.get();
+
+    if (!huff[htIndex]) {
+      // setup new ht and put it into the store
+      ht->setup(fullDecodeHT, fixDng16Bug);
+      huff[htIndex] = ht.get();
+      huffmanTableStore.emplace_back(std::move(ht));
+    }
+    headerLength -= 1 + 16 + nCodes;
+  }
+}
+
+JpegMarker AbstractLJpegDecompressor::getNextMarker(bool allowskip) {
+  uchar8 c0, c1 = input.getByte();
+  do {
+    c0 = c1;
+    c1 = input.getByte();
+  } while (allowskip && !(c0 == 0xFF && c1 != 0 && c1 != 0xFF));
+
+  if (!(c0 == 0xFF && c1 != 0 && c1 != 0xFF))
+    ThrowRDE("LJpegDecompressor::getNextMarker: (Noskip) Expected marker not found. Propably corrupt file.");
+
+  return (JpegMarker)c1;
+}
+
+} // namespace RawSpeed

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
@@ -1,0 +1,188 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2017 Axel Waggershauser
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "common/Common.h"              // for uint32
+#include "common/RawImage.h"            // for RawImage
+#include "decompressors/HuffmanTable.h" // IWYU pragma: keep
+#include "io/ByteStream.h"              // for ByteStream
+#include <array>                        // for array
+#include <memory>                       // for unique_ptr
+#include <utility>                      // for move
+#include <vector>                       // for vector
+
+/*
+ * The following enum and two structs are stolen from the IJG JPEG library
+ * Comments added by tm. See also Copyright in HuffmanTable.h.
+ */
+
+namespace RawSpeed {
+
+class ByteStream;
+
+enum JpegMarker { /* JPEG marker codes			*/
+  M_STUFF = 0x00,
+  M_SOF0  = 0xc0,	/* baseline DCT				*/
+  M_SOF1  = 0xc1,	/* extended sequential DCT		*/
+  M_SOF2  = 0xc2,	/* progressive DCT			*/
+  M_SOF3  = 0xc3,	/* lossless (sequential)		*/
+
+  M_SOF5  = 0xc5,	/* differential sequential DCT		*/
+  M_SOF6  = 0xc6,	/* differential progressive DCT		*/
+  M_SOF7  = 0xc7,	/* differential lossless		*/
+
+  M_JPG   = 0xc8,	/* JPEG extensions			*/
+  M_SOF9  = 0xc9,	/* extended sequential DCT		*/
+  M_SOF10 = 0xca,	/* progressive DCT			*/
+  M_SOF11 = 0xcb,	/* lossless (sequential)		*/
+
+  M_SOF13 = 0xcd,	/* differential sequential DCT		*/
+  M_SOF14 = 0xce,	/* differential progressive DCT		*/
+  M_SOF15 = 0xcf,	/* differential lossless		*/
+
+  M_DHT   = 0xc4,	/* define Huffman tables		*/
+
+  M_DAC   = 0xcc,	/* define arithmetic conditioning table	*/
+
+  M_RST0  = 0xd0,	/* restart				*/
+  M_RST1  = 0xd1,	/* restart				*/
+  M_RST2  = 0xd2,	/* restart				*/
+  M_RST3  = 0xd3,	/* restart				*/
+  M_RST4  = 0xd4,	/* restart				*/
+  M_RST5  = 0xd5,	/* restart				*/
+  M_RST6  = 0xd6,	/* restart				*/
+  M_RST7  = 0xd7,	/* restart				*/
+
+  M_SOI   = 0xd8,	/* start of image			*/
+  M_EOI   = 0xd9,	/* end of image				*/
+  M_SOS   = 0xda,	/* start of scan			*/
+  M_DQT   = 0xdb,	/* define quantization tables		*/
+  M_DNL   = 0xdc,	/* define number of lines		*/
+  M_DRI   = 0xdd,	/* define restart interval		*/
+  M_DHP   = 0xde,	/* define hierarchical progression	*/
+  M_EXP   = 0xdf,	/* expand reference image(s)		*/
+
+  M_APP0  = 0xe0,	/* application marker, used for JFIF	*/
+  M_APP1  = 0xe1,	/* application marker			*/
+  M_APP2  = 0xe2,	/* application marker			*/
+  M_APP3  = 0xe3,	/* application marker			*/
+  M_APP4  = 0xe4,	/* application marker			*/
+  M_APP5  = 0xe5,	/* application marker			*/
+  M_APP6  = 0xe6,	/* application marker			*/
+  M_APP7  = 0xe7,	/* application marker			*/
+  M_APP8  = 0xe8,	/* application marker			*/
+  M_APP9  = 0xe9,	/* application marker			*/
+  M_APP10 = 0xea,	/* application marker			*/
+  M_APP11 = 0xeb,	/* application marker			*/
+  M_APP12 = 0xec,	/* application marker			*/
+  M_APP13 = 0xed,	/* application marker			*/
+  M_APP14 = 0xee,	/* application marker, used by Adobe	*/
+  M_APP15 = 0xef,	/* application marker			*/
+
+  M_JPG0  = 0xf0,	/* reserved for JPEG extensions		*/
+  M_JPG13 = 0xfd,	/* reserved for JPEG extensions		*/
+  M_COM   = 0xfe,	/* comment				*/
+
+  M_TEM   = 0x01,	/* temporary use			*/
+  M_FILL  = 0xFF
+
+
+};
+
+/*
+* The following structure stores basic information about one component.
+*/
+struct JpegComponentInfo {
+  /*
+  * These values are fixed over the whole image.
+  * They are read from the SOF marker.
+  */
+  uint32 componentId = -1;		/* identifier for this component (0..255) */
+
+  /*
+  * Huffman table selector (0..3). The value may vary
+  * between scans. It is read from the SOS marker.
+  */
+  uint32 dcTblNo = -1;
+  uint32 superH = -1; // Horizontal Supersampling
+  uint32 superV = -1; // Vertical Supersampling
+};
+
+class SOFInfo {
+public:
+  JpegComponentInfo compInfo[4];
+  uint32 w = 0;    // Width
+  uint32 h = 0;    // Height
+  uint32 cps = 0;  // Components
+  uint32 prec = 0; // Precision
+  bool initialized = false;
+};
+
+class AbstractLJpegDecompressor
+{
+public:
+  AbstractLJpegDecompressor(const Buffer& data, Buffer::size_type offset,
+                            Buffer::size_type size, const RawImage& img)
+      : input(data, offset, size, getHostEndianness() == big), mRaw(img) {}
+  AbstractLJpegDecompressor(const Buffer& data, Buffer::size_type offset,
+                            const RawImage& img)
+      : AbstractLJpegDecompressor(data, offset, data.getSize() - offset, img) {}
+  virtual ~AbstractLJpegDecompressor() = default;
+
+protected:
+  bool fixDng16Bug = false;  // DNG v1.0.x compatibility
+  bool fullDecodeHT = true;  // FullDecode Huffman
+
+  void decode();
+  void parseSOF(SOFInfo* i);
+  void parseSOS();
+  void parseDHT();
+  JpegMarker getNextMarker(bool allowskip);
+
+  template <int N_COMP>
+  std::array<HuffmanTable*, N_COMP> getHuffmanTables() const {
+    std::array<HuffmanTable*, N_COMP> ht;
+    for (int i = 0; i < N_COMP; ++i)
+      ht[i] = huff[frame.compInfo[i].dcTblNo];
+    return ht;
+  }
+
+  template <int N_COMP>
+  std::array<ushort16, N_COMP> getInitialPredictors() const {
+    std::array<ushort16, N_COMP> pred;
+    pred.fill(1 << (frame.prec - Pt - 1));
+    return pred;
+  }
+
+  virtual void decodeScan() = 0;
+
+  ByteStream input;
+  RawImage mRaw;
+
+  SOFInfo frame;
+  uint32 predictorMode = 0;
+  uint32 Pt = 0;
+  std::array<HuffmanTable*, 4> huff{{}}; // 4 pointers into the store
+  std::vector<std::unique_ptr<HuffmanTable>> huffmanTableStore; // std::vector of unique HTs
+};
+
+} // namespace RawSpeed

--- a/src/librawspeed/decompressors/CMakeLists.txt
+++ b/src/librawspeed/decompressors/CMakeLists.txt
@@ -1,4 +1,8 @@
 FILE(GLOB DECOMPRESSOR_SOURCES
+  "AbstractLJpegDecompressor.cpp"
+  "AbstractLJpegDecompressor.h"
+  "Cr2Decompressor.cpp" # IWYU breaks
+  "Cr2Decompressor.h"
   "DeflateDecompressor.cpp"
   "DeflateDecompressor.h"
   "HasselbladDecompressor.cpp" # IWYU breaks
@@ -6,10 +10,8 @@ FILE(GLOB DECOMPRESSOR_SOURCES
   "HuffmanTable.h"
   "JpegDecompressor.cpp"
   "JpegDecompressor.h"
-  "LJpegDecompressor.cpp"
+  "LJpegDecompressor.cpp" # IWYU breaks
   "LJpegDecompressor.h"
-  "LJpegPlain.cpp" # IWYU breaks
-  "LJpegPlain.h"
   "NikonDecompressor.cpp"
   "NikonDecompressor.h"
   "PentaxDecompressor.cpp"

--- a/src/librawspeed/decompressors/Cr2Decompressor.h
+++ b/src/librawspeed/decompressors/Cr2Decompressor.h
@@ -1,7 +1,6 @@
 /*
     RawSpeed - RAW file decoder.
 
-    Copyright (C) 2009-2014 Klaus Post
     Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
@@ -27,13 +26,18 @@ namespace RawSpeed {
 
 // Decompresses Lossless JPEGs, with 2-4 components and optional X/Y subsampling
 
-class LJpegPlain final : public LJpegDecompressor
+class Cr2Decompressor final : public AbstractLJpegDecompressor
 {
+  // CR2 slices
+  std::vector<int> slicesWidths;
+
   void decodeScan() override;
   template<int N_COMP, int X_S_F, int Y_S_F> void decodeN_X_Y();
 
 public:
-  using LJpegDecompressor::LJpegDecompressor;
+  using AbstractLJpegDecompressor::AbstractLJpegDecompressor;
+
+  void decode(std::vector<int> slicesWidths);
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -74,4 +74,14 @@ void HasselbladDecompressor::decodeScan()
   input.skipBytes(bitStream.getBufferPosition());
 }
 
+void HasselbladDecompressor::decode(int pixelBaseOffset_)
+{
+  pixelBaseOffset = pixelBaseOffset_;
+  // We cannot use fully decoding huffman table,
+  // because values are packed two pixels at the time.
+  fullDecodeHT = false;
+
+  AbstractLJpegDecompressor::decode();
+}
+
 } // namespace RawSpeed

--- a/src/librawspeed/decompressors/HasselbladDecompressor.h
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.h
@@ -21,18 +21,20 @@
 
 #pragma once
 
-#include "decompressors/LJpegDecompressor.h"
+#include "decompressors/AbstractLJpegDecompressor.h"
 
 namespace RawSpeed {
 
-class HasselbladDecompressor final : public LJpegDecompressor
+class HasselbladDecompressor final : public AbstractLJpegDecompressor
 {
+  int pixelBaseOffset = 0;
+
   void decodeScan() override;
 
 public:
-  using LJpegDecompressor::LJpegDecompressor;
+  using AbstractLJpegDecompressor::AbstractLJpegDecompressor;
 
-  int pixelBaseOffset = 0;
+  void decode(int pixelBaseOffset_);
 };
 
 } // namespace RawSpeed

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -1,7 +1,6 @@
 /*
     RawSpeed - RAW file decoder.
 
-    Copyright (C) 2009-2014 Klaus Post
     Copyright (C) 2017 Axel Waggershauser
 
     This library is free software; you can redistribute it and/or
@@ -20,19 +19,15 @@
 */
 
 #include "decompressors/LJpegDecompressor.h"
-#include "common/Common.h"                // for uint32, getHostEndianness
-#include "common/Point.h"                 // for iPoint2D
-#include "decoders/RawDecoderException.h" // for ThrowRDE
-#include "decompressors/HuffmanTable.h"   // for HuffmanTable
-#include "io/ByteStream.h"                // for ByteStream
-#include "io/IOException.h"               // for IOException
-#include <array>                          // for array
-#include <memory>                         // for unique_ptr, allocator
-#include <vector>                         // for vector
+#include "common/Common.h"
+#include "io/BitPumpJPEG.h"
+#include "io/ByteStream.h"
+
+using namespace std;
 
 namespace RawSpeed {
 
-void LJpegDecompressor::decode(uint32 offsetX, uint32 offsetY) {
+void LJpegDecompressor::decode(uint32 offsetX, uint32 offsetY, bool fixDng16Bug_) {
   if ((int)offsetX >= mRaw->dim.x)
     ThrowRDE("LJpegDecompressor: X offset outside of image");
   if ((int)offsetY >= mRaw->dim.y)
@@ -40,151 +35,73 @@ void LJpegDecompressor::decode(uint32 offsetX, uint32 offsetY) {
   offX = offsetX;
   offY = offsetY;
 
-  if (getNextMarker(false) != M_SOI)
-    ThrowRDE("LJpegDecompressor: Image did not start with SOI. Probably not an LJPEG");
+  fixDng16Bug = fixDng16Bug_;
 
-  JpegMarker m;
-  do {
-    m = getNextMarker(true);
+  AbstractLJpegDecompressor::decode();
+}
 
-    switch (m) {
-    case M_DHT:  parseDHT(); break;
-    case M_SOF3: parseSOF(&frame); break;
-    case M_SOS:  parseSOS(); break;
-    case M_DQT:  ThrowRDE("LJpegDecompressor: Not a valid RAW file.");
-    default:  // Just let it skip to next marker
+void LJpegDecompressor::decodeScan()
+{
+  if (predictorMode != 1)
+    ThrowRDE("LJpegDecompressor: Unsupported predictor mode");
+
+  for (uint32 i = 0; i < frame.cps;  i++)
+    if (frame.compInfo[i].superH != 1 || frame.compInfo[i].superV != 1)
+      ThrowRDE("LJpegDecompressor: Unsupported subsampling");
+
+  if (frame.cps == 2)
+    decodeN<2>();
+  else if (frame.cps == 3)
+    decodeN<3>();
+  else if (frame.cps == 4)
+    decodeN<4>();
+  else
+    ThrowRDE("LJpegDecompressor: Unsupported number of components");
+}
+
+// N_COMP == number of components (2, 3 or 4)
+
+template <int N_COMP>
+void LJpegDecompressor::decodeN()
+{
+  auto ht = getHuffmanTables<N_COMP>();
+  auto pred = getInitialPredictors<N_COMP>();
+  auto predNext = pred.data();
+
+  BitPumpJPEG bitStream(input);
+
+  for (unsigned y = 0; y < frame.h; ++y) {
+    auto destY = offY + y;
+    // A recoded DNG might be split up into tiles of self contained LJpeg
+    // blobs. The tiles at the bottom and the right may extend beyond the
+    // dimension of the raw image buffer. The excessive content has to be
+    // ignored. For y, we can simply stop decoding when we reached the border.
+    if (destY >= (unsigned)mRaw->dim.y)
       break;
+
+    auto dest = (ushort16*)mRaw->getDataUncropped(offX, destY);
+
+    copy_n(predNext, N_COMP, pred.data());
+    // the predictor for the next line is the start of this line
+    predNext = dest;
+
+    unsigned width = min(frame.w,
+                         (mRaw->dim.x - offX) / (N_COMP / mRaw->getCpp()));
+
+    // For x, we first process all pixels within the image buffer ...
+    for (unsigned x = 0; x < width; ++x) {
+      unroll_loop<N_COMP>([&](int i) {
+        *dest++ = pred[i] += ht[i]->decodeNext(bitStream);
+      });
     }
-  } while (m != M_EOI);
-}
-
-void LJpegDecompressor::parseSOF(SOFInfo* sof) {
-  uint32 headerLength = input.getShort();
-  sof->prec = input.getByte();
-  sof->h = input.getShort();
-  sof->w = input.getShort();
-  sof->cps = input.getByte();
-
-  if (sof->prec > 16)
-    ThrowRDE("LJpegDecompressor: More than 16 bits per channel is not supported.");
-
-  if (sof->cps > 4 || sof->cps < 1)
-    ThrowRDE("LJpegDecompressor: Only from 1 to 4 components are supported.");
-
-  if (headerLength != 8 + sof->cps*3)
-    ThrowRDE("LJpegDecompressor: Header size mismatch.");
-
-  for (uint32 i = 0; i < sof->cps; i++) {
-    sof->compInfo[i].componentId = input.getByte();
-    uint32 subs = input.getByte();
-    frame.compInfo[i].superV = subs & 0xf;
-    frame.compInfo[i].superH = subs >> 4;
-    uint32 Tq = input.getByte();
-    if (Tq != 0)
-      ThrowRDE("LJpegDecompressor: Quantized components not supported.");
-  }
-  sof->initialized = true;
-
-  mRaw->metadata.subsampling.x = sof->compInfo[0].superH;
-  mRaw->metadata.subsampling.y = sof->compInfo[0].superV;
-}
-
-void LJpegDecompressor::parseSOS() {
-  if (!frame.initialized)
-    ThrowRDE("LJpegDecompressor::parseSOS: Frame not yet initialized (SOF Marker not parsed)");
-
-  uint32 headerLength = input.getShort();
-  if (headerLength != 3 + frame.cps * 2 + 3)
-    ThrowRDE("LJpegDecompressor::parseSOS: Invalid SOS header length.");
-
-  uint32 soscps = input.getByte();
-  if (frame.cps != soscps)
-    ThrowRDE("LJpegDecompressor::parseSOS: Component number mismatch.");
-
-  for (uint32 i = 0; i < frame.cps; i++) {
-    uint32 cs = input.getByte();
-    uint32 td = input.getByte() >> 4;
-
-    if (td > 3 || !huff[td])
-      ThrowRDE("LJpegDecompressor::parseSOS: Invalid Huffman table selection.");
-
-    int ciIndex = -1;
-    for (uint32 j = 0; j < frame.cps; ++j) {
-      if (frame.compInfo[j].componentId == cs)
-        ciIndex = j;
+    // ... and discard the rest.
+    for (unsigned x = width; x < frame.w; ++x) {
+      unroll_loop<N_COMP>([&](int i) {
+        ht[i]->decodeNext(bitStream);
+      });
     }
-
-    if (ciIndex == -1)
-        ThrowRDE("LJpegDecompressor::parseSOS: Invalid Component Selector");
-
-    frame.compInfo[ciIndex].dcTblNo = td;
   }
-
-  // Get predictor
-  predictorMode = input.getByte();
-  if (predictorMode > 8)
-    ThrowRDE("LJpegDecompressor::parseSOS: Invalid predictor mode.");
-
-  input.skipBytes(1);         // Se + Ah Not used in LJPEG
-  Pt = input.getByte() & 0xf; // Point Transform
-
-  decodeScan();
-}
-
-void LJpegDecompressor::parseDHT() {
-  uint32 headerLength = input.getShort() - 2; // Subtract myself
-
-  while (headerLength)  {
-    uint32 b = input.getByte();
-
-    uint32 htClass = b >> 4;
-    if (htClass != 0)
-      ThrowRDE("LJpegDecompressor::parseDHT: Unsupported Table class.");
-
-    uint32 htIndex = b & 0xf;
-    if (htIndex >= huff.size())
-      ThrowRDE("LJpegDecompressor::parseDHT: Invalid huffman table destination id.");
-
-    if (huff[htIndex] != nullptr)
-      ThrowRDE("LJpegDecompressor::parseDHT: Duplicate table definition");
-
-    auto ht = make_unique<HuffmanTable>();
-
-    // copy 16 bytes from input stream to number of codes per length table
-    uint32 nCodes = ht->setNCodesPerLength(input.getBuffer(16));
-    // spec says 16 different codes is max but Hasselblad violates that -> 17
-    if (nCodes > 17 || headerLength < 1 + 16 + nCodes)
-      ThrowRDE("LJpegDecompressor::parseDHT: Invalid DHT table.");
-
-    // copy nCodes bytes from input stream to code values table
-    ht->setCodeValues(input.getBuffer(nCodes));
-
-    // see if we already have a HuffmanTable with the same codes
-    for (const auto& i : huffmanTableStore)
-      if (*i == *ht)
-        huff[htIndex] = i.get();
-
-    if (!huff[htIndex]) {
-      // setup new ht and put it into the store
-      ht->setup(mFullDecodeHT, mDNGCompatible);
-      huff[htIndex] = ht.get();
-      huffmanTableStore.emplace_back(std::move(ht));
-    }
-    headerLength -= 1 + 16 + nCodes;
-  }
-}
-
-JpegMarker LJpegDecompressor::getNextMarker(bool allowskip) {
-  uchar8 c0, c1 = input.getByte();
-  do {
-    c0 = c1;
-    c1 = input.getByte();
-  } while (allowskip && !(c0 == 0xFF && c1 != 0 && c1 != 0xFF));
-
-  if (!(c0 == 0xFF && c1 != 0 && c1 != 0xFF))
-    ThrowRDE("LJpegDecompressor::getNextMarker: (Noskip) Expected marker not found. Propably corrupt file.");
-
-  return (JpegMarker)c1;
+  input.skipBytes(bitStream.getBufferPosition());
 }
 
 } // namespace RawSpeed

--- a/src/librawspeed/io/BitPumpJPEG.h
+++ b/src/librawspeed/io/BitPumpJPEG.h
@@ -41,7 +41,7 @@ template<> inline void BitPumpJPEG::fillCache() {
       data[pos+1] != 0xFF &&
       data[pos+2] != 0xFF &&
       data[pos+3] != 0xFF ) {
-    cache.push(loadMem<uint32>(data+pos, getHostEndianness() == little), 32);
+    cache.push(getBE<uint32>(data + pos), 32);
     pos += 4;
   } else {
     for (uint32 i = 0; i < nBytes; ++i) {

--- a/src/librawspeed/io/BitPumpMSB.h
+++ b/src/librawspeed/io/BitPumpMSB.h
@@ -34,7 +34,7 @@ using BitPumpMSB = BitStream<MSBBitPumpTag, BitStreamCacheRightInLeftOut>;
 template<> inline void BitPumpMSB::fillCache() {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "if the structure of the bit cache changed, this code has to be updated");
 
-  cache.push(loadMem<uint32>(data+pos, getHostEndianness() == little), 32);
+  cache.push(getBE<uint32>(data + pos), 32);
   pos += 4;
 }
 

--- a/src/librawspeed/io/BitPumpMSB16.h
+++ b/src/librawspeed/io/BitPumpMSB16.h
@@ -35,7 +35,7 @@ template<> inline void BitPumpMSB16::fillCache() {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "if the structure of the bit cache changed, this code has to be updated");
 
   for (int i = 0; i < 2; ++i) {
-    cache.push(loadMem<ushort16>(data+pos, getHostEndianness() == big), 16);
+    cache.push(getLE<ushort16>(data + pos), 16);
     pos += 2;
   }
 }

--- a/src/librawspeed/io/BitPumpMSB32.h
+++ b/src/librawspeed/io/BitPumpMSB32.h
@@ -34,7 +34,7 @@ using BitPumpMSB32 = BitStream<MSB32BitPumpTag, BitStreamCacheRightInLeftOut>;
 template<> inline void BitPumpMSB32::fillCache() {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "if the structure of the bit cache changed, this code has to be updated");
 
-  cache.push(loadMem<uint32>(data+pos, getHostEndianness() == big), 32);
+  cache.push(getLE<uint32>(data + pos), 32);
   pos += 4;
 }
 

--- a/src/librawspeed/io/BitPumpPlain.h
+++ b/src/librawspeed/io/BitPumpPlain.h
@@ -34,7 +34,7 @@ using BitPumpPlain = BitStream<PlainBitPumpTag, BitStreamCacheLeftInRightOut>;
 template<> inline void BitPumpPlain::fillCache() {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "if the structure of the bit cache changed, this code has to be updated");
 
-  cache.push(loadMem<uint32>(data+pos, getHostEndianness() == big), 32);
+  cache.push(getLE<uint32>(data + pos), 32);
   pos += 4;
 }
 

--- a/src/librawspeed/io/Buffer.h
+++ b/src/librawspeed/io/Buffer.h
@@ -88,7 +88,7 @@ public:
 
   // get memory of type T from byte offset 'offset + sizeof(T)*index' and swap byte order if required
   template<typename T> inline T get(bool inNativeByteOrder, size_type offset, size_type index = 0) const {
-    return loadMem<T>(getData(offset + index*(size_type)sizeof(T), (size_type)sizeof(T)), !inNativeByteOrder);
+    return getByteSwapped<T>(getData(offset + index*(size_type)sizeof(T), (size_type)sizeof(T)), !inNativeByteOrder);
   }
 
   inline size_type getSize() const {

--- a/src/librawspeed/parsers/FiffParser.cpp
+++ b/src/librawspeed/parsers/FiffParser.cpp
@@ -41,11 +41,11 @@ class RawDecoder;
 FiffParser::FiffParser(FileMap* inputData) : mInput(inputData) {}
 
 RawDecoder* FiffParser::getDecoder() {
-  const unsigned char* data = mInput->getData(0, 104);
+  const uchar8* data = mInput->getData(0, 104);
 
-  uint32 first_ifd = get4BE(data, 0x54) + 12;
-  uint32 second_ifd = get4BE(data, 0x64);
-  uint32 third_ifd = get4BE(data, 0x5C);
+  uint32 first_ifd = getU32BE(data + 0x54) + 12;
+  uint32 second_ifd = getU32BE(data + 0x64);
+  uint32 third_ifd = getU32BE(data + 0x5C);
 
   try {
     TiffRootIFDOwner rootIFD = parseTiff(mInput->getSubView(first_ifd));

--- a/src/librawspeed/parsers/TiffParser.cpp
+++ b/src/librawspeed/parsers/TiffParser.cpp
@@ -73,15 +73,14 @@ TiffRootIFDOwner parseTiff(const Buffer &data) {
   return root;
 }
 
-RawDecoder* makeDecoder(TiffRootIFDOwner _root, Buffer &data) {
-  TiffRootIFD* root = _root.release();
+RawDecoder* makeDecoder(TiffRootIFDOwner root, Buffer &data) {
   FileMap* mInput = &data;
   if (!root)
     throw TiffParserException("TiffIFD is null.");
 
   if (root->hasEntryRecursive(DNGVERSION)) {  // We have a dng image entry
     try {
-      return new DngDecoder(root, mInput);
+      return new DngDecoder(move(root), mInput);
     } catch (std::runtime_error& e) {
       //TODO: remove this exception type conversion
       throw TiffParserException(e.what());
@@ -97,54 +96,54 @@ RawDecoder* makeDecoder(TiffRootIFDOwner _root, Buffer &data) {
       TrimSpaces(model);
     }
     if (make == "Canon") {
-      return new Cr2Decoder(root, mInput);
+      return new Cr2Decoder(move(root), mInput);
     }
     if (make == "FUJIFILM") {
-      return new RafDecoder(root, mInput);
+      return new RafDecoder(move(root), mInput);
     }
     if (make == "NIKON CORPORATION" || make == "NIKON") {
-      return new NefDecoder(root, mInput);
+      return new NefDecoder(move(root), mInput);
     }
     if (make == "OLYMPUS IMAGING CORP." || make == "OLYMPUS CORPORATION" ||
         make == "OLYMPUS OPTICAL CO.,LTD") {
-      return new OrfDecoder(root, mInput);
+      return new OrfDecoder(move(root), mInput);
     }
     if (make == "SONY") {
-      return new ArwDecoder(root, mInput);
+      return new ArwDecoder(move(root), mInput);
     }
     if (make == "PENTAX Corporation" || make == "RICOH IMAGING COMPANY, LTD." ||
         make == "PENTAX") {
-      return new PefDecoder(root, mInput);
+      return new PefDecoder(move(root), mInput);
     }
     if (make == "Panasonic" || make == "LEICA") {
-      return new Rw2Decoder(root, mInput);
+      return new Rw2Decoder(move(root), mInput);
     }
     if (make == "SAMSUNG") {
-      return new SrwDecoder(root, mInput);
+      return new SrwDecoder(move(root), mInput);
     }
     if (make == "Mamiya-OP Co.,Ltd.") {
-      return new MefDecoder(root, mInput);
+      return new MefDecoder(move(root), mInput);
     }
     if (make == "Kodak") {
       if (model == "DCS560C")
-        return new Cr2Decoder(root, mInput);
+        return new Cr2Decoder(move(root), mInput);
 
-      return new DcrDecoder(root, mInput);
+      return new DcrDecoder(move(root), mInput);
     }
     if (make == "KODAK") {
-      return new DcsDecoder(root, mInput);
+      return new DcsDecoder(move(root), mInput);
     }
     if (make == "EASTMAN KODAK COMPANY") {
-      return new KdcDecoder(root, mInput);
+      return new KdcDecoder(move(root), mInput);
     }
     if (make == "SEIKO EPSON CORP.") {
-      return new ErfDecoder(root, mInput);
+      return new ErfDecoder(move(root), mInput);
     }
     if (make == "Hasselblad") {
-      return new ThreefrDecoder(root, mInput);
+      return new ThreefrDecoder(move(root), mInput);
     }
     if (make == "Leaf" || make == "Phase One A/S") {
-      return new MosDecoder(root, mInput);
+      return new MosDecoder(move(root), mInput);
     }
   }
 
@@ -154,11 +153,9 @@ RawDecoder* makeDecoder(TiffRootIFDOwner _root, Buffer &data) {
     string software = softwareIFD->getString();
     TrimSpaces(software);
     if (software == "Camera Library") {
-      return new MosDecoder(root, mInput);
+      return new MosDecoder(move(root), mInput);
     }
   }
-
-  delete root;
 
   throw TiffParserException("No decoder found. Sorry.");
   return nullptr;

--- a/src/librawspeed/tiff/CiffEntry.cpp
+++ b/src/librawspeed/tiff/CiffEntry.cpp
@@ -33,13 +33,13 @@ namespace RawSpeed {
 
 CiffEntry::CiffEntry(FileMap* f, uint32 value_data, uint32 offset) {
   own_data = nullptr;
-  ushort16 p = get2LE(f->getData(offset, 2), 0);
+  ushort16 p = getU16LE(f->getData(offset, 2));
   tag = (CiffTag) (p & 0x3fff);
   ushort16 datalocation = (p & 0xc000);
   type = (CiffDataType) (p & 0x3800);
   if (datalocation == 0x0000) { // Data is offset in value_data
-    bytesize = get4LE(f->getData(offset + 2, 4), 0);
-    data_offset = get4LE(f->getData(offset + 6, 4),0) + value_data;
+    bytesize = getU32LE(f->getData(offset + 2, 4));
+    data_offset = getU32LE(f->getData(offset + 6, 4)) + value_data;
     data = f->getDataWrt(data_offset, bytesize);
   } else if (datalocation == 0x4000) { // Data is stored directly in entry
     data_offset = offset + 2;
@@ -104,7 +104,7 @@ uint32 CiffEntry::getInt(uint32 num) {
   if (num*4+3 >= bytesize)
     ThrowCPE("CIFF, getInt: Trying to read out of bounds");
 
-  return get4LE(data, num*4);
+  return getU32LE(data + num * 4);
 }
 
 ushort16 CiffEntry::getShort(uint32 num) {
@@ -114,7 +114,7 @@ ushort16 CiffEntry::getShort(uint32 num) {
   if (num*2+1 >= bytesize)
     ThrowCPE("CIFF, getShort: Trying to read out of bounds");
 
-  return get2LE(data, num*2);
+  return getU16LE(data + num * 2);
 }
 
 uchar8 CiffEntry::getByte(uint32 num) {

--- a/src/librawspeed/tiff/CiffIFD.cpp
+++ b/src/librawspeed/tiff/CiffIFD.cpp
@@ -42,8 +42,8 @@ CiffIFD::CiffIFD(FileMap* f, uint32 start, uint32 end, uint32 _depth) {
   CIFF_DEPTH(_depth);
   mFile = f;
 
-  uint32 valuedata_size = get4LE(f->getData(end-4, 4), 0);
-  ushort16 dircount = get2LE(f->getData(start+valuedata_size, 2), 0);
+  uint32 valuedata_size = getU32LE(f->getData(end-4, 4));
+  ushort16 dircount = getU16LE(f->getData(start+valuedata_size, 2));
 
 //  fprintf(stderr, "Found %d entries between %d and %d after %d data bytes\n",
 //                  dircount, start, end, valuedata_size);

--- a/src/librawspeed/tiff/TiffIFD.cpp
+++ b/src/librawspeed/tiff/TiffIFD.cpp
@@ -253,5 +253,23 @@ TiffEntry* TiffIFD::getEntry(TiffTag tag) const {
   return i->second.get();
 }
 
+TiffID TiffRootIFD::getID() const
+{
+  TiffID id;
+  auto makeE = getEntryRecursive(MAKE);
+  auto modelE = getEntryRecursive(MODEL);
+
+  if (!makeE)
+    ThrowTPE("TiffIFD: Failed to find MAKE entry.");
+  if (!modelE)
+    ThrowTPE("TiffIFD: Failed to find MODEL entry.");
+
+  id.make = makeE->getString();
+  id.model = modelE->getString();
+  TrimSpaces(id.make);
+  TrimSpaces(id.model);
+
+  return id;
+}
 
 } // namespace RawSpeed

--- a/src/librawspeed/tiff/TiffIFD.h
+++ b/src/librawspeed/tiff/TiffIFD.h
@@ -80,6 +80,12 @@ public:
 //  const std::map<TiffTag, TiffEntry*>& getEntries() const { return entries; }
 };
 
+struct TiffID
+{
+  std::string make;
+  std::string model;
+};
+
 class TiffRootIFD : public TiffIFD
 {
 public:
@@ -87,6 +93,10 @@ public:
 
   TiffRootIFD(const DataBuffer &data, uint32 offset)
       : TiffIFD(data, offset, nullptr), rootBuffer(data) {}
+
+  // find the MAKE and MODEL tags identifying the camera
+  // note: the returned strings are trimmed automatically
+  TiffID getID() const;
 };
 
 inline bool isTiffInNativeByteOrder(const ByteStream& bs, uint32 pos, const char* context = "") {


### PR DESCRIPTION
1) Continuation of the cleanup of the TiffIFD object/memory handling, that I left off a few weeks back. 
1) Consolidate common code of the Tiff based decoders, introducing AbstractTiffDecoder
1) Splitting LJpegPlain code in two separate use cases: Cr2 and DNG

Details please see the individual commit messages.