### PR TITLE
Support for FujiFilm GFX100S

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8463,6 +8463,28 @@
 		<Crop x="0" y="4" width="-146" height="-6"/>
 		<Sensor black="62" white="16383"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="GFX100S">
+		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="63" white="16383"/>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX100S" mode="compressed">
+		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="62" white="16383"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="X-Pro1">
 		<ID make="Fujifilm" model="X-Pro1">Fujifilm X-Pro1</ID>
 		<CFA2 width="6" height="6">


### PR DESCRIPTION
Support for the new GFX100S. 

It's the same sensor than the GFX100. I use the name I find in the output of exiftool, as you can see they are no space between 'GFX' and '100S' (not like the GFX 100)
```
[100_FUJI_RAW][linux]$ exiftool DSCF0112.RAF|grep GFX
Camera Model Name               : GFX100S
Software                        : Digital Camera GFX100S Ver1.00
[100_FUJI_RAW][linux]$ 
```

I already upload some example on https://raw.pixls.us/

Hope the shot are okay for you, otherwise just ask me

I upload some samples. Because it's take 10-15 minutes each I loose the count. But I'm pretty sure I already upload
Format 4:3
- Fujifilm-GFX100S-14bits-compress-4_3.RAF
- Fujifilm-GFX100S-14bits-losslescompressed-4_3.RAF
- Fujifilm-GFX100S-14bits-uncompress-4_3.RAF
- Fujifilm-GFX100S-16bits-compress-4_3.RAF
- Fujifilm-GFX100S-16bits-losslesscompressed-4_3.RAF
- Fujifilm-GFX100S-16bits-uncompress-4_3.RAF

Same for the format 3:2

Does other format are useful ? I already take some other shot, but don't know if that is useful.