### PR TITLE
DO NOT MERGE - Wip/rw2 g9 gh5s support

### DIFF
--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -118,26 +118,25 @@ RawImage Rw2Decoder::decodeRawInternal() {
     if (!mFile->isValid(offset))
       ThrowRDE("Invalid image data offset, cannot decode.");
 
-    const TiffTag PANASONIC_RAWFORMAT = static_cast<TiffTag>(0x2d);
+    static constexpr TiffTag PANASONIC_RAWFORMAT = static_cast<TiffTag>(0x2d);
     bool v5Processing = false;
     if (raw->hasEntry(PANASONIC_RAWFORMAT)) {
-      uint32 rawFormat = raw->getEntry(PANASONIC_RAWFORMAT)->getU16();
+      auto rawFormat = raw->getEntry(PANASONIC_RAWFORMAT)->getU16();
       if (rawFormat == 5) {
         v5Processing = true;
       }
     }
 
-    const TiffTag PANASONIC_BITSPERSAMPLE = static_cast<TiffTag>(0xa);
-    uint32 bitsPerSample = 12;
+    static constexpr TiffTag PANASONIC_BITSPERSAMPLE =
+        static_cast<TiffTag>(0xa);
+    rawspeed::ushort16 bitsPerSample = 12;
     if (raw->hasEntry(PANASONIC_BITSPERSAMPLE)) {
       bitsPerSample = raw->getEntry(PANASONIC_BITSPERSAMPLE)->getU16();
     }
 
     if (v5Processing) {
-      section_split_offset = 0x2008;
       PanasonicDecompressorV5 v5(mRaw, ByteStream(mFile, offset),
-                                 hints.has("zero_is_not_bad"),
-                                 section_split_offset, bitsPerSample);
+                                 hints.has("zero_is_not_bad"), bitsPerSample);
       mRaw->createData();
       v5.decompress();
     } else {

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -24,6 +24,7 @@
 #include "common/Point.h"                           // for iPoint2D
 #include "decoders/RawDecoderException.h"           // for ThrowRDE
 #include "decompressors/PanasonicDecompressor.h"    // for PanasonicDecompr...
+#include "decompressors/PanasonicDecompressorV5.h"  // for PanasonicDecompr...
 #include "decompressors/UncompressedDecompressor.h" // for UncompressedDeco...
 #include "io/Buffer.h"                              // for Buffer
 #include "io/ByteStream.h"                          // for ByteStream
@@ -96,11 +97,10 @@ RawImage Rw2Decoder::decodeRawInternal() {
       mRaw->createData();
       u.decode12BitRaw<Endianness::little, false, true>(width, height);
     } else {
-      // It's using the new .RW2 decoding method
-      load_flags = 0;
-      // It's using the new .RW2 decoding method
+      section_split_offset = 0;
       PanasonicDecompressor p(mRaw, ByteStream(mFile, offset),
-                              hints.has("zero_is_not_bad"), load_flags);
+                              hints.has("zero_is_not_bad"),
+                              section_split_offset);
       mRaw->createData();
       p.decompress();
     }
@@ -118,13 +118,36 @@ RawImage Rw2Decoder::decodeRawInternal() {
     if (!mFile->isValid(offset))
       ThrowRDE("Invalid image data offset, cannot decode.");
 
-    // It's using the new .RW2 decoding method
-    load_flags = 0x2008;
-    // It's using the new .RW2 decoding method
-    PanasonicDecompressor p(mRaw, ByteStream(mFile, offset),
-                            hints.has("zero_is_not_bad"), load_flags);
-    mRaw->createData();
-    p.decompress();
+    const TiffTag PANASONIC_RAWFORMAT = static_cast<TiffTag>(0x2d);
+    bool v5Processing = false;
+    if (raw->hasEntry(PANASONIC_RAWFORMAT)) {
+      uint32 rawFormat = raw->getEntry(PANASONIC_RAWFORMAT)->getU16();
+      if (rawFormat == 5) {
+        v5Processing = true;
+      }
+    }
+
+    const TiffTag PANASONIC_BITSPERSAMPLE = static_cast<TiffTag>(0xa);
+    uint32 bitsPerSample = 12;
+    if (raw->hasEntry(PANASONIC_BITSPERSAMPLE)) {
+      bitsPerSample = raw->getEntry(PANASONIC_BITSPERSAMPLE)->getU16();
+    }
+
+    if (v5Processing) {
+      section_split_offset = 0x2008;
+      PanasonicDecompressorV5 v5(mRaw, ByteStream(mFile, offset),
+                                 hints.has("zero_is_not_bad"),
+                                 section_split_offset, bitsPerSample);
+      mRaw->createData();
+      v5.decompress();
+    } else {
+      section_split_offset = 0x2008;
+      PanasonicDecompressor p(mRaw, ByteStream(mFile, offset),
+                              hints.has("zero_is_not_bad"),
+                              section_split_offset);
+      mRaw->createData();
+      p.decompress();
+    }
   }
 
   return mRaw;

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -51,7 +51,7 @@ protected:
 private:
   std::string guessMode();
   uint32 offset = 0;
-  uint32 load_flags = 0;
+  uint32 section_split_offset = 0;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/CMakeLists.txt
+++ b/src/librawspeed/decompressors/CMakeLists.txt
@@ -36,6 +36,8 @@ FILE(GLOB SOURCES
   "OlympusDecompressor.h"
   "PanasonicDecompressor.cpp"
   "PanasonicDecompressor.h"
+  "PanasonicDecompressorV5.cpp"
+  "PanasonicDecompressorV5.h"
   "PentaxDecompressor.cpp"
   "PentaxDecompressor.h"
   "SamsungV0Decompressor.cpp"

--- a/src/librawspeed/decompressors/PanasonicDecompressor.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressor.h
@@ -38,8 +38,8 @@ class PanasonicDecompressor final : public AbstractParallelizedDecompressor {
   bool zero_is_bad;
 
   // The RW2 raw image buffer is split into sections of BufSize bytes.
-  // If section_split_offset is 0, then last section is not neccesarily full.
-  // If section_split_offset is not 0, then each section has two parts:
+  // If section_split_offset is 0, then the last section is not neccesarily
+  // full. If section_split_offset is not 0, then each section has two parts:
   //     bytes: [0..section_split_offset-1][section_split_offset..BufSize-1]
   //     pixels: [a..b][0..a-1]
   //   I.e. these two parts need to be swapped around.

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
@@ -116,14 +116,12 @@ struct PanasonicDecompressorV5::DataPump {
   uchar8* readBlock() {
 
     if (!bufPosition) {
-      auto remainSize = input.getRemainSize();
-
-      auto section2size =
-          std::min(remainSize, SerializationBlockSize - section_split_offset);
+      auto section2size = std::min(
+          input.getRemainSize(), SerializationBlockSize - section_split_offset);
       memcpy(buf.data() + section_split_offset, input.getData(section2size),
              section2size);
 
-      auto section1size = std::min(remainSize, section_split_offset);
+      auto section1size = std::min(input.getRemainSize(), section_split_offset);
       if (section1size != 0)
         memcpy(buf.data(), input.getData(section1size), section1size);
     }

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
@@ -1,0 +1,120 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+    Copyright (C) 2017 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "decompressors/PanasonicDecompressorV5.h"
+#include "common/Mutex.h"                 // for MutexLocker
+#include "common/Point.h"                 // for iPoint2D
+#include "common/RawImage.h"              // for RawImage, RawImageData
+#include "decoders/RawDecoderException.h" // for ThrowRDE
+#include <algorithm>                      // for min
+#include <array>                          // for array
+#include <cassert>                        // for assert
+#include <cstring>                        // for memcpy
+#include <utility>                        // for move
+#include <vector>                         // for vector
+
+namespace rawspeed {
+
+PanasonicDecompressorV5::PanasonicDecompressorV5(const RawImage& img,
+                                             const ByteStream& input_,
+                                             bool zero_is_not_bad,
+                                             uint32 bps_)
+    : AbstractParallelizedDecompressor(img), zero_is_bad(!zero_is_not_bad),
+      bps(bps_) {
+  if (mRaw->getCpp() != 1 || mRaw->getDataType() != TYPE_USHORT16 ||
+      mRaw->getBpp() != 2)
+    ThrowRDE("Unexpected component count / data type");
+
+  // FIXME sanity check sizes
+  // if (width > 5488 || height > 3912)
+  //   ThrowRDE("Too large image size: (%u; %u)", width, height);
+
+  const uint32 dataBlockSize = 16;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+
+  const auto rawBytesNormal = (mRaw->dim.area() * dataBlockSize) / encodedDataSize;
+
+  input = input_.peekStream(rawBytesNormal);
+}
+
+void PanasonicDecompressorV5::decompressThreaded(
+    const RawDecompressorThread* t) const {
+
+  const uint32 dataBlockSize = 16;
+
+  const auto raw_width = mRaw->dim.x;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+  //const uint32 blocksPerLine = mRaw->dim.x * encodedDataSize;
+  
+  ByteStream threadlocalInput(input);
+  threadlocalInput.skipBytes((t->start * dataBlockSize) / encodedDataSize);
+
+  std::vector<uint32> badPixelTracker; // for bad pixel management
+  for (uint32 y = t->start; y < t->end; y++) {
+
+    auto* dest = reinterpret_cast<ushort16*>(mRaw->getData(0, y));
+
+    for (auto col = 0; col < raw_width; col += encodedDataSize)
+    {
+      const uchar8* bytes = threadlocalInput.getData(dataBlockSize);
+      if (bps == 12)
+      {
+        *dest++ = ((bytes[1] & 0xF) << 8) + bytes[0];
+        *dest++ = 16 * bytes[2] + (bytes[1] >> 4);
+        *dest++ = ((bytes[4] & 0xF) << 8) + bytes[3];
+        *dest++ = 16 * bytes[5] + (bytes[4] >> 4);
+        *dest++ = ((bytes[7] & 0xF) << 8) + bytes[6];
+        *dest++ = 16 * bytes[8] + (bytes[7] >> 4);
+        *dest++ = ((bytes[10] & 0xF) << 8) + bytes[9];
+        *dest++ = 16 * bytes[11] + (bytes[10] >> 4);
+        *dest++ = ((bytes[13] & 0xF) << 8) + bytes[12];
+        *dest++ = 16 * bytes[14] + (bytes[13] >> 4);
+        
+        // FIXME zero_pos needs to be filled for bad pixels
+      }
+      else if (bps == 14)
+      {
+          /*
+          raw_block_data[col] = bytes[0] + ((bytes[1] & 0x3F) << 8);
+          raw_block_data[col + 1] = (bytes[1] >> 6) + 4 * (bytes[2]) +
+                                  ((bytes[3] & 0xF) << 10);
+          raw_block_data[col + 2] = (bytes[3] >> 4) + 16 * (bytes[4]) +
+                                  ((bytes[5] & 3) << 12);
+          raw_block_data[col + 3] = ((bytes[5] & 0xFC) >> 2) + (bytes[6] << 6);
+          raw_block_data[col + 4] = bytes[7] + ((bytes[8] & 0x3F) << 8);
+          raw_block_data[col + 5] = (bytes[8] >> 6) + 4 * bytes[9] + ((bytes[10] & 0xF) << 10);
+          raw_block_data[col + 6] = (bytes[10] >> 4) + 16 * bytes[11] + ((bytes[12] & 3) << 12);
+          raw_block_data[col + 7] = ((bytes[12] & 0xFC) >> 2) + (bytes[13] << 6);
+          raw_block_data[col + 8] = bytes[14] + ((bytes[15] & 0x3F) << 8);
+          */
+      }
+    }
+  }
+
+  if (zero_is_bad && !badPixelTracker.empty()) {
+    MutexLocker guard(&mRaw->mBadPixelMutex);
+    mRaw->mBadPixelPositions.insert(mRaw->mBadPixelPositions.end(),
+                                    badPixelTracker.begin(), badPixelTracker.end());
+  }
+}
+
+} // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
@@ -1,0 +1,167 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+    Copyright (C) 2017 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "decompressors/PanasonicDecompressorV5.h"
+#include "common/Mutex.h"                 // for MutexLocker
+#include "common/Point.h"                 // for iPoint2D
+#include "common/RawImage.h"              // for RawImage, RawImageData
+#include "decoders/RawDecoderException.h" // for ThrowRDE
+#include <algorithm>                      // for min
+#include <array>                          // for array
+#include <cassert>                        // for assert
+#include <cstring>                        // for memcpy
+#include <utility>                        // for move
+#include <vector>                         // for vector
+
+namespace rawspeed {
+
+PanasonicDecompressorV5::PanasonicDecompressorV5(const RawImage& img,
+                                                 const ByteStream& input_,
+                                                 bool zero_is_not_bad,
+                                                 uint32 section_split_offset_,
+                                                 uint32 bps_)
+    : AbstractParallelizedDecompressor(img), zero_is_bad(!zero_is_not_bad),
+      section_split_offset(section_split_offset_), bps(bps_) {
+  if (mRaw->getCpp() != 1 || mRaw->getDataType() != TYPE_USHORT16 ||
+      mRaw->getBpp() != 2)
+    ThrowRDE("Unexpected component count / data type");
+
+  // FIXME sanity check sizes
+  // if (width > 5488 || height > 3912)
+  //   ThrowRDE("Too large image size: (%u; %u)", width, height);
+
+  if (SerializationBlockSize < section_split_offset)
+    ThrowRDE(
+        "Bad section_split_offset: %u, less than SerializationBlockSize (%u)",
+        section_split_offset, SerializationBlockSize);
+
+  const uint32 dataBlockSize = 16;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+
+  const auto rawBytesNormal =
+      (mRaw->dim.area() * dataBlockSize) / encodedDataSize;
+
+  input = input_.peekStream(rawBytesNormal);
+}
+
+struct PanasonicDecompressorV5::DataPump {
+  ByteStream input;
+  std::vector<uchar8> buf;
+  int bufPosition = 0;
+  uint32 section_split_offset;
+  const uint32 dataBlockSize = 16;
+
+  DataPump(ByteStream input_, int section_split_offset_)
+      : input(std::move(input_)), section_split_offset(section_split_offset_) {
+    // get one more byte, so the return statement of getBits does not have
+    // to special case for accessing the last byte
+    buf.resize(SerializationBlockSize + 1UL);
+  }
+
+  void skipBytes(int bytes) {
+    // FIXME assert that alignment matches
+    input.skipBytes(bytes);
+  }
+
+  uchar8* readBlock() {
+
+    if (!bufPosition) {
+      assert(SerializationBlockSize >= section_split_offset);
+      auto size = std::min(input.getRemainSize(),
+                           SerializationBlockSize - section_split_offset);
+      memcpy(buf.data() + section_split_offset, input.getData(size), size);
+
+      size = std::min(input.getRemainSize(), section_split_offset);
+      if (size != 0)
+        memcpy(buf.data(), input.getData(size), size);
+    }
+
+    uchar8* blockAddress = buf.data() + bufPosition;
+
+    bufPosition = bufPosition + dataBlockSize;
+    bufPosition &= SerializationBlockSizeMask;
+
+    return blockAddress;
+  }
+};
+
+void PanasonicDecompressorV5::decompressThreaded(
+    const RawDecompressorThread* t) const {
+
+  DataPump dataPump(input, section_split_offset);
+
+  const uint32 dataBlockSize = 16;
+
+  const auto raw_width = mRaw->dim.x;
+  const uint32 encodedDataSize = bps == 12 ? 10 : 9;
+  // const uint32 blocksPerLine = mRaw->dim.x * encodedDataSize;
+
+  dataPump.skipBytes((t->start * dataBlockSize) / encodedDataSize);
+
+  std::vector<uint32> badPixelTracker; // for bad pixel management
+  for (uint32 y = t->start; y < t->end; y++) {
+
+    auto* dest = reinterpret_cast<ushort16*>(mRaw->getData(0, y));
+
+    for (auto col = 0; col < raw_width; col += encodedDataSize) {
+      uchar8* bytes = dataPump.readBlock();
+      if (bps == 12) {
+        *dest++ = ((bytes[1] & 0xF) << 8) + bytes[0];
+        *dest++ = 16 * bytes[2] + (bytes[1] >> 4);
+        *dest++ = ((bytes[4] & 0xF) << 8) + bytes[3];
+        *dest++ = 16 * bytes[5] + (bytes[4] >> 4);
+        *dest++ = ((bytes[7] & 0xF) << 8) + bytes[6];
+        *dest++ = 16 * bytes[8] + (bytes[7] >> 4);
+        *dest++ = ((bytes[10] & 0xF) << 8) + bytes[9];
+        *dest++ = 16 * bytes[11] + (bytes[10] >> 4);
+        *dest++ = ((bytes[13] & 0xF) << 8) + bytes[12];
+        *dest++ = 16 * bytes[14] + (bytes[13] >> 4);
+
+        // FIXME zero_pos needs to be filled for bad pixels
+      } else if (bps == 14) {
+        /*
+        raw_block_data[col] = bytes[0] + ((bytes[1] & 0x3F) << 8);
+        raw_block_data[col + 1] = (bytes[1] >> 6) + 4 * (bytes[2]) +
+                                ((bytes[3] & 0xF) << 10);
+        raw_block_data[col + 2] = (bytes[3] >> 4) + 16 * (bytes[4]) +
+                                ((bytes[5] & 3) << 12);
+        raw_block_data[col + 3] = ((bytes[5] & 0xFC) >> 2) + (bytes[6] << 6);
+        raw_block_data[col + 4] = bytes[7] + ((bytes[8] & 0x3F) << 8);
+        raw_block_data[col + 5] = (bytes[8] >> 6) + 4 * bytes[9] + ((bytes[10] &
+        0xF) << 10); raw_block_data[col + 6] = (bytes[10] >> 4) + 16 * bytes[11]
+        + ((bytes[12] & 3) << 12); raw_block_data[col + 7] = ((bytes[12] & 0xFC)
+        >> 2) + (bytes[13] << 6); raw_block_data[col + 8] = bytes[14] +
+        ((bytes[15] & 0x3F) << 8);
+        */
+      }
+    }
+  }
+
+  if (zero_is_bad && !badPixelTracker.empty()) {
+    MutexLocker guard(&mRaw->mBadPixelMutex);
+    mRaw->mBadPixelPositions.insert(mRaw->mBadPixelPositions.end(),
+                                    badPixelTracker.begin(),
+                                    badPixelTracker.end());
+  }
+}
+
+} // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -1,0 +1,47 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2017 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "common/Common.h"                                  // for uint32
+#include "decompressors/AbstractParallelizedDecompressor.h" // for Abstract...
+#include "io/ByteStream.h"                                  // for ByteStream
+
+namespace rawspeed {
+
+class RawImage;
+
+class PanasonicDecompressorV5 final : public AbstractParallelizedDecompressor {
+  static constexpr uint32 BufSize = 0x4000;
+  struct PanaBitpump;
+
+  void decompressThreaded(const RawDecompressorThread* t) const final;
+
+  ByteStream input;
+  bool zero_is_bad;
+
+  uint32 bps;
+
+public:
+  PanasonicDecompressorV5(const RawImage& img, const ByteStream& input_,
+                        bool zero_is_not_bad, uint32 bps_);
+};
+
+} // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -28,9 +28,10 @@ namespace rawspeed {
 
 class RawImage;
 
-class PanasonicDecompressor final : public AbstractParallelizedDecompressor {
-  static constexpr uint32 BufSize = 0x4000;
-  struct PanaBitpump;
+class PanasonicDecompressorV5 final : public AbstractParallelizedDecompressor {
+  static constexpr uint32 SerializationBlockSize = 0x4000;
+  static constexpr uint32 SerializationBlockSizeMask = 0x3FFF;
+  struct DataPump;
 
   void decompressThreaded(const RawDecompressorThread* t) const final;
 
@@ -45,9 +46,12 @@ class PanasonicDecompressor final : public AbstractParallelizedDecompressor {
   //   I.e. these two parts need to be swapped around.
   uint32 section_split_offset;
 
+  uint32 bps;
+
 public:
-  PanasonicDecompressor(const RawImage& img, const ByteStream& input_,
-                        bool zero_is_not_bad, uint32 section_split_offset_);
+  PanasonicDecompressorV5(const RawImage& img, const ByteStream& input_,
+                          bool zero_is_not_bad, uint32 section_split_offset_,
+                          uint32 bps_);
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -30,23 +30,28 @@ class RawImage;
 
 class PanasonicDecompressorV5 final : public AbstractParallelizedDecompressor {
   static constexpr uint32 SerializationBlockSize = 0x4000;
-  static constexpr uint32 SerializationBlockSizeMask = 0x3FFF;
+  static constexpr uint32 SerializationBlockSizeMask =
+      0x3FFF; // == 0x4000 - 1, set all bits
+  static constexpr uint32 PixelDataBlockSize = 16;
+
   struct DataPump;
 
   void decompressThreaded(const RawDecompressorThread* t) const final;
 
   ByteStream input;
-  bool zero_is_bad;
+  const bool zero_is_bad;
 
   // The RW2 raw image buffer is split into sections of BufSize bytes.
-  // If section_split_offset is 0, then last section is not neccesarily full.
-  // If section_split_offset is not 0, then each section has two parts:
+  // If section_split_offset is 0, then the last section is not neccesarily
+  // full. If section_split_offset is not 0, then each section has two parts:
   //     bytes: [0..section_split_offset-1][section_split_offset..BufSize-1]
   //     pixels: [a..b][0..a-1]
   //   I.e. these two parts need to be swapped around.
-  uint32 section_split_offset;
+  const uint32 section_split_offset; // FIXME there is no point in passing this
+                                     // via a constructor; make private constant
 
-  uint32 bps;
+  const uint32 bps;
+  const uint32 encodedDataSize; // computed in constructor
 
 public:
   PanasonicDecompressorV5(const RawImage& img, const ByteStream& input_,


### PR DESCRIPTION
Working G9 / GH5s support, including multi-threading. Note: Under execution of a debugger, MT is 136 ms, and single-threaded 119 ms for one simple test case. Beyond that, no benchmarking.

Not cleaned up, lacking sanitization.

PR is only made to benefit from established CI in upstream.