### PR TITLE
Fix definition for Panasonic TZ200 and friends

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7525,8 +7525,8 @@
 			<Alias>DC-FZ93</Alias>
 		</Aliases>
 	</Camera>
-	<Camera make="Panasonic" model="DC-TZ202">
-		<ID make="Panasonic" model="DC-TZ202">Panasonic DC-ZS200</ID>
+	<Camera make="Panasonic" model="DC-TZ200">
+		<ID make="Panasonic" model="DC-TZ200">Panasonic DC-TZ200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -7536,11 +7536,12 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="142" white="4095"/>
 		<Aliases>
-			<Alias>DC-TZ200</Alias>
+			<Alias>DC-TZ202</Alias>
+			<Alias>DC-ZS200</Alias>
 		</Aliases>
 	</Camera>
-	<Camera make="Panasonic" model="DC-TZ202" mode="3:2">
-		<ID make="Panasonic" model="DC-TZ202">Panasonic DC-ZS200</ID>
+	<Camera make="Panasonic" model="DC-TZ200" mode="3:2">
+		<ID make="Panasonic" model="DC-TZ200">Panasonic DC-TZ200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -7550,7 +7551,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="142" white="4095"/>
 		<Aliases>
-			<Alias>DC-TZ200</Alias>
+			<Alias>DC-TZ202</Alias>
+			<Alias>DC-ZS200</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K100D">


### PR DESCRIPTION
The ZS200 and TZ202 were mixed within the definition, resulting in "not found" errors when attempting to open ZS200 files in darktable.