### PR TITLE
Fujifilm X-S10 camera support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -10276,6 +10276,32 @@
 		<Crop x="4" y="0" width="-52" height="0"/>
 		<Sensor black="1024" white="16383"/>
         </Camera>
+	<Camera make="FUJIFILM" model="X-S10">
+		<ID make="Fujifilm" model="X-S10">Fujifilm X-S10</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="6" width="-132" height="0"/>
+		<Sensor black="1022" white="16383"/>
+	</Camera>
+	<Camera make="FUJIFILM" model="X-S10" mode="compressed">
+		<ID make="Fujifilm" model="X-S10">Fujifilm X-S10</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="6" width="-132" height="0"/>
+		<Sensor black="1022" white="16383"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="X-T1">
 		<ID make="Fujifilm" model="X-T1">Fujifilm X-T1</ID>
 		<CFA2 width="6" height="6">


### PR DESCRIPTION
Added support for the Fujifilm X-S10 for uncompressed raw files and for
lossless compressed raw files. The X-S10 is using the same sensor and
CPU as the X-T4.

I took two test shots at every ISO setting. Booth ISO 500 shots had a black
level of 1021. One of the two 10000 ISO shots had a black level of 1023.
ISO settings were 160, 200, 250, 320, 400, 500, 640, 800, 1000, 1250, 1600,
2000, 2500, 3200, 4000, 5000, 6400, 8000, 10000, 12800. I ignored the
extended ISO settings 80, 100, 125, 25600, 51200. I assume these small
black level variations can be ignored?

I uploaded as well three same files to https://raw.pixls.us/, an uncompressed,
a lossy compressed, and a lossless compressed RAF file.
