### PR TITLE
Remove final from CameraMetaData to allow derived classes

### DIFF
--- a/src/librawspeed/metadata/CameraMetaData.h
+++ b/src/librawspeed/metadata/CameraMetaData.h
@@ -41,7 +41,7 @@ struct CameraId {
   }
 };
 
-class CameraMetaData final {
+class CameraMetaData {
 public:
   CameraMetaData() = default;
 


### PR DESCRIPTION
CameraMetaData derived classes are needed if one want to create CameraMetaData ancestor not from file, but from other source (compressed resource, etc)