### PR TITLE
Remove wrong Ricoh GR II alias (GR Digital 2 is a different camera)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9976,9 +9976,6 @@
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="GR" mode="dng">
 		<ID make="Ricoh" model="GR">GR</ID>
 	</Camera>
-	<Camera make="RICOH" model="GR DIGITAL 2" mode="dng">
-		<ID make="Ricoh" model="GR II">Ricoh GR DIGITAL 2</ID>
-	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="GR II" mode="dng">
 		<ID make="Ricoh" model="GR II">Ricoh GR II</ID>
  	</Camera>


### PR DESCRIPTION
As suggested in #309 by @kmilos - and I agree.