### PR TITLE
various fixes to enhance portability

### DIFF
--- a/src/librawspeed/common/Memory.h
+++ b/src/librawspeed/common/Memory.h
@@ -35,8 +35,12 @@ namespace rawspeed {
 
 // coverity[+alloc]
 void* alignedMalloc(size_t size, size_t alignment)
+#if defined(__ICC) || defined(__ICL) 
+    __attribute__((malloc, warn_unused_result, alloc_size(1)));
+#else
     __attribute__((malloc, warn_unused_result, alloc_size(1), alloc_align(2),
                    deprecated("use alignedMalloc<alignment>(size)")));
+#endif
 
 template <typename T, size_t alignment>
 // coverity[+alloc]

--- a/src/librawspeed/common/Spline.h
+++ b/src/librawspeed/common/Spline.h
@@ -147,6 +147,20 @@ public:
 
   std::vector<Segment> getSegments() const { return segments; }
 
+private:
+  template<typename U>
+  typename std::enable_if<std::is_floating_point<U>::value, double>::type clamp(double x) const {
+    return x;
+  }
+
+  template<typename U>
+  typename std::enable_if<not std::is_floating_point<U>::value, double>::type clamp(double x) const {
+     x = std::max(x, double(std::numeric_limits<value_type>::min()));
+     x = std::min(x, double(std::numeric_limits<value_type>::max()));
+    return x;
+  }
+
+public:
   std::vector<value_type> calculateCurve() const {
     std::vector<value_type> curve(65536);
 
@@ -160,14 +174,7 @@ public:
 
         double interpolated = s.a + s.b * diff + s.c * diff_2 + s.d * diff_3;
 
-        if (!std::is_floating_point<value_type>::value) {
-          interpolated = std::max(
-              interpolated, double(std::numeric_limits<value_type>::min()));
-          interpolated = std::min(
-              interpolated, double(std::numeric_limits<value_type>::max()));
-        }
-
-        curve[x] = interpolated;
+        curve[x] = clamp<value_type>(interpolated);
       }
     }
 

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.cpp
@@ -36,24 +36,12 @@
 
 namespace rawspeed {
 
-struct PanasonicDecompressorV5::PacketDsc {
-  int bps;
-  int pixelsPerPacket;
+// There are two variants. Which one is to be used depends on image's bps.
+static constexpr PanasonicDecompressorV5::PacketDsc TwelveBitPacket =
+  PanasonicDecompressorV5::PacketDsc(/*bps=*/12);
+static constexpr PanasonicDecompressorV5::PacketDsc FourteenBitPacket =
+  PanasonicDecompressorV5::PacketDsc(/*bps=*/14);
 
-  constexpr PacketDsc();
-  explicit constexpr PacketDsc(int bps_)
-      : bps(bps_),
-        pixelsPerPacket(PanasonicDecompressorV5::bitsPerPacket / bps) {
-    // NOTE: the division is truncating. There may be some padding bits left.
-  }
-};
-
-constexpr PanasonicDecompressorV5::PacketDsc
-    PanasonicDecompressorV5::TwelveBitPacket =
-        PanasonicDecompressorV5::PacketDsc(/*bps=*/12);
-constexpr PanasonicDecompressorV5::PacketDsc
-    PanasonicDecompressorV5::FourteenBitPacket =
-        PanasonicDecompressorV5::PacketDsc(/*bps=*/14);
 
 PanasonicDecompressorV5::PanasonicDecompressorV5(const RawImage& img,
                                                  const ByteStream& input_,

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -31,6 +31,7 @@
 #include <utility>                              // for move
 #include <vector>                               // for vector
 
+
 namespace rawspeed {
 
 class PanasonicDecompressorV5 final : public AbstractDecompressor {
@@ -53,13 +54,20 @@ class PanasonicDecompressorV5 final : public AbstractDecompressor {
   static_assert(BlockSize % bytesPerPacket == 0, "");
   static constexpr uint32 PacketsPerBlock = BlockSize / bytesPerPacket;
 
+public:
   // Contains the decoding recepie for the packet,
-  struct PacketDsc;
+  struct PacketDsc {
+    int bps;
+    int pixelsPerPacket;
 
-  // There are two variants. Which one is to be used depends on image's bps.
-  static const PacketDsc TwelveBitPacket;
-  static const PacketDsc FourteenBitPacket;
+    explicit constexpr PacketDsc(int bps_)
+      : bps(bps_),
+      pixelsPerPacket(PanasonicDecompressorV5::bitsPerPacket / bps) {
+	// NOTE: the division is truncating. There may be some padding bits left.
+      }
+  };
 
+ private:
   // Takes care of unsplitting&swapping back the block at sectionSplitOffset.
   class ProxyStream;
 

--- a/src/librawspeed/decompressors/PanasonicDecompressorV5.h
+++ b/src/librawspeed/decompressors/PanasonicDecompressorV5.h
@@ -31,7 +31,6 @@
 #include <utility>                              // for move
 #include <vector>                               // for vector
 
-
 namespace rawspeed {
 
 class PanasonicDecompressorV5 final : public AbstractDecompressor {
@@ -54,20 +53,15 @@ class PanasonicDecompressorV5 final : public AbstractDecompressor {
   static_assert(BlockSize % bytesPerPacket == 0, "");
   static constexpr uint32 PacketsPerBlock = BlockSize / bytesPerPacket;
 
-public:
   // Contains the decoding recepie for the packet,
-  struct PacketDsc {
-    int bps;
-    int pixelsPerPacket;
+  struct PacketDsc;
 
-    explicit constexpr PacketDsc(int bps_)
-      : bps(bps_),
-      pixelsPerPacket(PanasonicDecompressorV5::bitsPerPacket / bps) {
-	// NOTE: the division is truncating. There may be some padding bits left.
-      }
-  };
+  template<int bps>
+  struct getPacketDsc;
 
- private:
+  template <int>
+  friend struct PanasonicDecompressorV5::getPacketDsc;
+
   // Takes care of unsplitting&swapping back the block at sectionSplitOffset.
   class ProxyStream;
 
@@ -98,12 +92,12 @@ public:
 
   void chopInputIntoBlocks(const PacketDsc& dsc);
 
-  template <const PacketDsc& dsc>
+  template <int bps>
   void processPixelPacket(BitPumpLSB* bs, ushort16* dest) const;
 
-  template <const PacketDsc& dsc> void processBlock(const Block& block) const;
+  template <int bps> void processBlock(const Block& block) const;
 
-  template <const PacketDsc& dsc> void decompressInternal() const noexcept;
+  template <int bps> void decompressInternal() const noexcept;
 
 public:
   PanasonicDecompressorV5(const RawImage& img, const ByteStream& input_,

--- a/src/librawspeed/io/BitStream.h
+++ b/src/librawspeed/io/BitStream.h
@@ -137,7 +137,7 @@ private:
   // In non-DEBUG builds, fillSafe() will be called at most once
   // per the life-time of the BitStream  therefore it should *NOT* be inlined
   // into the normal codepath.
-  inline void __attribute__((noinline, cold)) fillSafeNoinline() { fillSafe(); }
+  void __attribute__((noinline, cold)) fillSafeNoinline() { fillSafe(); }
 
 public:
   inline void fill(uint32 nbits = Cache::MaxGetBits) {


### PR DESCRIPTION
The applied fixes and modifications allow to compile rawspeed not only by using gcc and the clang compiler but also by the Intel C++ compiler version 19.0.2.187.