### PR TITLE
Introduce Hints class to simplify related use cases

### DIFF
--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -74,7 +74,7 @@ RawImage ArwDecoder::decodeRawInternal() {
       return mRaw;
     }
 
-    if (hints.find("srf_format") != hints.end()) {
+    if (hints.has("srf_format")) {
       raw = mRootIFD->getIFDWithTag(IMAGEWIDTH);
 
       uint32 width = raw->getEntry(IMAGEWIDTH)->getU32();
@@ -223,7 +223,7 @@ void ArwDecoder::DecodeUncompressed(const TiffIFD* raw) {
 
   UncompressedDecompressor u(*mFile, off, c2, mRaw, uncorrectedRawValues);
 
-  if (hints.find("sr2_format") != hints.end())
+  if (hints.has("sr2_format"))
     u.decode14BitRawBEunpacked(width, height);
   else
     u.decode16BitRawUnpacked(width, height);

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -181,13 +181,8 @@ void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
     if (mRootIFD->hasEntryRecursive(CANONCOLORDATA)) {
       TiffEntry *wb = mRootIFD->getEntryRecursive(CANONCOLORDATA);
       // this entry is a big table, and different cameras store used WB in
-      // different parts, so find the offset, starting with the most common one
-      int offset = 126;
-
-      // replace it with a hint if it exists
-      if (hints.find("wb_offset") != hints.end()) {
-        offset = stoi(hints.find("wb_offset")->second);
-      }
+      // different parts, so find the offset, default is the most common one
+      int offset = hints.get("wb_offset", 126);
 
       offset /= 2;
       mRaw->metadata.wbCoeffs[0] = (float) wb->getU16(offset + 0);
@@ -224,14 +219,14 @@ void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
 }
 
 int Cr2Decoder::getHue() {
-  if (hints.find("old_sraw_hue") != hints.end())
+  if (hints.has("old_sraw_hue"))
     return (mRaw->metadata.subsampling.y * mRaw->metadata.subsampling.x);
 
   if (!mRootIFD->hasEntryRecursive((TiffTag)0x10)) {
     return 0;
   }
   uint32 model_id = mRootIFD->getEntryRecursive((TiffTag)0x10)->getU32();
-  if (model_id >= 0x80000281 || model_id == 0x80000218 || (hints.find("force_new_sraw_hue") != hints.end()))
+  if (model_id >= 0x80000281 || model_id == 0x80000218 || (hints.has("force_new_sraw_hue")))
     return ((mRaw->metadata.subsampling.y * mRaw->metadata.subsampling.x) - 1) >> 1;
 
   return (mRaw->metadata.subsampling.y * mRaw->metadata.subsampling.x);
@@ -440,11 +435,10 @@ inline void YUV_TO_RGB<2>(int Y, int Cb, int Cr, const int* sraw_coeffs,
 
 // Interpolate and convert sRaw data.
 void Cr2Decoder::sRawInterpolate() {
-  vector<const TiffIFD*> data = mRootIFD->getIFDsWithTag(CANONCOLORDATA);
-  if (data.empty())
+  TiffEntry* wb = mRootIFD->getEntryRecursive(CANONCOLORDATA);
+  if (!wb)
     ThrowRDE("CR2 sRaw: Unable to locate WB info.");
 
-  TiffEntry* wb = data[0]->getEntry(CANONCOLORDATA);
   // Offset to sRaw coefficients used to reconstruct uncorrected RGB data.
   uint32 offset = 78;
 
@@ -454,14 +448,14 @@ void Cr2Decoder::sRawInterpolate() {
       (wb->getU16(offset + 1) + wb->getU16(offset + 2) + 1) >> 1;
   sraw_coeffs[2] = wb->getU16(offset + 3);
 
-  if (hints.find("invert_sraw_wb") != hints.end()) {
+  if (hints.has("invert_sraw_wb")) {
     sraw_coeffs[0] = (int)(1024.0f / ((float)sraw_coeffs[0] / 1024.0f));
     sraw_coeffs[2] = (int)(1024.0f / ((float)sraw_coeffs[2] / 1024.0f));
   }
 
   /* Determine sRaw coefficients */
-  bool isOldSraw = hints.find("sraw_40d") != hints.end();
-  bool isNewSraw = hints.find("sraw_new") != hints.end();
+  bool isOldSraw = hints.has("sraw_40d");
+  bool isNewSraw = hints.has("sraw_new");
 
   const auto& subSampling = mRaw->metadata.subsampling;
   int width = mRaw->dim.x / subSampling.x;

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -86,7 +86,7 @@ RawImage CrwDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
 
-  bool lowbits = hints.find("no_decompressed_lowbits") == hints.end();
+  bool lowbits = ! hints.has("no_decompressed_lowbits");
   decodeRaw(lowbits, dec_table, width, height);
 
   return mRaw;
@@ -156,15 +156,10 @@ void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
         mRaw->metadata.wbCoeffs[2] = (float) (1024.0 /wb->getByte(75));
       } else if (wb->type == CIFF_BYTE && wb->count > 768) { // Other G series and S series cameras
         // correct offset for most cameras
-        int offset = 120;
-        // check for the hint that we need to use other offset
-        if (hints.find("wb_offset") != hints.end()) {
-          stringstream wb_offset(hints.find("wb_offset")->second);
-          wb_offset >> offset;
-        }
+        int offset = hints.get("wb_offset", 120);
 
         ushort16 key[] = { 0x410, 0x45f3 };
-        if (hints.find("wb_mangle") == hints.end())
+        if (! hints.has("wb_mangle"))
           key[0] = key[1] = 0;
 
         offset /= 2;

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -60,7 +60,7 @@ RawImage KdcDecoder::decodeRawInternal() {
   uint32 off = offset->getU32(4) + offset->getU32(12);
 
   // Offset hardcoding gotten from dcraw
-  if (hints.find("easyshare_offset_hack") != hints.end())
+  if (hints.has("easyshare_offset_hack"))
     off = off < 0x15000 ? 0x15000 : 0x17000;
 
   if (off > mFile->getSize())

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -125,7 +125,7 @@ void MrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   auto id = rootIFD->getID();
   setMetaData(meta, id.make, id.model, "", iso);
 
-  if (hints.find("swapped_wb") != hints.end()) {
+  if (hints.has("swapped_wb")) {
     mRaw->metadata.wbCoeffs[0] = (float) wb_coeffs[2];
     mRaw->metadata.wbCoeffs[1] = (float) wb_coeffs[0];
     mRaw->metadata.wbCoeffs[2] = (float) wb_coeffs[1];

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -64,7 +64,7 @@ RawImage NefDecoder::decodeRawInternal() {
     }
   }
 
-  if (compression == 1 || (hints.find(string("force_uncompressed")) != hints.end()) ||
+  if (compression == 1 || (hints.has("force_uncompressed")) ||
       NEFIsUncompressed(raw)) {
     DecodeUncompressed();
     return mRaw;
@@ -189,15 +189,9 @@ void NefDecoder::DecodeUncompressed() {
   if (bitPerPixel == 14 && width*slices[0].h*2 == slices[0].count)
     bitPerPixel = 16; // D3 & D810
 
-  if(hints.find("real_bpp") != hints.end()) {
-    stringstream convert(hints.find("real_bpp")->second);
-    convert >> bitPerPixel;
-  }
+  bitPerPixel = hints.get("real_bpp", bitPerPixel);
 
-  bool bitorder = true;
-  auto msb_hint = hints.find("msb_override");
-  if (msb_hint != hints.end())
-    bitorder = ("true" == (msb_hint->second));
+  bool bitorder = ! hints.has("msb_override");
 
   offY = 0;
   for (uint32 i = 0; i < slices.size(); i++) {
@@ -206,9 +200,9 @@ void NefDecoder::DecodeUncompressed() {
     iPoint2D size(width, slice.h);
     iPoint2D pos(0, offY);
     try {
-      if (hints.find(string("coolpixmangled")) != hints.end())
+      if (hints.has("coolpixmangled"))
         readCoolpixMangledRaw(in, size, pos, width*bitPerPixel / 8);
-      else if (hints.find(string("coolpixsplit")) != hints.end())
+      else if (hints.has("coolpixsplit"))
         readCoolpixSplitRaw(in, size, pos, width*bitPerPixel / 8);
       else {
         UncompressedDecompressor u(in, mRaw, uncorrectedRawValues);
@@ -504,7 +498,7 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     }
   }
 
-  if (hints.find(string("nikon_wb_adjustment")) != hints.end()) {
+  if (hints.has("nikon_wb_adjustment")) {
     mRaw->metadata.wbCoeffs[0] *= 256/527.0;
     mRaw->metadata.wbCoeffs[2] *= 256/317.0;
   }

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -77,7 +77,7 @@ RawImage OrfDecoder::decodeRawInternal() {
   input.setPosition(off);
 
   try {
-    if (offsets->count != 1 || (hints.find(string("force_uncompressed")) != hints.end()))
+    if (offsets->count != 1 || hints.has("force_uncompressed"))
       decodeUncompressed(input, width, height, size);
     else
       decodeCompressed(input, width, height);
@@ -90,9 +90,9 @@ RawImage OrfDecoder::decodeRawInternal() {
 
 void OrfDecoder::decodeUncompressed(ByteStream& s, uint32 w, uint32 h, uint32 size) {
   UncompressedDecompressor u(s, mRaw, uncorrectedRawValues);
-  if ((hints.find(string("packed_with_control")) != hints.end()))
+  if (hints.has("packed_with_control"))
     u.decode12BitRawWithControl(w, h);
-  else if ((hints.find(string("jpeg32_bitorder")) != hints.end())) {
+  else if (hints.has("jpeg32_bitorder")) {
     iPoint2D dimensions(w, h), pos(0, 0);
     u.readUncompressedRaw(dimensions, pos, w * 12 / 8, 12, BitOrder_Jpeg32);
   } else if (size >= w*h*2) { // We're in an unpacked raw

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -87,7 +87,7 @@ RawImage RafDecoder::decodeRawInternal() {
   // Some fuji SuperCCD cameras include a second raw image next to the first one
   // that is identical but darker to the first. The two combined can produce
   // a higher dynamic range image. Right now we're ignoring it.
-  bool double_width = hints.find("double_width_unpacked") != hints.end();
+  bool double_width = hints.has("double_width_unpacked");
 
   mRaw->dim = iPoint2D(width*(double_width ? 2 : 1), height);
   mRaw->createData();
@@ -105,7 +105,7 @@ RawImage RafDecoder::decodeRawInternal() {
   } else if (input.isInNativeByteOrder() == (getHostEndianness() == big)) {
     u.decode16BitRawBEunpacked(width, height);
   } else {
-    if (hints.find("jpeg32_bitorder") != hints.end()) {
+    if (hints.has("jpeg32_bitorder")) {
       u.readUncompressedRaw(mRaw->dim, pos, width * bps / 8, bps,
                             BitOrder_Jpeg32);
     } else {
@@ -144,7 +144,7 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if (applyCrop) {
     new_size = cam->cropSize;
     crop_offset = cam->cropPos;
-    bool double_width = hints.find("double_width_unpacked") != hints.end();
+    bool double_width = hints.has("double_width_unpacked");
     // If crop size is negative, use relative cropping
     if (new_size.x <= 0)
       new_size.x = mRaw->dim.x / (double_width ? 2 : 1) - cam->cropPos.x + new_size.x;
@@ -155,7 +155,7 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
       new_size.y = mRaw->dim.y - cam->cropPos.y + new_size.y;
   }
 
-  bool rotate = hints.find("fuji_rotate") != hints.end();
+  bool rotate = hints.has("fuji_rotate");
   rotate = rotate & fujiRotate;
 
   // Rotate 45 degrees - could be multithreaded.

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -25,6 +25,7 @@
 #include "common/RawImage.h"              // for RawImage
 #include "common/Threading.h"             // for pthread_t
 #include "io/FileMap.h"                   // for FileMap
+#include "metadata/Camera.h"              // for Hints
 #include <map>                            // for map
 #include <string>                         // for string
 
@@ -175,7 +176,7 @@ protected:
   virtual int getDecoderVersion() const = 0;
 
   /* Hints set for the camera after checkCameraSupported has been called from the implementation*/
-   std::map<std::string,std::string> hints;
+  Hints hints;
 };
 
 class RawSlice {

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -161,9 +161,7 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
   int w = mRaw->dim.x / 14;
   uint32 y;
 
-  bool zero_is_bad = true;
-  if (hints.find("zero_is_not_bad") != hints.end())
-    zero_is_bad = false;
+  bool zero_is_bad = ! hints.has("zero_is_not_bad");
 
   /* 9 + 1/7 bits per pixel */
   int skip = w * 14 * t->start_y * 9;

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -52,10 +52,7 @@ RawImage SrwDecoder::decodeRawInternal() {
 
   if (32769 == compression)
   {
-    bool bit_order = false;  // Default guess
-    auto msb_hint = hints.find("msb_override");
-    if (msb_hint != hints.end())
-      bit_order = ("true" == (msb_hint->second));
+    bool bit_order = hints.get("msb_override", false);
     this->decodeUncompressed(raw, bit_order ? BitOrder_Jpeg : BitOrder_Plain);
     return mRaw;
   }
@@ -63,10 +60,7 @@ RawImage SrwDecoder::decodeRawInternal() {
   if (32770 == compression)
   {
     if (!raw->hasEntry ((TiffTag)40976)) {
-      bool bit_order = (bits == 12);  // Default guess
-      auto msb_hint = hints.find("msb_override");
-      if (msb_hint != hints.end())
-        bit_order = ("true" == (msb_hint->second));
+      bool bit_order = hints.get("msb_override", bits == 12);
       this->decodeUncompressed(raw, bit_order ? BitOrder_Jpeg : BitOrder_Plain);
       return mRaw;
     }

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -49,10 +49,7 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   mRaw->createData();
 
   HasselbladDecompressor l(*mFile, off, mRaw);
-  int pixelBaseOffset = 0;
-  auto pixelOffsetHint = hints.find("pixelBaseOffset");
-  if (pixelOffsetHint != hints.end())
-    pixelBaseOffset = stoi(pixelOffsetHint->second);
+  int pixelBaseOffset = hints.get("pixelBaseOffset", 0);
 
   try {
     l.decode(pixelBaseOffset);

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -228,7 +228,7 @@ void Camera::parseHints(const xml_node &cur) {
 
     string value = c.attribute("value").as_string();
 
-    hints.insert({name, value});
+    hints.add(name, value);
   }
 }
 

--- a/src/librawspeed/metadata/Camera.h
+++ b/src/librawspeed/metadata/Camera.h
@@ -26,6 +26,7 @@
 #include "metadata/CameraSensorInfo.h" // for CameraSensorInfo
 #include "metadata/ColorFilterArray.h" // for ColorFilterArray
 #include <map>                         // for map
+#include <sstream>                     // for istringstream
 #include <string>                      // for string, basic_string, allocator
 #include <vector>                      // for vector
 
@@ -34,6 +35,32 @@ class xml_node;
 } // namespace pugi
 
 namespace RawSpeed {
+
+class Hints
+{
+  std::map<std::string, std::string> data;
+public:
+  void add(const std::string& key, const std::string& value)
+  {
+    data.insert({key, value});
+  }
+
+  bool has(const std::string& key) const
+  {
+    return data.find(key) != data.end();
+  }
+
+  template <typename T>
+  T get(const std::string& key, T defaultValue) const
+  {
+    auto hint = data.find(key);
+    if (hint != data.end() && !hint->second.empty()) {
+      std::istringstream iss(hint->second);
+      iss >> std::boolalpha >> defaultValue;
+    }
+    return defaultValue;
+  }
+};
 
 class Camera
 {
@@ -57,7 +84,7 @@ public:
   std::vector<BlackArea> blackAreas;
   std::vector<CameraSensorInfo> sensorInfo;
   int decoderVersion;
-  std::map<std::string,std::string> hints;
+  Hints hints;
 protected:
   void parseCFA(const pugi::xml_node &node);
   void parseCrop(const pugi::xml_node &node);

--- a/src/librawspeed/metadata/CameraMetaData.cpp
+++ b/src/librawspeed/metadata/CameraMetaData.cpp
@@ -123,11 +123,11 @@ bool CameraMetaData::addCamera( Camera* cam )
   cameras[id] = cam;
 
   if (string::npos != cam->mode.find("chdk")) {
-    auto filesize_hint = cam->hints.find("filesize");
-    if (filesize_hint == cam->hints.end() || filesize_hint->second.empty()) {
+    auto filesize_hint = cam->hints.get("filesize", string());
+    if (filesize_hint.empty()) {
       writeLog(DEBUG_PRIO_WARNING, "CameraMetaData: CHDK camera: %s %s, no \"filesize\" hint set!\n", cam->make.c_str(), cam->model.c_str());
     } else {
-      chdkCameras[stoi(filesize_hint->second)] = cam;
+      chdkCameras[stoi(filesize_hint)] = cam;
       // writeLog(DEBUG_PRIO_WARNING, "CHDK camera: %s %s size:%u\n", cam->make.c_str(), cam->model.c_str(), size);
     }
   }


### PR DESCRIPTION
There are two often repeated use cases related to accessing camera hints parsed from the xml file:

* detect if a hint is present
* get the 'value' of an (optionally) present hint and assign it

This adds a simple class `Hints` to reduce code duplication and provide a convenient access to the camera hints.