### PR TITLE
Added basic support for Sony Alpha 9M2 (ILCE-9M2)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9168,6 +9168,17 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="512" white="16383"/>
 	</Camera>
+	<Camera make="SONY" model="ILCE-9M2">
+		<ID make="Sony" model="ILCE-9M2">Sony ILCE-9M2</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16380"/>
+	</Camera>
 	<Camera make="SONY" model="DSC-RX1">
 		<ID make="Sony" model="DSC-RX1">Sony DSC-RX1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Sensor and RAW File Format is same as ILCE-9 -> so all values copied. Changed BlackLevel to value read from exiv2 after conversion. Have checked WhiteLevel.