### PR TITLE
Support Sony ILCE-1

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7741,7 +7741,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="12" y="12" width="8640" height="5760"/>
+		<Crop x="0" y="0" width="8662" height="5784"/>
 		<Sensor black="512" white="16383"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7733,6 +7733,17 @@
 		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="512" white="16383"/>
 	</Camera>
+	<Camera make="SONY" model="ILCE-1">
+		<ID make="Sony" model="ILCE-1">Sony ILCE-1</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="12" y="12" width="8640" height="5760"/>
+		<Sensor black="512" white="16383"/>
+	</Camera>
 	<Camera make="SONY" model="ILCE-7">
 		<ID make="Sony" model="ILCE-7">Sony ILCE-7</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -205,7 +205,7 @@
       <xs:simpleType>
         <xs:restriction base="xs:unsignedShort">
           <xs:minInclusive value="1296"/>
-          <xs:maxInclusive value="6080"/>
+          <xs:maxInclusive value="8662"/>
         </xs:restriction>
       </xs:simpleType>
       <xs:simpleType>


### PR DESCRIPTION
~~Uses ARW DefaultCropOrigin+DefaultCropSize.~~

Absolute (positive) size is used instead of the preferred relative (negative) one because the new JPEG lossless compressed ARW mode uses tiles and has a different (larger) ImageWidth/ImageLenght to the usual uncompressed & lossy compressed modes, so this should be future proof.

Closes https://github.com/darktable-org/darktable/issues/8618 (w/o lossless compression; adobe_coeffs already in dt master)