### PR TITLE
Adds error message

### DIFF
--- a/src/librawspeed/metadata/CameraMetaData.cpp
+++ b/src/librawspeed/metadata/CameraMetaData.cpp
@@ -51,8 +51,8 @@ CameraMetaData::CameraMetaData(const char *docname) {
 
   if (!result) {
     ThrowCME(
-        "XML Document could not be parsed successfully. Error was: %s in %s",
-        result.description(), doc.child("node").attribute("attr").value());
+        "XML Document \"%s\" could not be parsed successfully. Error was: %s in %s",
+        docname, result.description(), doc.child("node").attribute("attr").value());
   }
 
   for (xml_node camera : doc.child("Cameras").children("Camera")) {


### PR DESCRIPTION
When I was trying to create out-of-binary-tree builds (be able to run darktable from the build directory without installing to enhance IDE experience and benefit from integrated cmake tools and thererlike) I figured out dt would not load because it was hanging in rawspeed. The reason was that I was missing a file next to the lib, which I did not yet copy (see #219). 

The message I got on the commandline was: 
[rawspeed] ../src/external/rawspeed/src/librawspeed/metadata/CameraMetaData.cpp:53: rawspeed::CameraMetaData::CameraMetaData(const char*): XML Document could not be parsed successfully. Error was: File was not found in  

You see here that neither `result.description()` nor `doc.child("node").attribute("attr").value()` gave any feedback. Also the obvious `docname` was missing in the feedback. 

Without fixing `result.description()` nor `doc.child("node").attribute("attr").value()` this PR just adds the docname to give appropriate feedback to the integrator. Please decide for yourself if you want to accept this PR as it is not the 100% solution.

Kind regards
David 