### PR TITLE
cmake: fix incorrect usage of CACHE variables

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -50,17 +50,13 @@ ENDIF()
 # NOT CMAKE_STATIC_LINKER_FLAGS
 SET(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} ${linkerflags}"
-    CACHE STRING "" FORCE )
+    )
 SET(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${linkerflags}"
-    CACHE STRING "" FORCE )
+    )
 SET(CMAKE_MODULE_LINKER_FLAGS
     "${CMAKE_MODULE_LINKER_FLAGS} ${linkerflags}"
-    CACHE STRING "" FORCE )
-MARK_AS_ADVANCED(
-    CMAKE_SHARED_LINKER_FLAGS
-    CMAKE_EXE_LINKER_FLAGS
-    CMAKE_MODULE_LINKER_FLAGS )
+    )
 
 if(RAWSPEED_ENABLE_LTO)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -78,30 +74,19 @@ if(RAWSPEED_ENABLE_LTO)
 
   set(CMAKE_C_FLAGS
       "${CMAKE_C_FLAGS} ${lto_compile}"
-      CACHE STRING "Flags used by the C compiler during all builds."
-      FORCE )
+      )
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} ${lto_compile}"
-      CACHE STRING "Flags used by the C++ compiler during all builds."
-      FORCE )
+      )
   set(CMAKE_EXE_LINKER_FLAGS
       "${CMAKE_EXE_LINKER_FLAGS} ${lto_link}"
-      CACHE STRING "Flags used for linking binaries during all builds."
-      FORCE )
+      )
   set(CMAKE_SHARED_LINKER_FLAGS
       "${CMAKE_SHARED_LINKER_FLAGS} ${lto_link}"
-      CACHE STRING "Flags used by the shared libraries linker during all builds."
-      FORCE )
+      )
   set(CMAKE_MODULE_LINKER_FLAGS
       "${CMAKE_MODULE_LINKER_FLAGS} ${lto_link}"
-      CACHE STRING "Flags used by the module linker during all builds."
-      FORCE )
-  mark_as_advanced(
-      CMAKE_C_FLAGS
-      CMAKE_CXX_FLAGS
-      CMAKE_EXE_LINKER_FLAGS
-      CMAKE_SHARED_LINKER_FLAGS
-      CMAKE_MODULE_LINKER_FLAGS )
+      )
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")


### PR DESCRIPTION
* setting CACHE variable recursively will keep adding parameters on cmake
  re-runs
* updating cached value of CMAKE_C_FLAGS and friends breaks the whole
  logic of it being passed on from a user initially and then necessary
  flags added on top, specifically it circumvents the
  `set(CMAKE_C_FLAGS_SAVE "${CMAKE_C_FLAGS}")`
  `do_stuff()`
  `set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_SAVE}")`
  trick utilized in several places (e.g. in darktable) when cmake is
  re-run
* that still leaves a general problem of updating global variables from
  inside the library, probably it should be done only at the top level
  of application cmake files, not ad-hoc like that, instead targets and
  other modern cmake features should be used

For context see darktable-org/darktable#6258 - LTO flags leak to global darktable scope, which I don't think is intended (or is it?).

There is probably more of such incorrect usage, e.g. check LLVMOpenMP.cmake. Basically every usage of `set(... CACHE ... FORCE)` should be suspect.