### PR TITLE
Added install steps to the librawspeed CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,3 +15,16 @@ add_subdirectory(librawspeed)
 if(BUILD_TOOLS)
   add_subdirectory(utilities)
 endif()
+
+set(PRIVATE_LIBS "-lpthread -ljpeg -lz -lrawspeed")
+set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
+CONFIGURE_FILE("librawspeed.pc.in" "rawspeed.pc" @ONLY)
+
+install(TARGETS rawspeed DESTINATION lib)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/librawspeed" DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rawspeed.pc" DESTINATION lib/pkgconfig)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rawspeedconfig.h" DESTINATION lib/librawspeed)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/external/ThreadSafetyAnalysis.h" DESTINATION lib/librawspeed)
+
+

--- a/src/librawspeed.pc.in
+++ b/src/librawspeed.pc.in
@@ -1,0 +1,11 @@
+prefix=@DEST_DIR@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: librawspeed
+Description: A fast camera raw file decoder (https://github.com/darkroom-org/rawspeed).
+Version: 4.0-development
+
+Libs: -L${libdir} @PRIVATE_LIBS@
+Cflags: -I${includedir}/librawspeed -I${libdir}/librawspeed


### PR DESCRIPTION
Copies the .h files to <prefix>/include/librawspeed
Copies the lib to <prefix>/lib
Copies the rawspeedconfig.h and ThreadSafetyAnalysis.h files to
<prefix>/lib/librawspeed
Generates a pkgconfig file and copies to <prefix>/lib/pkgconfig

I've put a version string into the .pc file, but I don't really know what it should be, so very open to feedback on that. It might be worth putting a version string into the top-level CMakeLists.txt file that can be passed down where it is needed.

