### PR TITLE
Fix overlapping tiled ljpeg compressed dngs

### DIFF
--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -121,8 +121,8 @@ void LJpegDecompressor::parseSOS() {
   }
 
   // Get predictor
-  pred = input.getByte();
-  if (pred > 8)
+  predictorMode = input.getByte();
+  if (predictorMode > 8)
     ThrowRDE("LJpegDecompressor::parseSOS: Invalid predictor mode.");
 
   input.skipBytes(1);         // Se + Ah Not used in LJPEG

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -168,7 +168,7 @@ protected:
 
   SOFInfo frame;
   std::vector<int> slicesW;
-  uint32 pred = 0;
+  uint32 predictorMode = 0;
   uint32 Pt = 0;
   uint32 offX = 0, offY = 0;  // Offset into image where decoding should start
   std::array<HuffmanTable*, 4> huff {}; // 4 pointers into the store


### PR DESCRIPTION
Fix #63 and thereby splitting LJpegPlain in two separate classes dealing with almost completely different use cases. Details see individual commits.