### PR TITLE
Canon EOS Rebel T7i: add another alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -491,6 +491,7 @@
 		</BlackAreas>
 		<Aliases>
 			<Alias id="EOS Rebel T7i">Canon EOS Rebel T7i</Alias>
+			<Alias id="EOS REBEL T7i">Canon EOS REBEL T7i</Alias>
 			<Alias id="EOS Kiss X9i">Canon EOS Kiss X9i</Alias>
 		</Aliases>
 	</Camera>


### PR DESCRIPTION
Added another alias for Canon EOS Rebel T7i with Rebel in all capitals (REBEL). Darktable was unable to open the raw camera file as rawpseed was unable to find a corresponding camera due to Rebel being in all capitals. This was reported here: https://github.com/darktable-org/darktable/issues/5973