### PR TITLE
support Fujifilm GFX 50R

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9235,6 +9235,28 @@
 		<Crop x="0" y="0" width="-936" height="0"/>
 		<Sensor black="65" white="16383"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="GFX 50R">
+		<ID make="Fujifilm" model="GFX 50R">Fujifilm GFX 50R</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-936" height="0"/>
+		<Sensor black="65" white="16383"/>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX 50R" mode="compressed">
+		<ID make="Fujifilm" model="GFX 50R">Fujifilm GFX 50R</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-936" height="0"/>
+		<Sensor black="65" white="16383"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="X-Pro1">
 		<ID make="Fujifilm" model="X-Pro1">Fujifilm X-Pro1</ID>
 		<CFA2 width="6" height="6">


### PR DESCRIPTION
I just copied the entry from the Fujifilm GFX 50S.

Since both cameras have the same image sensor and same processor etc, it seems to work well.

Here's an example compressed raw file that I've tested it on (warning: 50 MB image): https://pics.dllu.net/file/dllu-pics/2019-01-04-15-28-50_DSCF1010_f010f82bf45c732b1724dbb86808a86e0fafa555.raf

Uncompressed raw files from https://www.dpreview.com/sample-galleries/3629279893/fujifilm-gfx-50r-pre-production-sample-gallery/0782803572 work as well.