### PR TITLE
Panasonic S5/S1/S1H: Fix Black Point

### DIFF
--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -214,13 +214,9 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (raw->hasEntry(static_cast<TiffTag>(0x1c)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1d)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1e))) {
-    const auto getBlack = [&raw](TiffTag t) -> int {
-      return raw->getEntry(t)->getU16();
-    };
-
-    const int blackRed = getBlack(static_cast<TiffTag>(0x1c));
-    const int blackGreen = getBlack(static_cast<TiffTag>(0x1d));
-    const int blackBlue = getBlack(static_cast<TiffTag>(0x1e));
+    const int blackRed = raw->getEntry(static_cast<TiffTag>(0x1c))->getU16();
+    const int blackGreen = raw->getEntry(static_cast<TiffTag>(0x1d))->getU16();
+    const int blackBlue = raw->getEntry(static_cast<TiffTag>(0x1e))->getU16();
 
     for(int i = 0; i < 2; i++) {
       for(int j = 0; j < 2; j++) {

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -215,11 +215,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       raw->hasEntry(static_cast<TiffTag>(0x1d)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1e))) {
     const auto getBlack = [&raw](TiffTag t) -> int {
-      const auto val = raw->getEntry(t)->getU32();
-      int out;
-      if (__builtin_sadd_overflow(val, 15, &out))
-        ThrowRDE("Integer overflow when calculating black level");
-      return out;
+      return raw->getEntry(t)->getU16();
     };
 
     const int blackRed = getBlack(static_cast<TiffTag>(0x1c));


### PR DESCRIPTION
-Fix black point by reading shorts/u16 instead of u32. Don't add 15 or check for overflow.

There's discussion in this Darktable [issue](https://github.com/darktable-org/darktable/issues/9811) about this issue.

Jens suggested I check against the white point, but I don't see it in this decoder. There doesn't seem to be a reason why there was addition of 15 or the overflow check. It appears to be wrong assumption as it causes low-light images to be green.

Here's the Exiftools document about [Panasonic Raws](https://exiftool.org/TagNames/PanasonicRaw.html) (RW2) to verify the black levels are shorts.

Let me know if there's any other changes.