### PR TITLE
DngDecoder should return blacklevels also for 2-component images. (#215)

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -689,7 +689,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) {
   if (!raw->hasEntry(BLACKLEVEL))
     return true;
 
-  if (mRaw->getCpp() != 1)
+  if ((mRaw->getCpp() < 1) || (mRaw->getCpp() > 2))
     return false;
 
   TiffEntry* black_entry = raw->getEntry(BLACKLEVEL);


### PR DESCRIPTION
These are observed in DNG's converted from dual pixels CR3 raws.
Wrong colors result from non-applying the blacklevels.

Second part to fix issue darktable-org#214
See also: https://github.com/darktable-org/rawspeed/issues/215