### PR TITLE
Add Sony DSC-HX95 alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -9415,6 +9415,9 @@
 		</CFA>
 		<Crop x="10" y="0" width="-20" height="-10"/>
 		<Sensor black="800" white="16300"/>
+		<Aliases>
+			<Alias>DSC-HX95</Alias>
+		</Aliases>
 	</Camera>
 	<Camera make="SONY" model="DSC-R1">
 		<ID make="Sony" model="DSC-R1">Sony DSC-R1</ID>


### PR DESCRIPTION
See https://www.digitalcameraworld.com/uk/news/sony-unleashes-pocket-sized-hx95-and-hx99-travel-zoom-cameras

Also compared DCPs shipped w/ DNG converter, there is only the single byte (9 vs 5) difference.

([Related support request to be created once the samples are up.](https://discuss.pixls.us/t/sony-dsc-hx95-not-supported/27475))