### PR TITLE
Panasonic DMC TZ61: add basic camera support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6603,6 +6603,76 @@
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="145" white="3956"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-TZ61">
+		<ID make="Panasonic" model="DMC-TZ61">Panasonic DMC-ZS40</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="145" white="3971"/>
+		<Aliases>
+			<Alias>DMC-ZS40</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-TZ61" mode="4:3">
+		<ID make="Panasonic" model="DMC-TZ61">Panasonic DMC-ZS40</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="146" white="3971"/>
+		<Aliases>
+			<Alias>DMC-ZS40</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-TZ61" mode="3:2">
+		<ID make="Panasonic" model="DMC-TZ61">Panasonic DMC-ZS40</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="146" white="3971"/>
+		<Aliases>
+			<Alias>DMC-ZS40</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-TZ61" mode="1:1">
+		<ID make="Panasonic" model="DMC-TZ61">Panasonic DMC-ZS40</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-6" height="0"/>
+		<Sensor black="146" white="3971"/>
+		<Aliases>
+			<Alias>DMC-ZS40</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-TZ61" mode="16:9">
+		<ID make="Panasonic" model="DMC-TZ61">Panasonic DMC-ZS40</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="146" white="3971"/>
+		<Aliases>
+			<Alias>DMC-ZS40</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ71">
 		<ID make="Panasonic" model="DMC-TZ71">Panasonic DMC-ZS50</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
see darktable #11508

also TZ60, TZ61 and ZS40 seems to be the same camera there
a differences in black and white points for TZ60 (already
in cameras.xml) and TZ61
http://www.camera-usermanual.com/manuals/panasonic/Panasonic_LUMIX_DMC-TZ60.pdf