### PR TITLE
Apply clang implicit integer truncation sanitizer

### DIFF
--- a/src/librawspeed/common/RawImageDataU16.cpp
+++ b/src/librawspeed/common/RawImageDataU16.cpp
@@ -488,7 +488,7 @@ void RawImageDataU16::doLookup( int start_y, int end_y )
           uint32 delta = lookup >> 16;
           v = 15700 *(v & 65535) + (v >> 16);
           uint32 pix = base + ((delta * (v & 2047) + 1024) >> 12);
-          *pixel = pix;
+          *pixel = clampBits(pix, 16);
           pixel++;
         }
       }

--- a/src/librawspeed/common/TableLookUp.cpp
+++ b/src/librawspeed/common/TableLookUp.cpp
@@ -59,7 +59,8 @@ void TableLookUp::setTable(int ntable, const std::vector<ushort16>& table) {
     int upper = i < (nfilled - 1) ? table[i + 1] : center;
     int delta = upper - lower;
     t[i * 2] = clampBits(center - ((upper - lower + 2) / 4), 16);
-    t[i * 2 + 1] = delta;
+    t[i * 2 + 1] = ushort16(delta);
+    // FIXME: this is completely broken when the curve is non-monotonic.
   }
 
   for (int i = nfilled; i < 65536; i++) {

--- a/src/librawspeed/common/TableLookUp.cpp
+++ b/src/librawspeed/common/TableLookUp.cpp
@@ -58,7 +58,7 @@ void TableLookUp::setTable(int ntable, const std::vector<ushort16>& table) {
     int lower = i > 0 ? table[i - 1] : center;
     int upper = i < (nfilled - 1) ? table[i + 1] : center;
     int delta = upper - lower;
-    t[i * 2] = center - ((upper - lower + 2) / 4);
+    t[i * 2] = clampBits(center - ((upper - lower + 2) / 4), 16);
     t[i * 2 + 1] = delta;
   }
 

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -371,7 +371,7 @@ void ArwDecoder::SonyDecrypt(const uint32* ibuf, uint32* obuf, uint32 len,
 
   // Initialize the decryption pad from the key
   for (int p=0; p < 4; p++)
-    pad[p] = key = key * 48828125UL + 1UL;
+    pad[p] = key = uint32(key * 48828125UL + 1UL);
   pad[3] = pad[3] << 1 | (pad[0]^pad[2]) >> 31;
   for (int p=4; p < 127; p++)
     pad[p] = (pad[p-4]^pad[p-2]) << 1 | (pad[p-3]^pad[p-1]) >> 31;

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -506,8 +506,13 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
       mRaw->sixteenBitLookup();
   }
 
- // Default white level is (2 ** BitsPerSample) - 1
-  mRaw->whitePoint = (1UL << bps) - 1UL;
+  if (mRaw->getDataType() == TYPE_USHORT16) {
+    // Default white level is (2 ** BitsPerSample) - 1
+    mRaw->whitePoint = (1UL << bps) - 1UL;
+  } else if (mRaw->getDataType() == TYPE_FLOAT32) {
+    // Default white level is 1.0f. But we can't represent that here.
+    mRaw->whitePoint = 65535;
+  }
 
   if (raw->hasEntry(WHITELEVEL)) {
     TiffEntry *whitelevel = raw->getEntry(WHITELEVEL);

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -253,9 +253,12 @@ void IiqDecoder::DecodeStrip(const IiqStrip& strip, uint32 width,
     int i = len[col & 1];
     if (i == 14)
       img[col] = pred[col & 1] = pump.getBits(16);
-    else
-      img[col] = pred[col & 1] +=
+    else {
+      pred[col & 1] +=
           static_cast<signed>(pump.getBits(i)) + 1 - (1 << (i - 1));
+      // FIXME: is the truncation the right solution here?
+      img[col] = ushort16(pred[col & 1]);
+    }
   }
 }
 

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -82,8 +82,10 @@ void HasselbladDecompressor::decodeScan() {
       int len2 = ht[0]->decodeLength(bitStream);
       p1 += getBits(&bitStream, len1);
       p2 += getBits(&bitStream, len2);
-      dest[x] = p1;
-      dest[x+1] = p2;
+      // NOTE: this is rather unusual and weird, but appears to be correct.
+      // clampBits(p, 16) results in completely garbled images.
+      dest[x] = ushort16(p1);
+      dest[x + 1] = ushort16(p2);
     }
   }
   input.skipBytes(bitStream.getBufferPosition());

--- a/src/librawspeed/decompressors/KodakDecompressor.cpp
+++ b/src/librawspeed/decompressors/KodakDecompressor.cpp
@@ -101,7 +101,8 @@ KodakDecompressor::decodeSegment(const uint32 bsize) {
     bits -= len;
     diff = len != 0 ? HuffmanTable::signExtended(diff, len) : diff;
 
-    out[i] = diff;
+    // FIXME: this looks strange. I suspect we are doing it backwards.
+    out[i] = ushort16(diff);
   }
 
   return out;
@@ -120,13 +121,15 @@ void KodakDecompressor::decompress() {
 
       const segment buf = decodeSegment(len);
 
+      // FIXME: unsigned predictor?!
       std::array<uint32, 2> pred;
       pred.fill(0);
 
       for (uint32 i = 0; i < len; i++) {
         pred[i & 1] += buf[i];
 
-        ushort16 value = pred[i & 1];
+        // FIXME: as with decodeSegment(), something is probably really wrong.
+        auto value = ushort16(pred[i & 1]);
         if (value >= (1U << bps))
           ThrowRDE("Value out of bounds %d (bps = %i)", value, bps);
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -145,7 +145,7 @@ void OlympusDecompressor::decompress(ByteStream input) const {
             nw[c] = pred;
           }
         }
-        dest[x] = pred + ((diff * 4) | low);
+        dest[x] = ushort16(pred + ((diff * 4) | low));
         // Set predictor
         left[c] = dest[x];
       } else {
@@ -165,7 +165,7 @@ void OlympusDecompressor::decompress(ByteStream input) const {
         } else
           pred = std::abs(leftMinusNw) > std::abs(upMinusNw) ? left[c] : up;
 
-        dest[x] = pred + ((diff * 4) | low);
+        dest[x] = ushort16(pred + ((diff * 4) | low));
         // Set predictors
         left[c] = dest[x];
         nw[c] = up;
@@ -207,7 +207,7 @@ void OlympusDecompressor::decompress(ByteStream input) const {
             nw[c] = pred;
           }
         }
-        dest[x] = left[c] = pred + ((diff * 4) | low);
+        dest[x] = left[c] = ushort16(pred + ((diff * 4) | low));
       } else {
         int up = dest[-pitch + (static_cast<int>(x))];
         int leftMinusNw = left[c] - nw[c];
@@ -223,7 +223,7 @@ void OlympusDecompressor::decompress(ByteStream input) const {
         } else
           pred = std::abs(leftMinusNw) > std::abs(upMinusNw) ? left[c] : up;
 
-        dest[x] = left[c] = pred + ((diff * 4) | low);
+        dest[x] = left[c] = ushort16(pred + ((diff * 4) | low));
         nw[c] = up;
       }
       border = y_border;

--- a/src/utilities/rstest/md5.cpp
+++ b/src/utilities/rstest/md5.cpp
@@ -58,8 +58,8 @@ static void md5_compress(md5_state* state, const uint8_t block[64]) {
 
   auto ROUND_TAIL = [ROTL32, &schedule](uint32_t& a, uint32_t b, uint32_t expr,
                                         uint32_t k, uint32_t s, uint32_t t) {
-    a = 0UL + a + expr + t + schedule[k];
-    (a) = 0UL + b + ROTL32(a, s);
+    a = uint32_t(0UL + a + expr + t + schedule[k]);
+    (a) = uint32_t(0UL + b + ROTL32(a, s));
   };
 
   auto ROUND0 = [ROUND_TAIL](uint32_t& a, uint32_t b, uint32_t c, uint32_t d,
@@ -152,10 +152,10 @@ static void md5_compress(md5_state* state, const uint8_t block[64]) {
   ROUND3(c, d, a, b, 2, 15, 0x2AD7D2BB);
   ROUND3(b, c, d, a, 9, 21, 0xEB86D391);
 
-  (*state)[0] = 0UL + (*state)[0] + a;
-  (*state)[1] = 0UL + (*state)[1] + b;
-  (*state)[2] = 0UL + (*state)[2] + c;
-  (*state)[3] = 0UL + (*state)[3] + d;
+  (*state)[0] = uint32_t(0UL + (*state)[0] + a);
+  (*state)[1] = uint32_t(0UL + (*state)[1] + b);
+  (*state)[2] = uint32_t(0UL + (*state)[2] + c);
+  (*state)[3] = uint32_t(0UL + (*state)[3] + d);
 }
 
 /* Full message hasher */

--- a/test/librawspeed/common/CommonTest.cpp
+++ b/test/librawspeed/common/CommonTest.cpp
@@ -434,7 +434,7 @@ protected:
     dst.resize((size_t)dstPitch * height);
 
     fill(src.begin(), src.end(), 0);
-    fill(dst.begin(), dst.end(), -1);
+    fill(dst.begin(), dst.end(), static_cast<decltype(dst)::value_type>(-1));
   }
   void generate() {
     uchar8 v = 0;

--- a/test/librawspeed/common/CommonTest.cpp
+++ b/test/librawspeed/common/CommonTest.cpp
@@ -276,7 +276,14 @@ INSTANTIATE_TEST_CASE_P(ClampBitsTest, ClampBitsTest,
 TEST_P(ClampBitsTest, ClampBitsTest) { ASSERT_EQ(clampBits(in, n), expected); }
 TEST(ClampBitsDeathTest, Only16Bit) {
 #ifndef NDEBUG
-  ASSERT_DEATH({ ASSERT_EQ(clampBits(0, 17), 0); }, "n <= 16");
+  ASSERT_DEATH({ ASSERT_EQ(clampBits(0, 17), 0); }, "nBits <= 16");
+#endif
+}
+
+TEST(ClampBitsUnsignedDeathTest, NoNopClamps) {
+#ifndef NDEBUG
+  ASSERT_DEATH({ ASSERT_EQ(clampBits<ushort16>(0, 16), 0); },
+               "BitWidthOfT > nBits");
 #endif
 }
 


### PR DESCRIPTION
Just so i don't break the build yet again..

This fixes all the integer truncation issues that are trigger-able by the current [RPU](https://raw.pixls.us/) sample set.
This case of issues is now detectable via clang's `-fsanitize=implicit-integer-truncation` sanitizer,
as implemented in https://reviews.llvm.org/D48958

Not all the fixes ended up being straight-forward. There are four remaining issues to be resolved:
* LookUpTable is just completely broken, and needs a full rewrite from scratch (https://github.com/darktable-org/rawspeed/commit/4ebeddc4a2562846be48c7a6adbf552887bd8fc9)
* KodakDecompressor is doing something very strange with predictor (https://github.com/darktable-org/rawspeed/commit/17699af765a557e5abec083772eed5512a96340c).
  Maybe a bug, maybe super weird, but intentional, like in the Hasselblad's case (https://github.com/darktable-org/rawspeed/commit/5e13cd93b4bff12ce2b973a09edee300c08ac931).
* Similarly, OlympusDecompressor looks super weird (https://github.com/darktable-org/rawspeed/commit/69ccfe6095bf9d854526a09358a964da9e8b40f3).
* IiqDecoder also truncates predictor (https://github.com/darktable-org/rawspeed/commit/865c5e4682ef58c28c2aa28c32352ae1d4a08ffd). But `clampBits()` does not change the decoded image.. 

This does affect the decoding of raws:
```
WARNING: the following 5 tests have failed:
./Kodak/DCS460D/RAW_KODAK_DCS460D_FILEVERSION_3.TIF failed: hash/metadata mismatch
./Kodak/EOS DCS 1/RAW_CANON_DCS1.TIF failed: hash/metadata mismatch
./Kodak/EOS DCS 3/DCS00240.TIF failed: hash/metadata mismatch
./Olympus/E-M5 Mark II/M0082437.ORF failed: hash/metadata mismatch
./Olympus/SH-2/PC260009.ORF failed: hash/metadata mismatch
```
The last two, Olympus raws are completely broken/unsupported anyway (some unsupported compression scheme, it seems). The Kodak's are most likely affected because of the LookUpTable issue[s].

I've filed issues to not forget about these findings:
- [ ] https://github.com/darktable-org/rawspeed/issues/139
- [ ] https://github.com/darktable-org/rawspeed/issues/140
- [x] https://github.com/darktable-org/rawspeed/issues/141
- [ ] https://github.com/darktable-org/rawspeed/issues/142
- [x] https://github.com/darktable-org/rawspeed/issues/143
