### PR TITLE
cameras.xml: add Fujifilm X-T20 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8646,6 +8646,19 @@
 		<Crop x="4" y="0" width="-52" height="0"/>
 		<Sensor black="1024" white="16383"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="X-T20">
+		<ID make="Fujifilm" model="X-T20">Fujifilm X-T20</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">RBGBRG</ColorRow>
+			<ColorRow y="1">GGRGGB</ColorRow>
+			<ColorRow y="2">GGBGGR</ColorRow>
+			<ColorRow y="3">BRGRBG</ColorRow>
+			<ColorRow y="4">GGBGGR</ColorRow>
+			<ColorRow y="5">GGRGGB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="1024" white="16383"/>
+	</Camera>
 	<Camera make="KONICA MINOLTA" model="DYNAX 5D">
 		<ID make="Minolta" model="Dynax 5D">Konica Minolta Maxxum 5D</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Black level of 1024 is taken from DNG, rather than from RAF (which has 1022) to be consistent with other Fujifilm entries. Crop produces a 6034x4032 image, vs. 6032x4032 as stated in EXIF.

Companion to https://github.com/darktable-org/darktable/pull/1455.