### PR TITLE
CMake: correctly detect OpenMP on macOS with Xcode 10 compiler

### DIFF
--- a/cmake/src-dependencies.cmake
+++ b/cmake/src-dependencies.cmake
@@ -46,13 +46,17 @@ if(WITH_OPENMP)
     message(STATUS "Looking for OpenMP - found")
     set(HAVE_OPENMP 1)
 
-    if(NOT TARGET OpenMP::OpenMP)
-      add_library(OpenMP::OpenMP INTERFACE IMPORTED)
-      set_property(TARGET OpenMP::OpenMP PROPERTY INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}")
-      set_property(TARGET OpenMP::OpenMP PROPERTY INTERFACE_LINK_LIBRARIES "${OpenMP_CXX_FLAGS}")
+    if(NOT TARGET OpenMP::OpenMP_CXX)
+      add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
+      if(OpenMP_CXX_FLAGS)
+        set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+      endif()
+      if(OpenMP_CXX_LIBRARIES)
+        set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_LIBRARIES})
+      endif()
     endif()
 
-    target_link_libraries(rawspeed PUBLIC OpenMP::OpenMP)
+    target_link_libraries(rawspeed PUBLIC OpenMP::OpenMP_CXX)
     set_package_properties(OpenMP PROPERTIES
                            TYPE RECOMMENDED
                            URL https://www.openmp.org/


### PR DESCRIPTION
It's now possible to use OpenMP with Xcode without the need to use gcc as compiler. One need to install libomp, pass -Xclang -fopenmp flags to compiler and link against libomp. This commit changes cmake openmp target name from OpenMP::OpenMP to OpenMP::OpenMP_CXX so that it matches upstream name from FindOpenMP.cmake. This way correct settings from that module are used. I also copied more correct version of setting up OpenMP target from upstream cmake module for older cmake versions. Original version uses separate_arguments function with NATIVE_COMMAND option, which we can't use because it's unavailable in cmake-3.4. separate_arguments is indeed required for macOS OpenMP support, because without it -Xclang -fopenmp flags are treated as one and passed to compiler quoted: "-Xclang -fopenmp". Since this commit makes sure we use values set in FindOpenMP.cmake module it doesn't matter much that we're missing separate_arguments call. Or we can add it with UNIX_COMMAND option which is available in cmake-3.4.
