### PR TITLE
Panasonic DMC-FZ330: add basic camera support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4383,6 +4383,29 @@
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="143" white="4095"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ330">
+		<ID make="Panasonic" model="DMC-FZ330">Panasonic DMC-FZ300</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="142" white="4095"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ330" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ330">Panasonic DMC-FZ300</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="142" white="4095"/>
+	</Camera>
+
 	<Camera make="Panasonic" model = "DMC-G1">
 		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
all modes (4:3, 1:1, 16:9, 3:2) have the same pixel count as 4:3

see darktable #11604