### PR TITLE
add nikon z 5 (camera only supports compressed raw)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2655,6 +2655,28 @@
 			<Hint name="msb_override" value=""/>
 		</Hints>
 	</Camera>
+        <Camera make="NIKON CORPORATION" model="NIKON Z 5" mode="14bit-compressed">
+                <ID make="Nikon" model="Z 5">Nikon Z 5</ID>
+                <CFA width="2" height="2">
+                        <Color x="0" y="0">RED</Color>
+                        <Color x="1" y="0">GREEN</Color>
+                        <Color x="0" y="1">GREEN</Color>
+                        <Color x="1" y="1">BLUE</Color>
+                </CFA>
+                <Crop x="0" y="0" width="0" height="0"/>
+                <Sensor black="1008" white="15520"/>
+        </Camera>
+        <Camera make="NIKON CORPORATION" model="NIKON Z 5" mode="12bit-compressed">
+                <ID make="Nikon" model="Z 5">Nikon Z 5</ID>
+                <CFA width="2" height="2">
+                        <Color x="0" y="0">RED</Color>
+                        <Color x="1" y="0">GREEN</Color>
+                        <Color x="0" y="1">GREEN</Color>
+                        <Color x="1" y="1">BLUE</Color>
+                </CFA>
+                <Crop x="0" y="0" width="0" height="0"/>
+                <Sensor black="251" white="3880"/>
+        </Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON Z 6" mode="14bit-compressed">
 		<ID make="Nikon" model="Z 6">Nikon Z 6</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Added support for Nikon Z5 to cameras.xml, based on samples uploaded to raw.pixls.us (refer darktable ticket darktable-org/darktable#6173). This camera doesn't seem to support uncompressed raws, just compressed (lossy & lossless). Black and White points extracted out of both lossy and lossless compressed raw samples are identical, and are also consistent with values in existing Z6 entry. 

Used Adobe DNG converter 12.4.0.555 on macOS.