### PR TITLE
Fix various source comment typos

### DIFF
--- a/.ci/sonar-project.properties
+++ b/.ci/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.lang.patterns.cpp=**/*.cpp,**/*.cc,**/*.cxx,**/*.c++,**/*.h,**/*.hpp,**/*.
 sonar.working.directory=build/sonar-workdir
 sonar.cfamily.build-wrapper-output=build/bw-output
 
-# it expects cppunit xml format. googletest format is uncompatible.
+# it expects cppunit xml format. googletest format is incompatible.
 # sonar.cfamily.cppunit.reportsPath=build/unittest-reports
 
 sonar.cfamily.gcov.reportsPath=build

--- a/src/librawspeed/common/Point.h
+++ b/src/librawspeed/common/Point.h
@@ -160,7 +160,7 @@ public:
   void setSize(const iPoint2D& size) { dim = size; }
   void setSize(iPoint2D&& size) { dim = size; }
 
-  /* Crop, so area is postitive, and return true, if there is any area left */
+  /* Crop, so area is positive, and return true, if there is any area left */
   /* This will ensure that bottomright is never on the left/top of the offset */
   bool cropArea() {
     dim.x = std::max(0, dim.x);

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -267,7 +267,7 @@ inline RawImage RawImage::create(const iPoint2D& dim, RawImageType type,
 inline Array2DRef<uint16_t>
 RawImageData::getU16DataAsUncroppedArray2DRef() const noexcept {
   assert(dataType == TYPE_USHORT16 &&
-         "Attemping to access floating-point buffer as uint16_t.");
+         "Attempting to access floating-point buffer as uint16_t.");
   assert(data && "Data not yet allocated.");
   return {reinterpret_cast<uint16_t*>(data), cpp * dim.x, dim.y,
           static_cast<int>(pitch / sizeof(uint16_t))};

--- a/src/librawspeed/common/Spline.h
+++ b/src/librawspeed/common/Spline.h
@@ -97,7 +97,7 @@ private:
       s.d = (sn.c - s.c) / (3. * h[i]);
     }
 
-    // The last segment is nonsensical, and was only used to temporairly store
+    // The last segment is nonsensical, and was only used to temporarily store
     // the a and c to simplify calculations, so drop that 'segment' now
     segments.pop_back();
 

--- a/src/librawspeed/io/Buffer.h
+++ b/src/librawspeed/io/Buffer.h
@@ -37,7 +37,7 @@ namespace rawspeed {
  *
  * It allows access to some piece of memory, typically a whole or part
  * of a raw file. The underlying memory may be owned by the buffer or not.
- * It supports move operations to properly deal with owneship transfer.
+ * It supports move operations to properly deal with ownership transfer.
  * It intentionally supports only read/const access to the underlying memory.
  *
  *************************************************************************/

--- a/src/librawspeed/parsers/TiffParser.cpp
+++ b/src/librawspeed/parsers/TiffParser.cpp
@@ -72,7 +72,7 @@ TiffRootIFDOwner TiffParser::parse(TiffIFD* parent, const Buffer& data) {
 
   TiffRootIFDOwner root = std::make_unique<TiffRootIFD>(
       parent, nullptr, bs,
-      UINT32_MAX); // tell TiffIFD constructur not to parse bs as IFD
+      UINT32_MAX); // tell TiffIFD constructor not to parse bs as IFD
 
   NORangesSet<Buffer> ifds;
 

--- a/src/librawspeed/tiff/TiffIFD.cpp
+++ b/src/librawspeed/tiff/TiffIFD.cpp
@@ -60,7 +60,7 @@ void TiffIFD::parseIFDEntry(NORangesSet<Buffer>* ifds, ByteStream* bs) {
   try {
     switch (t->tag) {
     case DNGPRIVATEDATA:
-      // These are arbitrairly 'rebased', to preserve the offsets, but as it is
+      // These are arbitrarily 'rebased', to preserve the offsets, but as it is
       // implemented right now, that could trigger UB (pointer arithmetics,
       // creating pointer to unowned memory, etc). And since this is not even
       // used anywhere right now, let's not


### PR DESCRIPTION
Found via `codespell -q 3`