### PR TITLE
Add k-1 II support.

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7519,6 +7519,17 @@
 		<Crop x="4" y="18" width="-10" height="-2"/>
 		<Sensor black="64" white="16316"/>
 	</Camera>
+	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-1 Mark II">
+		<ID make="Pentax" model="K-1 II">Pentax K-1 II</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="4" y="18" width="-10" height="-2"/>
+		<Sensor black="64" white="16316"/>
+	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-3">
 		<ID make="Pentax" model="K-3">Pentax K-3</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Hi, I juste received my Pentax K-1 II and am working on darktable support.

Since the sensor is strictly the same as the K-1 mark I, I don't think there should be any change in values? I've sent a first sample to raw.pixls.us