### PR TITLE
Support Sony ILCE-7SM3

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7851,7 +7851,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="12" y="8" width="-36" height="-8"/>
+		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="512" white="16383"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-9">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7843,6 +7843,17 @@
 		<Crop x="0" y="0" width="-32" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
+	<Camera make="SONY" model="ILCE-7SM3">
+		<ID make="Sony" model="ILCE-7SM3">Sony ILCE-7SM3</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="12" y="8" width="-36" height="-8"/>
+		<Sensor black="512" white="16383"/>
+	</Camera>
 	<Camera make="SONY" model="ILCE-9">
 		<ID make="Sony" model="ILCE-9">Sony ILCE-9</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
~~Haven't actually inspected the RPU sample, but used default crop from converted DNG, as well black & white levels.~~

~~Btw, it seems recent ARW versions also originally contain DefaultCropOrigin+DefaultCropSize to begin with (identical to converted DNG).~~

Closes https://github.com/darktable-org/darktable/issues/8632