### PR TITLE
Phase one correction

### DIFF
--- a/src/librawspeed/common/CMakeLists.txt
+++ b/src/librawspeed/common/CMakeLists.txt
@@ -17,6 +17,7 @@ FILE(GLOB SOURCES
   "RawImageDataFloat.cpp"
   "RawImageDataU16.cpp"
   "RawspeedException.h"
+  "Spline.h"
   "TableLookUp.cpp"
   "TableLookUp.h"
   "Threading.h"

--- a/src/librawspeed/common/Spline.h
+++ b/src/librawspeed/common/Spline.h
@@ -1,0 +1,95 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2017 Robert Bieber
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "common/Common.h" // for ushort16
+#include "common/Point.h"  // for iPoint2D
+#include <vector>          // for vector
+
+namespace rawspeed {
+
+class Spline final {
+public:
+  static std::vector<ushort16>
+  calculateCurve(const std::vector<iPoint2D>& control_points) {
+    const int num_coords = control_points.size();
+    const int num_segments = num_coords - 1;
+
+    // These are the constant factors for each segment of the curve.
+    // Each segment i will have the formula:
+    // f(x) = a[i] + b[i]*(x - x[i]) + c[i]*(x - x[i])^2 + d[i]*(x - x[i])^3
+    std::vector<double> a(num_coords);
+    std::vector<double> b(num_segments);
+    std::vector<double> c(num_coords);
+    std::vector<double> d(num_segments);
+
+    // Extra values used during computation
+    std::vector<double> h(num_segments);
+    std::vector<double> alpha(num_segments);
+    std::vector<double> l(num_coords);
+    std::vector<double> mu(num_coords);
+    std::vector<double> z(num_coords);
+
+    for (int i = 0; i < num_coords; i++)
+      a[i] = control_points[i].y;
+
+    for (int i = 0; i < num_segments; i++)
+      h[i] = control_points[i + 1].x - control_points[i].x;
+
+    for (int i = 1; i < num_segments; i++)
+      alpha[i] =
+          (3. / h[i]) * (a[i + 1] - a[i]) - (3. / h[i - 1]) * (a[i] - a[i - 1]);
+
+    l[0] = mu[0] = z[0] = 0;
+
+    for (int i = 1; i < num_segments; i++) {
+      l[i] = 2 * (control_points[i + 1].x - control_points[i - 1].x) -
+             (h[i - 1] * mu[i - 1]);
+      mu[i] = h[i] / l[i];
+      z[i] = (alpha[i] - h[i - 1] * z[i - 1]) / l[i];
+    }
+
+    l[num_segments] = 1;
+    z[num_segments] = c[num_segments] = 0;
+
+    for (int i = num_segments - 1; i >= 0; i--) {
+      c[i] = z[i] - mu[i] * c[i + 1];
+      b[i] = (a[i + 1] - a[i]) / h[i] - h[i] * (c[i + 1] + 2 * c[i]) / 3.;
+      d[i] = (c[i + 1] - c[i]) / (3. * h[i]);
+    }
+
+    std::vector<ushort16> curve(65536);
+
+    for (int i = 0; i < num_segments; i++) {
+      for (int x = control_points[i].x; x <= control_points[i + 1].x; x++) {
+        double diff = x - control_points[i].x;
+        double diff_2 = diff * diff;
+        double diff_3 = diff * diff * diff;
+
+        curve[x] = a[i] + b[i] * diff + c[i] * diff_2 + d[i] * diff_3;
+      }
+    }
+
+    return curve;
+  }
+};
+
+} // namespace rawspeed

--- a/src/librawspeed/decoders/IiqDecoder.h
+++ b/src/librawspeed/decoders/IiqDecoder.h
@@ -73,6 +73,10 @@ protected:
   uint32 black_level = 0;
   void DecodePhaseOneC(const std::vector<IiqStrip>& strips, uint32 width,
                        uint32 height);
+  void CorrectPhaseOneC(ByteStream meta_data, uint32 split_row,
+                        uint32 split_col);
+  void CorrectQuadrantMultipliersCombined(ByteStream data, uint32 split_row,
+                                          uint32 split_col);
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
This is a complete implementation of the combined quadrant correction for phase one RAW files.  Below I'm attaching before/after 100% crops of sky rendering before and after this patch.  I *think* this is ready to merge, but so far I've only tested it on Credo 40 files.  I'm out of time for tonight so I want to get this up for comments, but please don't merge it until I've gotten a chance to test it on all the available IIQ samples (I'll also add an IIQ-S sample for the Credo 40 tomorrow).

![comparison](https://user-images.githubusercontent.com/191601/33511935-53c0bf3c-d6f3-11e7-8577-e4059ee80878.png)
