### PR TITLE
Add DC-GX7MK3 alias & remove spaces

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -926,7 +926,7 @@
 		<Sensor black="2047" white="13400" iso_list="100 125"/>
 		<Sensor black="2048" white="12400" iso_list="160 320 640 1250 2500 5000"/>
 		<Sensor black="2047" white="15300" iso_list="10000 12800 16000 25600"/>
-		<Sensor black="2040" white="16000" iso_list="51200"/>		
+		<Sensor black="2040" white="16000" iso_list="51200"/>
 		<BlackAreas>
 			<Vertical x="4" width="64"/>
 			<Horizontal y="24" height="8"/>
@@ -7807,6 +7807,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="-66" height="0"/>
 		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DC-GX7MK3</Alias>
+		</Aliases>
 	</Camera>
 	<Camera make="Panasonic" model="DC-GX9" mode="4:3">
 		<ID make="Panasonic" model="DC-GX9">Panasonic DC-GX9</ID>
@@ -7818,6 +7821,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="-66" height="0"/>
 		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DC-GX7MK3</Alias>
+		</Aliases>
 	</Camera>
 	<Camera make="Panasonic" model="DC-TZ90">
 		<ID make="Panasonic" model="DC-TZ90">Panasonic DC-ZS70</ID>


### PR DESCRIPTION
In Japan, the GX9 is called GX7MK3.