### PR TITLE
feat: add the camera definition for Sony ZV-E10

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8093,6 +8093,17 @@
 		<Crop x="0" y="0" width="-8" height="0"/>
 		<Sensor black="800" white="16300"/>
 	</Camera>
+	<Camera make="SONY" model="ZV-E10">
+		<ID make="Sony" model="ZV-E10">Sony ZV-E10</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-22" height="0"/>
+		<Sensor black="512" white="16383"/>
+	</Camera>
 	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng">
 		<ID make="Sinar" model="Hy6">Sinar Hy6</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
This PR adds a basic supprt for the recently launched [Sony ZV-E10](https://www.sony.com/en-sa/electronics/interchangeable-lens-cameras/zv-e10/specifications). The camera data refers to the profile of Sony Alpha 6400 since these two models have almost the same spec.