### PR TITLE
rawspeed: Fujifilm GFX50S II support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8644,6 +8644,28 @@
 		<Crop x="0" y="0" width="-938" height="-4"/>
 		<Sensor black="65" white="16383"/>
 	</Camera>
+        <Camera make="FUJIFILM" model="GFX50S II">
+                <ID make="Fujifilm" model="GFX50S II">Fujifilm GFX 50S II</ID>
+                <CFA width="2" height="2">
+                        <Color x="0" y="0">RED</Color>
+                        <Color x="1" y="0">GREEN</Color>
+                        <Color x="0" y="1">GREEN</Color>
+                        <Color x="1" y="1">BLUE</Color>
+                </CFA>
+                <Crop x="0" y="0" width="0" height="0"/>
+                <Sensor black="64" white="16383"/>
+        </Camera>
+        <Camera make="FUJIFILM" model="GFX50S II" mode="compressed">
+                <ID make="Fujifilm" model="GFX50S II">Fujifilm GFX 50S II</ID>
+                <CFA width="2" height="2">
+                        <Color x="0" y="0">RED</Color>
+                        <Color x="1" y="0">GREEN</Color>
+                        <Color x="0" y="1">GREEN</Color>
+                        <Color x="1" y="1">BLUE</Color>
+                </CFA>
+                <Crop x="0" y="0" width="0" height="0"/>
+                <Sensor black="64" white="16383"/>
+        </Camera>
 	<Camera make="FUJIFILM" model="GFX 100">
 		<ID make="Fujifilm" model="GFX 100">Fujifilm GFX 100</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Output from dngmeta.sh script, w/ added compressed mode:

TODO (for both modes):

1. Verify crop (copy from 50S/50R?)
2. Verify black level (DNG says 64; 50S/50R have 65 in rawspeed and also in DNG, so Adobe does not treat them as 100% identical indeed)

Also, is 3rd (new lossy) compression mode missing? (also for GFX100S?) I have no idea how/if this new mode works out w/ rawspeed...

Addresses part of https://github.com/darktable-org/darktable/issues/10608