### PR TITLE
Add support for 7RM4

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8849,6 +8849,17 @@
 		<Crop x="0" y="0" width="-20" height="0"/>
 		<Sensor black="512" white="16383"/>
 	</Camera>
+	<Camera make="SONY" model="ILCE-7RM4">
+		<ID make="Sony" model="ILCE-7RM4">Sony ILCE-7RM4</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-32" height="-20"/>
+		<Sensor black="512" white="16383"/>
+	</Camera>
 	<Camera make="SONY" model="ILCE-7S">
 		<ID make="Sony" model="ILCE-7S">Sony ILCE-7S</ID>
 		<CFA width="2" height="2">

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -185,8 +185,8 @@ RawImage ArwDecoder::decodeRawInternal() {
     }
   }
 
-  if (width == 0 || height == 0 || height % 2 != 0 || width > 8000 ||
-      height > 5320)
+  if (width == 0 || height == 0 || height % 2 != 0 || width > 9600 ||
+      height > 6376)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   bool arw1 = uint64_t(counts->getU32()) * 8 != width * height * bitPerPixel;
@@ -240,7 +240,7 @@ void ArwDecoder::DecodeUncompressed(const TiffIFD* raw) {
 
   mRaw->dim = iPoint2D(width, height);
 
-  if (width == 0 || height == 0 || width > 8000 || height > 5320)
+  if (width == 0 || height == 0 || width > 9600 || height > 6376)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   if (c2 == 0)


### PR DESCRIPTION
Camera data based on the output of Adobe DNG converter:

```
Exif.SubImage1.DefaultCropOrigin             Rational    2  32/1 20/1
Exif.SubImage1.DefaultCropSize               Rational    2  9504/1 6336/1
Exif.SubImage1.BlackLevel                    Rational    4  131072/256 131072/256 131072/256 131072/256
Exif.SubImage1.WhiteLevel                    Short       1  16383
```

Image dimensions based on ARW:

```
Exif.SubImage1.ImageWidth                    Short       1  9600
Exif.SubImage1.ImageLength                   Short       1  6376
```