### PR TITLE
Add basic camera support for Sony ZV-1

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9356,6 +9356,17 @@
 			<Alias id="SLT-A99">SLT-A99V</Alias>
 		</Aliases>
 	</Camera>
+	<Camera make="SONY" model="ZV-1">
+		<ID make="Sony" model="ZV-1">Sony ZV-1</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-32" height="-24"/>
+		<Sensor black="800" white="16300"/>
+	</Camera>
 	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng">
 		<ID make="Sinar" model="Hy6">Sinar Hy6</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
This PR adds basic camera support for the new [Sony ZV-1](https://www.sony.com/electronics/cyber-shot-compact-cameras/zv-1/specifications).

Someone already uploaded a sample `.ARW` file to https://raw.pixls.us/. I could provide more examples, if necessary.

I would also like to contribute a color matrix for this model, but since Adobe doesn't support this camera yet, I am not sure how to get ahold of it. 

@LebedevRI do you have any suggestions on how we might get the color matrix using another method?