### PR TITLE
SAMSUNG NX500 sensor crop fix

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8150,7 +8150,7 @@
 			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="0" y="0" width="-16" height="-16"/>
 		<Sensor black="1024" white="16100" iso_min="51200"/>
 		<Sensor black="512" white="16100" iso_min="8000" iso_max="25600"/>
 		<Sensor black="128" white="16100"/>
@@ -8163,7 +8163,7 @@
 			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="0" y="0" width="-16" height="-16"/>
 		<Sensor black="128" white="4000" iso_min="8000"/>
 		<Sensor black="32" white="4000"/>
 	</Camera>


### PR DESCRIPTION
The SAMSUNG NX500 sensor has 16 extra pixels on the bottom and right of
the sensor that do have valid image data.

The camera generated JPEGs however do not use this area, and therefore
our RAW processed images are slightly misaligned (off center), while
subtle, it's still best avoided.

Another side effect is that the new 6480x4320 crop, has a perfect 3:2
aspect ratio, as where the old 6496x4336 crop, was slightly off.