### PR TITLE
Fix misc. typos

### DIFF
--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -155,7 +155,7 @@ void CrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
             {wb->getU16(36), wb->getU16(37), wb->getU16(38), wb->getU16(39)}};
         for (const auto& mul : wbMuls) {
           if (0 == mul)
-            ThrowRDE("WB coeffient is zero!");
+            ThrowRDE("WB coefficient is zero!");
         }
 
         mRaw->metadata.wbCoeffs[0] = static_cast<float>(1024.0 / wbMuls[0]);

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -92,7 +92,7 @@ RawImage DcrDecoder::decodeRawInternal() {
     for (auto i = 0U; i < 3; i++) {
       const auto mul = blob->getU16(20 + i);
       if (0 == mul)
-        ThrowRDE("WB coeffient is zero!");
+        ThrowRDE("WB coefficient is zero!");
       mRaw->metadata.wbCoeffs[i] = 2048.0F / mul;
     }
   }

--- a/src/librawspeed/decompressors/CrwDecompressor.cpp
+++ b/src/librawspeed/decompressors/CrwDecompressor.cpp
@@ -53,7 +53,7 @@ CrwDecompressor::CrwDecompressor(const RawImage& img, uint32_t dec_table,
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   if (lowbits) {
-    // If there are low bits, the first part (size is calculatable) is low bits
+    // If there are low bits, the first part (size is calculable) is low bits
     // Each block is 4 pairs of 2 bits, so we have 1 block per 4 pixels
     const unsigned lBlocks = 1 * height * width / 4;
     assert(lBlocks > 0);

--- a/src/librawspeed/decompressors/HuffmanTableVector.h
+++ b/src/librawspeed/decompressors/HuffmanTableVector.h
@@ -48,7 +48,7 @@ protected:
     CodeSymbol partial;
     uint64_t codeId;
 
-    // Read bits until either find the code or detect the uncorrect code
+    // Read bits until either find the code or detect the incorrect code
     for (partial.code = 0, partial.code_len = 1;; ++partial.code_len) {
       assert(partial.code_len <= 16);
 
@@ -82,7 +82,7 @@ protected:
       }
     }
 
-    // We have either returned the found symbol, or thrown on uncorrect symbol.
+    // We have either returned the found symbol, or thrown on incorrect symbol.
     __builtin_unreachable();
   }
 

--- a/src/librawspeed/decompressors/UncompressedDecompressor.cpp
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.cpp
@@ -311,7 +311,7 @@ void UncompressedDecompressor::decode12BitRaw(uint32_t w, uint32_t h) {
   static constexpr const auto bits = 12;
 
   static_assert(e == Endianness::little || e == Endianness::big,
-                "unknown endiannes");
+                "unknown endianness");
 
   static constexpr const auto shift = 16 - bits;
   static constexpr const auto pack = 8 - shift;
@@ -385,7 +385,7 @@ UncompressedDecompressor::decode12BitRaw<Endianness::big, false, true>(
 template <Endianness e>
 void UncompressedDecompressor::decode12BitRawUnpackedLeftAligned(uint32_t w,
                                                                  uint32_t h) {
-  static_assert(e == Endianness::big, "unknown endiannes");
+  static_assert(e == Endianness::big, "unknown endianness");
 
   sanityCheck(w, &h, 2);
 
@@ -413,7 +413,7 @@ template <int bits, Endianness e>
 void UncompressedDecompressor::decodeRawUnpacked(uint32_t w, uint32_t h) {
   static_assert(bits == 12 || bits == 14 || bits == 16, "unhandled bitdepth");
   static_assert(e == Endianness::little || e == Endianness::big,
-                "unknown endiannes");
+                "unknown endianness");
 
   static constexpr const auto shift = 16 - bits;
   static constexpr const auto mask = (1 << (8 - shift)) - 1;


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,ist,optio`