### PR TITLE
rawspeed: Pentax K-3 Mark III support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6755,6 +6755,17 @@
                 <Crop x="4" y="0" width="-36" height="0"/>
                 <Sensor black="1" white="15865"/>
         </Camera>
+        <Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-3 Mark III">
+                <ID make="Ricoh" model="PENTAX K-3 Mark III">PENTAX K-3 Mark III</ID>
+                <CFA width="2" height="2">
+                        <Color x="0" y="0">RED</Color>
+                        <Color x="1" y="0">GREEN</Color>
+                        <Color x="0" y="1">GREEN</Color>
+                        <Color x="1" y="1">BLUE</Color>
+                </CFA>
+                <Crop x="24" y="34" width="-28" height="-14"/>
+                <Sensor black="64" white="16315"/>
+        </Camera>
 	<Camera make="PENTAX" model="PENTAX K-5" decoder_version="2">
 		<ID make="Pentax" model="K-5">PENTAX K-5</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6756,7 +6756,7 @@
                 <Sensor black="1" white="15865"/>
         </Camera>
         <Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-3 Mark III">
-                <ID make="Ricoh" model="PENTAX K-3 Mark III">PENTAX K-3 Mark III</ID>
+                <ID make="Pentax" model="K-3 Mark III">PENTAX K-3 Mark III</ID>
                 <CFA width="2" height="2">
                         <Color x="0" y="0">RED</Color>
                         <Color x="1" y="0">GREEN</Color>


### PR DESCRIPTION
Addresses part of https://github.com/darktable-org/darktable/issues/8991

black and white levels come from DNG converter and `dngmeta.sh` script, crops from visual inspection of RPU PEF sample

Not sure about the make and model though as scheme seems to be changed from K-3 II...