### PR TITLE
[RFC] Skeleton of Phase One Sensor Corrections

### DIFF
--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -127,10 +127,13 @@ RawImage IiqDecoder::decodeRawInternal() {
 
   uint32 width = 0;
   uint32 height = 0;
+  uint32 split_row = 0;
+  uint32 split_col = 0;
 
   Buffer raw_data;
   ByteStream block_offsets;
   ByteStream wb;
+  ByteStream correction_meta_data;
 
   for (uint32 entry = 0; entry < entries_count; entry++) {
     const uint32 tag = es.getU32();
@@ -151,12 +154,21 @@ RawImage IiqDecoder::decodeRawInternal() {
     case 0x10f:
       raw_data = bs.getSubView(data, len);
       break;
+    case 0x110:
+      correction_meta_data = bs.getSubStream(data);
+      break;
     case 0x21c:
       // they are not guaranteed to be sequential!
       block_offsets = bs.getSubStream(data, len);
       break;
     case 0x21d:
       black_level = data >> 2;
+      break;
+    case 0x222:
+      split_col = data;
+      break;
+    case 0x224:
+      split_row = data;
       break;
     default:
       // FIXME: is there a "block_sizes" entry?
@@ -187,6 +199,9 @@ RawImage IiqDecoder::decodeRawInternal() {
   mRaw->createData();
 
   DecodePhaseOneC(strips, width, height);
+  if (correction_meta_data.getSize() != 0) {
+    CorrectPhaseOneC(correction_meta_data, split_row, split_col);
+  }
 
   for (int i = 0; i < 3; i++)
     mRaw->metadata.wbCoeffs[i] = wb.getFloat();
@@ -240,6 +255,47 @@ void IiqDecoder::DecodePhaseOneC(const std::vector<IiqStrip>& strips,
                                  uint32 width, uint32 height) {
   for (const auto& strip : strips)
     DecodeStrip(strip, width, height);
+}
+
+void IiqDecoder::CorrectPhaseOneC(ByteStream meta_data, uint32 split_row,
+                                  uint32 split_col) {
+  ByteStream meta_data_base(meta_data.getSubStream(0));
+
+  meta_data.skipBytes(8);
+  const uint32 bytes_to_entries = meta_data.getU32();
+  meta_data.skipBytes(bytes_to_entries - 12);
+  const uint32 entries_count = meta_data.getU32();
+  meta_data.skipBytes(4);
+
+  // this is how much is to be read for all the entries
+  ByteStream entries(meta_data.getStream(16 * entries_count));
+
+  bool quadrant_multiplier_applied = false;
+
+  for (uint32 entry = 0; entry < entries_count; entry++) {
+    const uint32 tag = entries.getU32();
+    const uint32 len = entries.getU32();
+    const uint32 data = entries.getU32();
+
+    switch (tag) {
+    case 0x431:
+      if (!quadrant_multiplier_applied) {
+        CorrectQuadrantMultipliersCombined(
+            meta_data_base.getSubStream(data, len), split_row, split_col);
+      }
+      quadrant_multiplier_applied = true;
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+void IiqDecoder::CorrectQuadrantMultipliersCombined(ByteStream data,
+                                                    uint32 split_row,
+                                                    uint32 split_col) {
+  // TODO: Implementation
+
 }
 
 void IiqDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/IiqDecoder.h
+++ b/src/librawspeed/decoders/IiqDecoder.h
@@ -73,6 +73,10 @@ protected:
   uint32 black_level = 0;
   void DecodePhaseOneC(const std::vector<IiqStrip>& strips, uint32 width,
                        uint32 height);
+  void CorrectPhaseOneC(ByteStream meta_data, uint32 split_row,
+                        uint32 split_col);
+  void CorrectQuadrantMultipliersCombined(ByteStream data, uint32 split_row,
+                                          uint32 split_col);
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
I'd like to get dcraw's IIQ sensor corrections into RawSpeed, so I started working just on reading the data today.  I don't expect this to be accepted, I just wanted to show what I'm thinking of doing before I get too far and see if there's anything objectionable about the approach I'm taking or the file formatting.  I've never touched RawSpeed before, so apologies if I've made a bunch of mistakes

Commit Message Below:
----------------------------------------------
dcraw has a function called phase_one_correct, which applies some
corrections to the raw data based on metadata embedded in the RAW
file.  I would like to implement any of these that I can find RAW
files serving as examples for, as they can make a significant
difference on the output (the quadrant multipliers, in particular, can
cause visible seams to appear in the rendered image if not correctly
applied).  This commit just adds some code to read the extended
metadata, with the skeleton of a function for one particular type of
correction and room to add more.