### PR TITLE
Fujifilm X100V crop revision

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8667,7 +8667,7 @@
 			<ColorRow y="4">GGRGGB</ColorRow>
 			<ColorRow y="5">RBGBRG</ColorRow>
 		</CFA2>
-		<Crop x="0" y="12" width="-138" height="0"/>
+		<Crop x="0" y="7" width="-132" height="-1"/>
 		<Sensor black="1022" white="16383"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X100V" mode="compressed">
@@ -8680,7 +8680,7 @@
 			<ColorRow y="4">GGRGGB</ColorRow>
 			<ColorRow y="5">RBGBRG</ColorRow>
 		</CFA2>
-		<Crop x="0" y="12" width="-138" height="0"/>
+		<Crop x="0" y="7" width="-132" height="-1"/>
 		<Sensor black="1022" white="16383"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-H1">


### PR DESCRIPTION
Sample from raw.pixls.us show a top black border of 5 pixels, bottom border 1 pixel, no left border, 132 pixels right border.

Setting these values produces a black border at top edge when rendered in darktable. Setting top crop to 7 gets rid of this.

I'm not sure of the ramifications of changing these values for a camera already in active use via darktable.

This may help with darktable-org/darktable#8644.