### PR TITLE
Update linker flags for Windows

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -42,7 +42,7 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-IF(NOT APPLE)
+IF(NOT APPLE AND NOT WIN32)
   set(linkerflags "-Wl,--as-needed")
 ELSE()
   set(linkerflags "")


### PR DESCRIPTION
Fixes #313

`--as-needed` affects only ELF binaries' DT_NEEDED flag, and `lld` on Windows throws an error instead of ignoring it like `ld` does.