### PR TITLE
[CI] Add CIFuzz integration

### DIFF
--- a/.github/workflows/CI-ossfuzz.yml
+++ b/.github/workflows/CI-ossfuzz.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_call:
+    inputs:
+      sanitizer:
+        required: true
+        type: string
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: (OSS-FUZZ) Building with ${{ inputs.sanitizer }} sanitizer
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'librawspeed'
+          dry-run: false
+          language: c++
+          sanitizer: ${{ inputs.sanitizer }}
+      - name: (OSS-FUZZ) Running ${{ inputs.sanitizer }}-sanitized fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'librawspeed'
+          fuzz-seconds: 600
+          dry-run: false
+          sanitizer: ${{ inputs.sanitizer }}
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,6 +127,15 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
       SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+  linux-ossfuzz:
+    if: github.repository == 'darktable-org/rawspeed' && (github.event_name == 'pull_request' || (github.ref_type == 'branch' && github.ref_name == 'develop'))
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [ address, undefined, memory ]
+    uses: ./.github/workflows/CI-ossfuzz.yml
+    with:
+      sanitizer: ${{ matrix.sanitizer }}
   windows-msys2-fast:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Add CIFuzz workflow action to have fuzzers build and run on each PR.
This is a service offered by OSS-Fuzz, on which rawspeed already runs.

Signed-off-by: David Korczynski <david@adalogics.com>