### PR TITLE
CMake: allow enabling LTO on macOS

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -71,6 +71,9 @@ if(RAWSPEED_ENABLE_LTO)
     include(gcc-toolchain)
     set(lto_compile "-flto")
     set(lto_link "-flto")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(lto_compile "-flto=thin -fstrict-vtable-pointers")
+    set(lto_link "-flto=thin")
   endif()
 
   set(CMAKE_C_FLAGS


### PR DESCRIPTION
Enabled -flto=thin on macOS. There's no -fforce-emit-vtables flag in AppleClang. I haven't added LTO cache flags, they exist, but named differently and I'm not sure how to test them. Adding -fwhole-program-vtables makes linker crash when it links libdarktable. rsidentify links OK, so I have a question - is darktable supposed to be built with -flto=thin flag too? Because right now -flto=thin flag isn't passed to darktable at all, not to compile stage, not to link stage (but it seems linker doesn't care about this flag anyway, so I'm not sure if lto_link is needed at all here).
Another question - do we want maybe to try -flto=full?