### PR TITLE
Add Ricoh GR III

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9772,6 +9772,9 @@
 	<Camera make="RICOH" model="GR DIGITAL 2" mode="dng">
 		<ID make="Ricoh" model="GR II">Ricoh GR DIGITAL 2</ID>
 	</Camera>
+	<Camera make="RICOH IMAGING COMPANY, LTD." model="RICOH GR III" mode="dng">
+		<ID make="Ricoh" model="GR III">Ricoh GR DIGITAL 3</ID>
+	</Camera>
 	<Camera make="Canon" model="Canon PowerShot A720 IS" mode="dng">
 		<ID make="Canon" model="PowerShot A720 IS">Canon PowerShot A720 IS</ID>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9773,7 +9773,7 @@
 		<ID make="Ricoh" model="GR II">Ricoh GR DIGITAL 2</ID>
 	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="RICOH GR III" mode="dng">
-		<ID make="Ricoh" model="GR III">Ricoh GR DIGITAL 3</ID>
+		<ID make="Ricoh" model="GR III">Ricoh GR III</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot A720 IS" mode="dng">
 		<ID make="Canon" model="PowerShot A720 IS">Canon PowerShot A720 IS</ID>


### PR DESCRIPTION
I hope I made this one right.

This allows for full run of https://github.com/darktable-org/darktable/issues/9091 (which reads from cameras.xml) as well as makes darktable nicely accept DNG from https://raw.pixls.us/getfile.php/3115/nice/Ricoh%20-%20RICOH%20GR%20III%20-%2014bit%20(3:2).DNG with no rendition artifacts

(without this, the colors i get are wack).