### PR TITLE
Improve comprehensibility of RW2 decoder/decompressor interaction

### DIFF
--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -96,11 +96,9 @@ RawImage Rw2Decoder::decodeRawInternal() {
       mRaw->createData();
       u.decode12BitRaw<Endianness::little, false, true>(width, height);
     } else {
-      // It's using the new .RW2 decoding method
-      load_flags = 0;
-      // It's using the new .RW2 decoding method
+      section_split_offset = 0;
       PanasonicDecompressor p(mRaw, ByteStream(mFile, offset),
-                              hints.has("zero_is_not_bad"), load_flags);
+                              hints.has("zero_is_not_bad"), section_split_offset);
       mRaw->createData();
       p.decompress();
     }
@@ -118,11 +116,9 @@ RawImage Rw2Decoder::decodeRawInternal() {
     if (!mFile->isValid(offset))
       ThrowRDE("Invalid image data offset, cannot decode.");
 
-    // It's using the new .RW2 decoding method
-    load_flags = 0x2008;
-    // It's using the new .RW2 decoding method
+    section_split_offset = 0x2008;
     PanasonicDecompressor p(mRaw, ByteStream(mFile, offset),
-                            hints.has("zero_is_not_bad"), load_flags);
+                            hints.has("zero_is_not_bad"), section_split_offset);
     mRaw->createData();
     p.decompress();
   }

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -51,7 +51,7 @@ protected:
 private:
   std::string guessMode();
   uint32 offset = 0;
-  uint32 load_flags = 0;
+  uint32 section_split_offset = 0;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/CMakeLists.txt
+++ b/src/librawspeed/decompressors/CMakeLists.txt
@@ -36,6 +36,8 @@ FILE(GLOB SOURCES
   "OlympusDecompressor.h"
   "PanasonicDecompressor.cpp"
   "PanasonicDecompressor.h"
+  "PanasonicDecompressorV5.cpp"
+  "PanasonicDecompressorV5.h"
   "PentaxDecompressor.cpp"
   "PentaxDecompressor.h"
   "SamsungV0Decompressor.cpp"

--- a/src/librawspeed/decompressors/PanasonicDecompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressor.cpp
@@ -37,9 +37,9 @@ namespace rawspeed {
 PanasonicDecompressor::PanasonicDecompressor(const RawImage& img,
                                              const ByteStream& input_,
                                              bool zero_is_not_bad,
-                                             uint32 load_flags_)
+                                             uint32 section_split_offset_)
     : AbstractParallelizedDecompressor(img), zero_is_bad(!zero_is_not_bad),
-      load_flags(load_flags_) {
+      section_split_offset(section_split_offset_) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != TYPE_USHORT16 ||
       mRaw->getBpp() != 2)
     ThrowRDE("Unexpected component count / data type");
@@ -60,19 +60,19 @@ PanasonicDecompressor::PanasonicDecompressor(const RawImage& img,
   // if (width > 5488 || height > 3912)
   //   ThrowRDE("Too large image size: (%u; %u)", width, height);
 
-  if (BufSize < load_flags)
-    ThrowRDE("Bad load_flags: %u, less than BufSize (%u)", load_flags, BufSize);
+  if (BufSize < section_split_offset)
+    ThrowRDE("Bad section_split_offset: %u, less than BufSize (%u)", section_split_offset, BufSize);
 
   // Naive count of bytes that given pixel count requires.
   // Do division first, because we know the remainder is always zero,
   // and the next multiplication won't overflow.
   assert(mRaw->dim.area() % 7ULL == 0ULL);
   const auto rawBytesNormal = (mRaw->dim.area() / 7ULL) * 8ULL;
-  // If load_flags is zero, than that size is the size we need to read.
+  // If section_split_offset is zero, then that we need to read the normal amount of bytes.
   // But if it is not, then we need to round up to multiple of BufSize, because
-  // of splitting&rotation of each BufSize's slice in half at load_flags bytes.
+  // of splitting&rotation of each BufSize's slice in half at section_split_offset bytes.
   const auto bufSize =
-      load_flags == 0 ? rawBytesNormal : roundUp(rawBytesNormal, BufSize);
+      section_split_offset == 0 ? rawBytesNormal : roundUp(rawBytesNormal, BufSize);
   input = input_.peekStream(bufSize);
 }
 
@@ -80,10 +80,10 @@ struct PanasonicDecompressor::PanaBitpump {
   ByteStream input;
   std::vector<uchar8> buf;
   int vbits = 0;
-  uint32 load_flags;
+  uint32 section_split_offset;
 
-  PanaBitpump(ByteStream input_, int load_flags_)
-      : input(std::move(input_)), load_flags(load_flags_) {
+  PanaBitpump(ByteStream input_, int section_split_offset_)
+      : input(std::move(input_)), section_split_offset(section_split_offset_) {
     // get one more byte, so the return statement of getBits does not have
     // to special case for accessing the last byte
     buf.resize(BufSize + 1UL);
@@ -98,15 +98,15 @@ struct PanasonicDecompressor::PanaBitpump {
 
   uint32 getBits(int nbits) {
     if (!vbits) {
-      /* On truncated files this routine will just return just for the truncated
+      /* On truncated files this routine will just return for the truncated
        * part of the file. Since there is no chance of affecting output buffer
        * size we allow the decoder to decode this
        */
-      assert(BufSize >= load_flags);
-      auto size = std::min(input.getRemainSize(), BufSize - load_flags);
-      memcpy(buf.data() + load_flags, input.getData(size), size);
+      assert(BufSize >= section_split_offset);
+      auto size = std::min(input.getRemainSize(), BufSize - section_split_offset);
+      memcpy(buf.data() + section_split_offset, input.getData(size), size);
 
-      size = std::min(input.getRemainSize(), load_flags);
+      size = std::min(input.getRemainSize(), section_split_offset);
       if (size != 0)
         memcpy(buf.data(), input.getData(size), size);
     }
@@ -118,7 +118,7 @@ struct PanasonicDecompressor::PanaBitpump {
 
 void PanasonicDecompressor::decompressThreaded(
     const RawDecompressorThread* t) const {
-  PanaBitpump bits(input, load_flags);
+  PanaBitpump bits(input, section_split_offset);
 
   /* 9 + 1/7 bits per pixel */
   bits.skipBytes(8 * mRaw->dim.x * t->start / 7);

--- a/src/librawspeed/decompressors/PanasonicDecompressor.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressor.h
@@ -38,16 +38,16 @@ class PanasonicDecompressor final : public AbstractParallelizedDecompressor {
   bool zero_is_bad;
 
   // The RW2 raw image buffer is split into sections of BufSize bytes.
-  // If load_flags is 0, then last section is not nessesairly full.
-  // If load_flags is not 0, then each section has two parts:
-  //     bytes: [0..load_flags-1][load_flags..BufSize-1]
+  // If section_split_offset is 0, then last section is not neccesarily full.
+  // If section_split_offset is not 0, then each section has two parts:
+  //     bytes: [0..section_split_offset-1][section_split_offset..BufSize-1]
   //     pixels: [a..b][0..a-1]
   //   I.e. these two parts need to be swapped around.
-  uint32 load_flags;
+  uint32 section_split_offset;
 
 public:
   PanasonicDecompressor(const RawImage& img, const ByteStream& input_,
-                        bool zero_is_not_bad, uint32 load_flags_);
+                        bool zero_is_not_bad, uint32 section_split_offset_);
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
@@ -1,0 +1,120 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+    Copyright (C) 2017 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "decompressors/PanasonicDecompressorV5.h"
+#include "common/Mutex.h"                 // for MutexLocker
+#include "common/Point.h"                 // for iPoint2D
+#include "common/RawImage.h"              // for RawImage, RawImageData
+#include "decoders/RawDecoderException.h" // for ThrowRDE
+#include <algorithm>                      // for min
+#include <array>                          // for array
+#include <cassert>                        // for assert
+#include <cstring>                        // for memcpy
+#include <utility>                        // for move
+#include <vector>                         // for vector
+
+namespace rawspeed {
+
+PanasonicDecompressorV5::PanasonicDecompressorV5(const RawImage& img,
+                                             const ByteStream& input_,
+                                             bool zero_is_not_bad,
+                                             uint32 bps_)
+    : AbstractParallelizedDecompressor(img), zero_is_bad(!zero_is_not_bad),
+      bps(bps_) {
+  if (mRaw->getCpp() != 1 || mRaw->getDataType() != TYPE_USHORT16 ||
+      mRaw->getBpp() != 2)
+    ThrowRDE("Unexpected component count / data type");
+
+  // FIXME sanity check sizes
+  // if (width > 5488 || height > 3912)
+  //   ThrowRDE("Too large image size: (%u; %u)", width, height);
+
+  const uint32 dataBlockSize = 16;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+
+  const auto rawBytesNormal = (mRaw->dim.area() * dataBlockSize) / encodedDataSize;
+
+  input = input_.peekStream(rawBytesNormal);
+}
+
+void PanasonicDecompressorV5::decompressThreaded(
+    const RawDecompressorThread* t) const {
+
+  const uint32 dataBlockSize = 16;
+
+  const auto raw_width = mRaw->dim.x;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+  //const uint32 blocksPerLine = mRaw->dim.x * encodedDataSize;
+  
+  ByteStream threadlocalInput(input);
+  threadlocalInput.skipBytes((t->start * dataBlockSize) / encodedDataSize);
+
+  std::vector<uint32> badPixelTracker; // for bad pixel management
+  for (uint32 y = t->start; y < t->end; y++) {
+
+    auto* dest = reinterpret_cast<ushort16*>(mRaw->getData(0, y));
+
+    for (auto col = 0; col < raw_width; col += encodedDataSize)
+    {
+      const uchar8* bytes = threadlocalInput.getData(dataBlockSize);
+      if (bps == 12)
+      {
+        *dest++ = ((bytes[1] & 0xF) << 8) + bytes[0];
+        *dest++ = 16 * bytes[2] + (bytes[1] >> 4);
+        *dest++ = ((bytes[4] & 0xF) << 8) + bytes[3];
+        *dest++ = 16 * bytes[5] + (bytes[4] >> 4);
+        *dest++ = ((bytes[7] & 0xF) << 8) + bytes[6];
+        *dest++ = 16 * bytes[8] + (bytes[7] >> 4);
+        *dest++ = ((bytes[10] & 0xF) << 8) + bytes[9];
+        *dest++ = 16 * bytes[11] + (bytes[10] >> 4);
+        *dest++ = ((bytes[13] & 0xF) << 8) + bytes[12];
+        *dest++ = 16 * bytes[14] + (bytes[13] >> 4);
+        
+        // FIXME zero_pos needs to be filled for bad pixels
+      }
+      else if (bps == 14)
+      {
+          /*
+          raw_block_data[col] = bytes[0] + ((bytes[1] & 0x3F) << 8);
+          raw_block_data[col + 1] = (bytes[1] >> 6) + 4 * (bytes[2]) +
+                                  ((bytes[3] & 0xF) << 10);
+          raw_block_data[col + 2] = (bytes[3] >> 4) + 16 * (bytes[4]) +
+                                  ((bytes[5] & 3) << 12);
+          raw_block_data[col + 3] = ((bytes[5] & 0xFC) >> 2) + (bytes[6] << 6);
+          raw_block_data[col + 4] = bytes[7] + ((bytes[8] & 0x3F) << 8);
+          raw_block_data[col + 5] = (bytes[8] >> 6) + 4 * bytes[9] + ((bytes[10] & 0xF) << 10);
+          raw_block_data[col + 6] = (bytes[10] >> 4) + 16 * bytes[11] + ((bytes[12] & 3) << 12);
+          raw_block_data[col + 7] = ((bytes[12] & 0xFC) >> 2) + (bytes[13] << 6);
+          raw_block_data[col + 8] = bytes[14] + ((bytes[15] & 0x3F) << 8);
+          */
+      }
+    }
+  }
+
+  if (zero_is_bad && !badPixelTracker.empty()) {
+    MutexLocker guard(&mRaw->mBadPixelMutex);
+    mRaw->mBadPixelPositions.insert(mRaw->mBadPixelPositions.end(),
+                                    badPixelTracker.begin(), badPixelTracker.end());
+  }
+}
+
+} // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -1,0 +1,47 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2017 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "common/Common.h"                                  // for uint32
+#include "decompressors/AbstractParallelizedDecompressor.h" // for Abstract...
+#include "io/ByteStream.h"                                  // for ByteStream
+
+namespace rawspeed {
+
+class RawImage;
+
+class PanasonicDecompressorV5 final : public AbstractParallelizedDecompressor {
+  static constexpr uint32 BufSize = 0x4000;
+  struct PanaBitpump;
+
+  void decompressThreaded(const RawDecompressorThread* t) const final;
+
+  ByteStream input;
+  bool zero_is_bad;
+
+  uint32 bps;
+
+public:
+  PanasonicDecompressorV5(const RawImage& img, const ByteStream& input_,
+                        bool zero_is_not_bad, uint32 bps_);
+};
+
+} // namespace rawspeed


### PR DESCRIPTION
Rename load_lags to section_split_offset to clarify what really happens - after all, load flags is _not_ a flag, but used only as an offset.

This does not introduce functional change. This is only meant to improve general maintainability.