### PR TITLE
rawspeed: SONY ILCE-7C support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9178,6 +9178,17 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
+	<Camera make="SONY" model="ILCE-7C">
+		<ID make="Sony" model="ILCE-7C">Sony ILCE-7C</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16383"/>
+	</Camera>
 	<Camera make="SONY" model="ILCE-7R">
 		<ID make="Sony" model="ILCE-7R">Sony ILCE-7R</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Part [2/2] of darktable-org/darktable#6669

Camera info was extracted with dngmeta.sh and Adobe DNG Converter 13.0 (Macintosh)


---

Update at Sun, 08 Nov 2020 02:35:01 +0800:

<details>
<summary>output from dngmeta.sh</summary><pre>
/mnt/waifuh1t/repo/darktable/tools> ./dngmeta.sh  /tmp/raws/_DSC0021.dng
DNG created by : Adobe DNG Converter 13.0 (Macintosh)
DNG Illuminant : 21 (should be 21)


$ nano -w src/external/adobe_coeff.c

{ "Sony ILCE-7C", { 7374,-2389,-551,-5435,13162,2519,-1006,1795,6552 } },

$ git commit -a -m "adobe_coeff: SONY ILCE-7C support" --author " <chino@amausaan>"


$ nano -w src/external/rawspeed/data/cameras.xml (mind the tabs)

	<Camera make="SONY" model="ILCE-7C">
		<ID make="Sony" model="ILCE-7C">Sony ILCE-7C</ID>
		<CFA width="2" height="2">
			<Color x="0" y="0">RED</Color>
			<Color x="1" y="0">GREEN</Color>
			<Color x="0" y="1">GREEN</Color>
			<Color x="1" y="1">BLUE</Color>
		</CFA>
		<Crop x="0" y="0" width="0" height="0"/>
		<Sensor black="512" white="16383"/>
	</Camera>

NOTE: The default crop exposes the full sensor including garbage pixels, which need to be visually inspected. (negative width/height values are right/bottom crops, which are preferred)

NOTE: Sensor black and white levels sometimes vary based on ISO, please run this tool on raws for each of the camera's supported ISOs

$ git commit -a -m "rawspeed: SONY ILCE-7C support" --author " <chino@amausaan>"
</pre></details>