### PR TITLE
Fujifilm X100F: add basic camera support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8494,6 +8494,19 @@
 		<Crop x="0" y="0" width="-64" height="0"/>
 		<Sensor black="257" white="4094"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="X100F">
+		<ID make="Fujifilm" model="X100F">Fujifilm X100F</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">RBGBRG</ColorRow>
+			<ColorRow y="1">GGRGGB</ColorRow>
+			<ColorRow y="2">GGBGGR</ColorRow>
+			<ColorRow y="3">BRGRBG</ColorRow>
+			<ColorRow y="4">GGBGGR</ColorRow>
+			<ColorRow y="5">GGRGGB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="1024" white="16383"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="X100S">
 		<ID make="Fujifilm" model="X100S">Fujifilm X100S</ID>
 		<CFA2 width="6" height="6">


### PR DESCRIPTION
see darktable #11525

Dngmeta reads wrong cfa patter, manually fixed,
commressed images can not be loaded.