### PR TITLE
Support for Leica D-LUX 7

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6951,6 +6951,32 @@
 		<Crop x="0" y="0" width="-144" height="0"/>
 		<Sensor black="143" white="4095"/>
 	</Camera>
+	<!-- LEICA D-LUX 7 is the same camera as Panasonic DC-LX100M2 -->
+	<Camera make="LEICA CAMERA AG" model="D-Lux 7">
+		<ID make="Leica" model="D-Lux 7">D-Lux 7</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="D-Lux 7" mode="4:3">
+		<ID make="Leica" model="D-Lux 7">D-Lux 7</ID>
+		<Crop x="10" y="6" width="-60" height="-4"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="D-Lux 7" mode="1:1">
+		<ID make="Leica" model="D-Lux 7">D-Lux 7</ID>
+		<Crop x="0" y="6" width="-130" height="-4"/>
+		<Sensor black="144" white="4095"/>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="D-Lux 7" mode="16:9">
+		<ID make="Leica" model="D-Lux 7">D-Lux 7</ID>
+		<Crop x="10" y="0" width="-90" height="0"/>
+		<Sensor black="144" white="4095"/>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="D-Lux 7" mode="3:2">
+		<ID make="Leica" model="D-Lux 7">D-Lux 7</ID>
+		<Crop x="4" y="0" width="-90" height="0"/>
+		<Sensor black="144" white="4095"/>
+	</Camera>
 	<Camera make="Panasonic" model="DMC-LX1" mode="16:9">
 		<ID make="Panasonic" model="DMC-LX1">Panasonic DMC-LX1</ID>
 		<CFA width="2" height="2">

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -54,7 +54,7 @@ bool Rw2Decoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
 
   // FIXME: magic
 
-  return make == "Panasonic" || make == "LEICA";
+  return make == "Panasonic" || make == "LEICA" || make == "LEICA CAMERA AG";
 }
 
 RawImage Rw2Decoder::decodeRawInternal() {


### PR DESCRIPTION
This is basically the same camera as Pana LX100 Mark II, just some other housing. So:

- copy in cameras.xml
- add "LEICA CAMERA AG" as a valid make in the decoder. Almost all recent firmware from Leica
  uses this btw.