### PR TITLE
Fix Panasonic Black Levels for newer cameras.

### DIFF
--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -226,16 +226,16 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       raw->hasEntry(static_cast<TiffTag>(0x1e))) {
     const auto getBlack = [&raw, version](TiffTag t) {
       const int val = raw->getEntry(t)->getU16();
+      int out;
       // After version 4 the black levels appears to be correct.
       // Continue adding 15 for older raw versions.
       if(version > 4) {
-        return val;
+        out = val;
       } else {
-        int out;
         if (__builtin_sadd_overflow(val, 15, &out))
           ThrowRDE("Integer overflow when calculating black level");
-        return out;
       }
+      return out;
     };
 
     const int blackRed = getBlack(static_cast<TiffTag>(0x1c));

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -225,7 +225,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       raw->hasEntry(static_cast<TiffTag>(0x1d)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1e))) {
     const auto getBlack = [&raw, version](TiffTag t) {
-      const uint32_t val = raw->getEntry(t)->getU16();
+      const int val = raw->getEntry(t)->getU16();
       // After version 4 the black levels appears to be correct.
       // Continue adding 15 for older raw versions.
       if(version > 4) {

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -224,7 +224,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (raw->hasEntry(static_cast<TiffTag>(0x1c)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1d)) &&
       raw->hasEntry(static_cast<TiffTag>(0x1e))) {
-    const auto getBlack = [&raw](TiffTag t) {
+    const auto getBlack = [&raw, version](TiffTag t) {
       const uint32_t val = raw->getEntry(t)->getU16();
       // After version 4 the black levels appears to be correct.
       // Continue adding 15 for older raw versions.

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -217,7 +217,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
           ? mRootIFD->getIFDWithTag(TiffTag::PANASONIC_STRIPOFFSET)
           : mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS);
 
-  const auto uint16_t version = 
+  const uint16_t version = 
       raw->getEntry(TiffTag::PANASONIC_RAWFORMAT)->getU16();
 
   // Read blacklevels


### PR DESCRIPTION
Pivot black levels on raw version. Newer then version 5 should have correct black levels.