### PR TITLE
Fix early return from IiqDecoder::CorrectPhaseOneC

### DIFF
--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -238,12 +238,10 @@ void IiqDecoder::CorrectPhaseOneC(ByteStream meta_data, uint32 split_row,
 
     switch (tag) {
     case 0x431:
-      if (!iiq.quadrantMultipliers)
-        return;
-
-      CorrectQuadrantMultipliersCombined(meta_data.getSubStream(offset, len),
+      if (iiq.quadrantMultipliers)
+        CorrectQuadrantMultipliersCombined(meta_data.getSubStream(offset, len),
                                          split_row, split_col);
-      return;
+      break;
     default:
       break;
     }


### PR DESCRIPTION
Alter behaviour of IiqDecoder::CorrectPhaseOneC when encountering tag
0x431, to no longer return from the function allowing for checking other
tags.