### PR TITLE
Fix build with GCC7/8

### DIFF
--- a/src/librawspeed/decompressors/VC5Decompressor.h
+++ b/src/librawspeed/decompressors/VC5Decompressor.h
@@ -134,8 +134,10 @@ class VC5Decompressor final : public AbstractDecompressor {
     };
     struct ReconstructableBand final : AbstractBand {
       bool clampUint;
-      BandData lowpass;
-      BandData highpass;
+      struct {
+        BandData lowpass;
+        BandData highpass;
+      } intermediates;
       explicit ReconstructableBand(Wavelet& wavelet_, bool clampUint_ = false)
           : AbstractBand(wavelet_), clampUint(clampUint_) {}
       void createLowpassReconstructionTask() noexcept;


### PR DESCRIPTION
OpenMP support for C++'s `this` pointer is not really available
in OpenMP 4.5 that we're tracking, so we have to avoid using it.

Clang does not complain about that,
filed https://bugs.llvm.org/show_bug.cgi?id=51678