### PR TITLE
Change lack-of-samples into a noisy warning (Refs. #335)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -84,7 +84,7 @@
 ]>
 
 <Cameras>
-	<Camera make="ARRI" model="ALEXA" supported="no"><!-- no samples -->
+	<Camera make="ARRI" model="ALEXA" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -1600,7 +1600,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS M2" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="Canon EOS M2" supported="no-samples">
 		<ID make="Canon" model="EOS M2">Canon EOS M2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3008,7 +3008,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="GoPro" model="FUSION" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="GoPro" model="FUSION" mode="dng" supported="no-samples">
 		<ID make="GoPro" model="FUSION">GoPro FUSION</ID>
 	</Camera>
 	<Camera make="GoPro" model="HERO5 Black" mode="dng">
@@ -3077,7 +3077,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed" supported="no-samples">
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3095,7 +3095,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed" supported="no-samples">
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3191,7 +3191,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D2H" mode="12bit-compressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D2H" mode="12bit-compressed" supported="no-samples">
 		<ID make="Nikon" model="D2H">Nikon D2H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -3209,7 +3209,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D2H" mode="12bit-uncompressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D2H" mode="12bit-uncompressed" supported="no-samples">
 		<ID make="Nikon" model="D2H">Nikon D2H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -3407,7 +3407,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed" supported="no-samples">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3425,7 +3425,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed" supported="no-samples">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3443,7 +3443,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-compressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-compressed" supported="no-samples">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3461,7 +3461,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-uncompressed" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-uncompressed" supported="no-samples">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -6059,7 +6059,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4" supported="no-samples">
 		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -6113,7 +6113,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" mode="12bit-compressed" decoder_version="4" supported="no"><!-- no samples -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" mode="12bit-compressed" decoder_version="4" supported="no-samples">
 		<ID make="Nikon" model="1 S1">Nikon 1 S1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -6510,7 +6510,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7700" mode="12bit-compressed" decoder_version="5" supported="no"><!-- no samples -->
+	<Camera make="NIKON" model="COOLPIX P7700" mode="12bit-compressed" decoder_version="5" supported="no-samples">
 		<ID make="Nikon" model="Coolpix P7700">Nikon Coolpix P7700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -6902,7 +6902,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="SP320" supported="no"><!-- no samples -->
+	<Camera make="OLYMPUS IMAGING CORP." model="SP320" supported="no-samples">
 		<ID make="Olympus" model="SP320">Olympus SP320</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
@@ -6950,7 +6950,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="OLYMPUS OPTICAL CO.,LTD" model="E-10" supported="no"><!-- no samples -->
+	<Camera make="OLYMPUS OPTICAL CO.,LTD" model="E-10" supported="no-samples">
 		<ID make="Olympus" model="E-10">Olympus E-10</ID>
 		<Crop x="0" y="0" width="2256" height="1684"/>
 		<Sensor black="32" white="1023"/>
@@ -7360,7 +7360,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="SP570UZ" supported="no"><!-- no samples -->
+	<Camera make="OLYMPUS IMAGING CORP." model="SP570UZ" supported="no-samples">
 		<ID make="Olympus" model="SP570UZ">Olympus SP570UZ</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
@@ -7411,7 +7411,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-FX150" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-FX150" supported="no-samples">
 		<ID make="Panasonic" model="DMC-FX150">Panasonic DMC-FX150</ID>
 		<Crop x="0" y="0" width="4429" height="3324"/>
 		<Sensor black="15" white="3986"/>
@@ -7423,7 +7423,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-FX150" mode="4:3" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-FX150" mode="4:3" supported="no-samples">
 		<ID make="Panasonic" model="DMC-FX150">Panasonic DMC-FX150</ID>
 		<Crop x="0" y="0" width="4429" height="3324"/>
 		<Sensor black="15" white="3986"/>
@@ -7717,7 +7717,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-G2" mode="4:3" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-G2" mode="4:3" supported="no-samples">
 		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="3900"/>
@@ -7729,7 +7729,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-G2" mode="3:2" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-G2" mode="3:2" supported="no-samples">
 		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="3900"/>
@@ -7741,7 +7741,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-G2" mode="16:9" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-G2" mode="16:9" supported="no-samples">
 		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="3900"/>
@@ -7753,7 +7753,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-G2" mode="1:1" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-G2" mode="1:1" supported="no-samples">
 		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3900"/>
@@ -7765,7 +7765,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DMC-G2" supported="no"><!-- no samples -->
+	<Camera make="Panasonic" model="DMC-G2" supported="no-samples">
 		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="3900"/>
@@ -10292,7 +10292,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="LEICA" model="D-LUX 6" supported="no"><!-- no samples -->
+	<Camera make="LEICA" model="D-LUX 6" supported="no-samples">
 		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -10310,7 +10310,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="LEICA" model="D-LUX 6" mode="4:3" supported="no"><!-- no samples -->
+	<Camera make="LEICA" model="D-LUX 6" mode="4:3" supported="no-samples">
 		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -10328,7 +10328,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="LEICA" model="D-LUX 6" mode="3:2" supported="no"><!-- no samples -->
+	<Camera make="LEICA" model="D-LUX 6" mode="3:2" supported="no-samples">
 		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -10346,7 +10346,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="LEICA" model="D-LUX 6" mode="16:9" supported="no"><!-- no samples -->
+	<Camera make="LEICA" model="D-LUX 6" mode="16:9" supported="no-samples">
 		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -10364,7 +10364,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="LEICA" model="D-LUX 6" mode="1:1" supported="no"><!-- no samples -->
+	<Camera make="LEICA" model="D-LUX 6" mode="1:1" supported="no-samples">
 		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -11672,7 +11672,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="PENTAX Corporation" model="PENTAX K200D" supported="no"><!-- no samples -->
+	<Camera make="PENTAX Corporation" model="PENTAX K200D" supported="no-samples">
 		<ID make="Pentax" model="K200D">Pentax K200D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -12000,7 +12000,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="PENTAX" model="PENTAX K200D" supported="no"><!-- no samples -->
+	<Camera make="PENTAX" model="PENTAX K200D" supported="no-samples">
 		<ID make="Pentax" model="K200D">Pentax K200D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -12018,7 +12018,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="PENTAX" model="PENTAX K2000" supported="no"><!-- no samples -->
+	<Camera make="PENTAX" model="PENTAX K2000" supported="no-samples">
 		<ID make="Pentax" model="K2000">Pentax K2000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -12147,7 +12147,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="NX5" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="NX5" supported="no-samples">
 		<ID make="Samsung" model="NX5">Samsung NX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -12168,7 +12168,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="NX10" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="NX10" supported="no-samples">
 		<ID make="Samsung" model="NX10">Samsung NX10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -12190,7 +12190,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="NX11" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="NX11" supported="no-samples">
 		<ID make="Samsung" model="NX11">Samsung NX11</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -12275,7 +12275,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="NX20" decoder_version="2" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="NX20" decoder_version="2" supported="no-samples">
 		<ID make="Samsung" model="NX20">Samsung NX20</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -12338,7 +12338,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="NX2000" decoder_version="3" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="NX2000" decoder_version="3" supported="no-samples">
 		<ID make="Samsung" model="NX2000">Samsung NX2000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -12452,7 +12452,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3" supported="no-samples">
 		<ID make="Samsung" model="EK-GN120">Samsung EK-GN120</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -12906,7 +12906,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A380" supported="no"><!-- no samples -->
+	<Camera make="SONY" model="DSLR-A380" supported="no-samples">
 		<ID make="Sony" model="DSLR-A380">Sony DSLR-A380</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -12996,7 +12996,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A560" supported="no"><!-- no samples -->
+	<Camera make="SONY" model="DSLR-A560" supported="no-samples">
 		<ID make="Sony" model="DSLR-A560">Sony DSLR-A560</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
@@ -14004,7 +14004,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng" supported="no-samples">
 		<ID make="Sinar" model="Hy6">Sinar Hy6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -14043,7 +14043,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="FinePix S6000fd" supported="no"><!-- no samples -->
+	<Camera make="FUJIFILM" model="FinePix S6000fd" supported="no-samples">
 		<ID make="Fujifilm" model="FinePix S6000fd">Fujifilm FinePix S6000fd</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
@@ -14192,7 +14192,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="IS-1" supported="no"><!-- no samples -->
+	<Camera make="FUJIFILM" model="IS-1" supported="no-samples">
 		<ID make="Fujifilm" model="IS-1">Fujifilm IS-1</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
@@ -14439,7 +14439,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="FinePix S9600fd" supported="no"><!-- no samples -->
+	<Camera make="FUJIFILM" model="FinePix S9600fd" supported="no-samples">
 		<ID make="Fujifilm" model="FinePix S9600fd">Fujifilm FinePix S9600fd</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
@@ -14515,7 +14515,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="FinePix HS50EXR" supported="no"><!-- no samples -->
+	<Camera make="FUJIFILM" model="FinePix HS50EXR" supported="no-samples">
 		<ID make="Fujifilm" model="FinePix HS50EXR">Fujifilm FinePix HS50EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -15848,7 +15848,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Minolta Co., Ltd." model="DiMAGE 5" supported="no"><!-- no samples -->
+	<Camera make="Minolta Co., Ltd." model="DiMAGE 5" supported="no-samples">
 		<ID make="Minolta" model="DiMAGE 5">Minolta DiMAGE 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16020,7 +16020,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Creo/Leaf" model="Leaf Aptus 22(LF3779     )/Hasselblad H1" supported="no"><!-- no samples -->
+	<Camera make="Creo/Leaf" model="Leaf Aptus 22(LF3779     )/Hasselblad H1" supported="no-samples">
 		<ID make="Leaf" model="Aptus 22">Leaf Aptus 22</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16092,7 +16092,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Leaf" model="Credo 60" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Credo 60" supported="no-samples">
 		<ID make="Leaf" model="Credo 60">Leaf Credo 60</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16110,7 +16110,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Leaf" model="Credo 80" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Credo 80" supported="no-samples">
 		<ID make="Leaf" model="Credo 80">Leaf Credo 80</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16128,7 +16128,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Leaf" model="Leaf Aptus-II 5(LI300059   )/Mamiya 645 AFD" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf Aptus-II 5(LI300059   )/Mamiya 645 AFD" supported="no-samples">
 		<ID make="Leaf" model="Aptus-II 5">Leaf Aptus-II 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -16146,7 +16146,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Leaf" model="Leaf Aptus-II 8(LI300247   )/Mamiya 645 AFD" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf Aptus-II 8(LI300247   )/Mamiya 645 AFD" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -16156,7 +16156,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15000"/>
 	</Camera>
-	<Camera make="Leaf" model="Leaf AFi-II 7(BT12701    )/Leaf AFi" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf AFi-II 7(BT12701    )/Leaf AFi" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -16166,7 +16166,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15000"/>
 	</Camera>
-	<Camera make="Leaf" model="Leaf Aptus-II 10(LI300019   )/Phase One 645DF" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf Aptus-II 10(LI300019   )/Phase One 645DF" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -16176,7 +16176,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15000"/>
 	</Camera>
-	<Camera make="Leaf" model="Leaf Aptus-II 10R(           )/Large Format" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf Aptus-II 10R(           )/Large Format" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -16186,7 +16186,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15000"/>
 	</Camera>
-	<Camera make="Leaf" model="Leaf Aptus-II 12(LI301306   )/Phase One 645DF/645AF" supported="no"><!-- no samples -->
+	<Camera make="Leaf" model="Leaf Aptus-II 12(LI301306   )/Phase One 645DF/645AF" supported="no-samples">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -16250,7 +16250,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Phase One A/S" model="IQ250" supported="no"><!-- no samples -->
+	<Camera make="Phase One A/S" model="IQ250" supported="no-samples">
 		<ID make="Phase One" model="IQ250">Phase One IQ250</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16448,13 +16448,13 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Eastman Kodak Company" model="Kodak Digital Science DC50 Zoom Camera" supported="no"><!-- no samples -->
+	<Camera make="Eastman Kodak Company" model="Kodak Digital Science DC50 Zoom Camera" supported="no-samples">
 		<ID make="Kodak" model="DC50">Kodak Digital Science DC50 Zoom Camera</ID>
 	</Camera>
-	<Camera make="Eastman Kodak Company" model="Kodak DC120 ZOOM Digital Camera" supported="no"><!-- no samples -->
+	<Camera make="Eastman Kodak Company" model="Kodak DC120 ZOOM Digital Camera" supported="no-samples">
 		<ID make="Kodak" model="DC120">Kodak DC120 ZOOM Digital Camera</ID>
 	</Camera>
-	<Camera make="EASTMAN KODAK COMPANY" model="KODAK EasyShare Z980 Digital Camera" supported="no"><!-- no samples -->
+	<Camera make="EASTMAN KODAK COMPANY" model="KODAK EasyShare Z980 Digital Camera" supported="no-samples">
 		<ID make="Kodak" model="EasyShare Z980">Kodak Z980</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -16808,7 +16808,7 @@
 	<Camera make="PENTAX" model="PENTAX Q7" mode="dng">
 		<ID make="Pentax" model="Q7">PENTAX Q7</ID>
 	</Camera>
-	<Camera make="PENTAX" model="PENTAX Q10" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="PENTAX" model="PENTAX Q10" mode="dng" supported="no-samples">
 		<ID make="Pentax" model="Q10">PENTAX Q10</ID>
 	</Camera>
 	<Camera make="PENTAX RICOH IMAGING" model="PENTAX MX-1" mode="dng">
@@ -16891,19 +16891,19 @@
 	<Camera make="OnePlus" model="One A0001" mode="dng">
 		<ID make="OnePlus" model="One">OnePlus One</ID>
 	</Camera>
-	<Camera make="SAMSUNG DIGITAL IMA" model="SAMSUNG GX20" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG DIGITAL IMA" model="SAMSUNG GX20" mode="dng" supported="no-samples">
 		<ID make="Samsung" model="GX20">Samsung GX20</ID>
 	</Camera>
-	<Camera make="samsung" model="SM-G920F" supported="no"><!-- no samples -->
+	<Camera make="samsung" model="SM-G920F" supported="no-samples">
 		<ID make="Samsung" model="G920F">Samsung G920F</ID>
 	</Camera>
-	<Camera make="samsung" model="SM-G935F" supported="no"><!-- no samples -->
+	<Camera make="samsung" model="SM-G935F" supported="no-samples">
 		<ID make="Samsung" model="G935F">Samsung G935F</ID>
 	</Camera>
-	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX10" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX10" supported="no-samples">
 		<ID make="Samsung" model="GX10">Samsung GX10</ID>
 	</Camera>
-	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX20" supported="no"><!-- no samples -->
+	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX20" supported="no-samples">
 		<ID make="Samsung" model="GX20">Samsung GX20</ID>
 	</Camera>
 	<Camera make="Nokia" model="Lumia 1020" mode="dng">
@@ -16932,10 +16932,10 @@
 	<Camera make="Nikon" model="LS-5000" mode="dng">
 		<ID make="Nikon" model="LS-5000">Nikon LS-5000</ID>
 	</Camera>
-	<Camera make="SIGMA" model="SIGMA DP1" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="SIGMA" model="SIGMA DP1" mode="dng" supported="no-samples">
 		<ID make="Sigma" model="DP1">Sigma DP1</ID>
 	</Camera>
-	<Camera make="SIGMA" model="SIGMA DP1 Merrill" mode="dng" supported="no"><!-- no samples -->
+	<Camera make="SIGMA" model="SIGMA DP1 Merrill" mode="dng" supported="no-samples">
 		<ID make="Sigma" model="DP1 Merrill">Sigma DP1 Merrill</ID>
 	</Camera>
 	<Camera make="LGE" model="Nexus 5X" mode="dng">
@@ -16953,7 +16953,7 @@
 	<Camera make="LG Mobile" model="VS995" mode="dng">
 		<ID make="LG" model="VS995">LG VS995</ID>
 	</Camera>
-	<Camera make="AVT" model="F-080C" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-080C" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -16966,7 +16966,7 @@
 			<Hint name="full_height" value="768"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-145C" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-145C" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -16979,7 +16979,7 @@
 			<Hint name="full_height" value="1040"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-201C" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-201C" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -16992,7 +16992,7 @@
 			<Hint name="full_height" value="1200"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-510C" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-510C" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17005,7 +17005,7 @@
 			<Hint name="full_height" value="1958"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-510C" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-510C" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17019,7 +17019,7 @@
 			<Hint name="offset" value="12"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-510C" mode="chdk-c" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-510C" mode="chdk-c" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17032,7 +17032,7 @@
 			<Hint name="full_height" value="1958"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-510C" mode="chdk-d" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-510C" mode="chdk-d" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17046,7 +17046,7 @@
 			<Hint name="offset" value="12"/>
 		</Hints>
 	</Camera>
-	<Camera make="AVT" model="F-810C" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="AVT" model="F-810C" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17059,7 +17059,7 @@
 			<Hint name="full_height" value="2469"/>
 		</Hints>
 	</Camera>
-	<Camera make="AgfaPhoto" model="DC-833m" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="AgfaPhoto" model="DC-833m" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -17072,7 +17072,7 @@
 			<Hint name="full_height" value="2448"/>
 		</Hints>
 	</Camera>
-	<Camera make="Alcatel" model="5035D" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Alcatel" model="5035D" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -17085,7 +17085,7 @@
 			<Hint name="full_height" value="1902"/>
 		</Hints>
 	</Camera>
-	<Camera make="Baumer" model="TXG14" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Baumer" model="TXG14" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -17099,7 +17099,7 @@
 			<Hint name="offset" value="1078"/>
 		</Hints>
 	</Camera>
-	<Camera make="Canon" model="PowerShot SD300" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="PowerShot SD300" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17112,7 +17112,7 @@
 			<Hint name="full_height" value="1766"/>
 		</Hints>
 	</Camera>
-	<Camera make="Canon" model="PowerShot A460" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="PowerShot A460" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17148,7 +17148,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Canon" model="PowerShot A530" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="PowerShot A530" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17215,7 +17215,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Canon" model="PowerShot A470" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="PowerShot A470" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -17350,7 +17350,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Canon" model="PowerShot SX120 IS" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Canon" model="PowerShot SX120 IS" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17415,7 +17415,7 @@
 			<Hint name="full_height" value="3504"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-2000UX" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-2000UX" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17428,7 +17428,7 @@
 			<Hint name="full_height" value="1211"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-3*00EX" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-3*00EX" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17441,7 +17441,7 @@
 			<Hint name="full_height" value="1547"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-5700" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-5700" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17454,7 +17454,7 @@
 			<Hint name="full_height" value="1924"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z60" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z60" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -17467,7 +17467,7 @@
 			<Hint name="full_height" value="2181"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-S20" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-S20" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17480,7 +17480,7 @@
 			<Hint name="full_height" value="1208"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-S100" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-S100" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17493,7 +17493,7 @@
 			<Hint name="full_height" value="1578"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-R41" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-R41" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17506,7 +17506,7 @@
 			<Hint name="full_height" value="1720"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-P505" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-P505" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17519,7 +17519,7 @@
 			<Hint name="full_height" value="1928"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-R51" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-R51" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17532,7 +17532,7 @@
 			<Hint name="full_height" value="1929"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z50" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z50" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17545,7 +17545,7 @@
 			<Hint name="full_height" value="1932"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z500" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z500" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -17558,7 +17558,7 @@
 			<Hint name="full_height" value="1937"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z55" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z55" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17571,7 +17571,7 @@
 			<Hint name="full_height" value="1986"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-P600" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-P600" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17584,7 +17584,7 @@
 			<Hint name="full_height" value="2172"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z750" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z750" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17597,7 +17597,7 @@
 			<Hint name="full_height" value="2319"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z75" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z75" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17610,7 +17610,7 @@
 			<Hint name="full_height" value="2321"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-P700" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-P700" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17623,7 +17623,7 @@
 			<Hint name="full_height" value="2350"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z850" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z850" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17636,7 +17636,7 @@
 			<Hint name="full_height" value="2498"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z8" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z8" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17649,7 +17649,7 @@
 			<Hint name="full_height" value="2502"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-Z1050" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-Z1050" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17662,7 +17662,7 @@
 			<Hint name="full_height" value="2752"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="EX-ZR100" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="EX-ZR100" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17675,7 +17675,7 @@
 			<Hint name="full_height" value="3044"/>
 		</Hints>
 	</Camera>
-	<Camera make="Casio" model="QV-4000" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Casio" model="QV-4000" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17688,7 +17688,7 @@
 			<Hint name="full_height" value="1700"/>
 		</Hints>
 	</Camera>
-	<Camera make="Creative" model="PC-CAM 600" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Creative" model="PC-CAM 600" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -17701,7 +17701,7 @@
 			<Hint name="full_height" value="769"/>
 		</Hints>
 	</Camera>
-	<Camera make="DJI" model="" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="DJI" model="" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -17714,7 +17714,7 @@
 			<Hint name="full_height" value="3288"/>
 		</Hints>
 	</Camera>
-	<Camera make="Matrix" model="" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Matrix" model="" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17727,7 +17727,7 @@
 			<Hint name="full_height" value="3288"/>
 		</Hints>
 	</Camera>
-	<Camera make="Foculus" model="531C" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Foculus" model="531C" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -17740,7 +17740,7 @@
 			<Hint name="full_height" value="1200"/>
 		</Hints>
 	</Camera>
-	<Camera make="Generic" model="" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Generic" model="" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17753,7 +17753,7 @@
 			<Hint name="full_height" value="480"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="DC20" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="DC20" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17766,7 +17766,7 @@
 			<Hint name="full_height" value="244"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="DC20" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="DC20" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17779,7 +17779,7 @@
 			<Hint name="full_height" value="244"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="DCS200" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="DCS200" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -17792,7 +17792,7 @@
 			<Hint name="full_height" value="1076"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="C330" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="C330" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17805,7 +17805,7 @@
 			<Hint name="full_height" value="1779"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="C330" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="C330" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17900,7 +17900,7 @@
 			<Hint name="full_height" value="3000"/>
 		</Hints>
 	</Camera>
-	<Camera make="Kodak" model="KAI-0340" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Kodak" model="KAI-0340" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -17913,7 +17913,7 @@
 			<Hint name="full_height" value="480"/>
 		</Hints>
 	</Camera>
-	<Camera make="Micron" model="2010" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Micron" model="2010" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -17948,7 +17948,7 @@
 			<Hint name="offset" value="513"/>
 		</Hints>
 	</Camera>
-	<Camera make="Nikon" model="E900" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E900" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -17961,7 +17961,7 @@
 			<Hint name="full_height" value="969"/>
 		</Hints>
 	</Camera>
-	<Camera make="Nikon" model="E950" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E950" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -17982,7 +17982,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Nikon" model="E2100" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E2100" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18002,7 +18002,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Nikon" model="E990" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E990" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18015,7 +18015,7 @@
 			<Hint name="full_height" value="1541"/>
 		</Hints>
 	</Camera>
-	<Camera make="Nikon" model="E3700" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E3700" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18028,7 +18028,7 @@
 			<Hint name="full_height" value="1542"/>
 		</Hints>
 	</Camera>
-	<Camera make="Nikon" model="E4500" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E4500" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18069,7 +18069,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Nikon" model="E5000" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="E5000" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18090,7 +18090,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Nikon" model="COOLPIX S6" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Nikon" model="COOLPIX S6" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18103,7 +18103,7 @@
 			<Hint name="full_height" value="2118"/>
 		</Hints>
 	</Camera>
-	<Camera make="Olympus" model="C770UZ" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Olympus" model="C770UZ" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -18116,7 +18116,7 @@
 			<Hint name="full_height" value="1718"/>
 		</Hints>
 	</Camera>
-	<Camera make="Pentax" model="Optio S" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Pentax" model="Optio S" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18129,7 +18129,7 @@
 			<Hint name="full_height" value="1540"/>
 		</Hints>
 	</Camera>
-	<Camera make="Pentax" model="Optio S" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Pentax" model="Optio S" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18155,7 +18155,7 @@
 			<Hint name="full_height" value="1737"/>
 		</Hints>
 	</Camera>
-	<Camera make="Pentax" model="Optio 750Z" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Pentax" model="Optio 750Z" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18168,7 +18168,7 @@
 			<Hint name="full_height" value="2322"/>
 		</Hints>
 	</Camera>
-	<Camera make="Pixelink" model="A782" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="Pixelink" model="A782" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18181,7 +18181,7 @@
 			<Hint name="full_height" value="3000"/>
 		</Hints>
 	</Camera>
-	<Camera make="RoverShot" model="3320AF" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="RoverShot" model="3320AF" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18194,7 +18194,7 @@
 			<Hint name="full_height" value="1536"/>
 		</Hints>
 	</Camera>
-	<Camera make="ST Micro" model="STV680 VGA" mode="chdk" supported="no"><!-- no samples -->
+	<Camera make="ST Micro" model="STV680 VGA" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">BG</ColorRow>
 			<ColorRow y="1">GR</ColorRow>
@@ -18207,7 +18207,7 @@
 			<Hint name="full_height" value="484"/>
 		</Hints>
 	</Camera>
-	<Camera make="Samsung" model="S85" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Samsung" model="S85" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18227,7 +18227,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Samsung" model="S85" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Samsung" model="S85" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -18273,7 +18273,7 @@
 			<Hint name="full_height" value="3000"/>
 		</Hints>
 	</Camera>
-	<Camera make="Sinar" model="" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Sinar" model="" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18287,7 +18287,7 @@
 			<Hint name="offset" value="68"/>
 		</Hints>
 	</Camera>
-	<Camera make="Sinar" model="" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Sinar" model="" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18301,7 +18301,7 @@
 			<Hint name="offset" value="68"/>
 		</Hints>
 	</Camera>
-	<Camera make="Sinar" model="" mode="chdk-c" supported="no"><!-- no samples -->
+	<Camera make="Sinar" model="" mode="chdk-c" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -18315,7 +18315,7 @@
 			<Hint name="offset" value="68"/>
 		</Hints>
 	</Camera>
-	<Camera make="Sony" model="XCD-SX910CR" mode="chdk-a" supported="no"><!-- no samples -->
+	<Camera make="Sony" model="XCD-SX910CR" mode="chdk-a" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>
@@ -18328,7 +18328,7 @@
 			<Hint name="full_height" value="1024"/>
 		</Hints>
 	</Camera>
-	<Camera make="Sony" model="XCD-SX910CR" mode="chdk-b" supported="no"><!-- no samples -->
+	<Camera make="Sony" model="XCD-SX910CR" mode="chdk-b" supported="no-samples">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GR</ColorRow>
 			<ColorRow y="1">BG</ColorRow>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -511,10 +511,11 @@
   </xs:simpleType>
   <xs:simpleType name="CameraTypeSupportedType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="no"/>
+      <xs:pattern value="(no|no-samples)"/>
       <xs:minLength value="2"/>
-      <xs:maxLength value="2"/>
+      <xs:maxLength value="10"/>
       <xs:enumeration value="no"/>
+      <xs:enumeration value="no-samples"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="CameraType">

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -173,8 +173,20 @@ bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
     return false;
   }
 
-  if (!cam->supported)
+  switch (cam->supportStatus) {
+  case Camera::SupportStatus::Supported:
+    break; // Yay us!
+  case Camera::SupportStatus::Unsupported:
     ThrowRDE("Camera not supported (explicit). Sorry.");
+  case Camera::SupportStatus::NoSamples:
+    noSamples = true;
+    writeLog(DEBUG_PRIO::WARNING,
+             "Camera support status is unknown: '%s' '%s' '%s'\n"
+             "Please consider providing samples on <https://raw.pixls.us/> "
+             "if you wish for the support to not be discontinued, thanks!",
+             make.c_str(), model.c_str(), mode.c_str());
+    break; // WYSIWYG.
+  }
 
   if (cam->decoderVersion > getDecoderVersion())
     ThrowRDE("Camera not supported in this version. Update RawSpeed for support.");

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -109,6 +109,10 @@ public:
     explicit operator bool() const { return quadrantMultipliers /*|| ...*/; }
   } iiq;
 
+  // Indicate if the cameras.xml says that the camera support status is unknown
+  // due to the lack of RPU samples
+  bool noSamples = false;
+
 protected:
   /* Attempt to decode the image */
   /* A RawDecoderException will be thrown if the image cannot be decoded, */

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -55,8 +55,16 @@ Camera::Camera(const pugi::xml_node& camera) : cfa(iPoint2D(0, 0)) {
 
   canonical_id = make + " " + model;
 
-  supported =
-      camera.attribute("supported").as_string("yes") == std::string("yes");
+  supportStatus = [&camera]() {
+    const std::string_view v = camera.attribute("supported").as_string("yes");
+    if (v == "yes")
+      return Camera::SupportStatus::Supported;
+    if (v == "no")
+      return Camera::SupportStatus::Unsupported;
+    if (v == "no-samples")
+      return Camera::SupportStatus::NoSamples;
+    ThrowCME("Attribute 'supported' has unknown value.");
+  }();
   mode = camera.attribute("mode").as_string("");
   decoderVersion = camera.attribute("decoder_version").as_int(0);
 

--- a/src/librawspeed/metadata/Camera.h
+++ b/src/librawspeed/metadata/Camera.h
@@ -77,6 +77,12 @@ public:
 class Camera
 {
 public:
+  enum class SupportStatus {
+    Unsupported,
+    Supported,
+    NoSamples,
+  };
+
 #ifdef HAVE_PUGIXML
   explicit Camera(const pugi::xml_node& camera);
 #endif
@@ -93,7 +99,7 @@ public:
   std::vector<std::string> aliases;
   std::vector<std::string> canonical_aliases;
   ColorFilterArray cfa;
-  bool supported;
+  SupportStatus supportStatus;
   iPoint2D cropSize;
   iPoint2D cropPos;
   std::vector<BlackArea> blackAreas;

--- a/src/librawspeed/metadata/CameraMetaData.cpp
+++ b/src/librawspeed/metadata/CameraMetaData.cpp
@@ -149,7 +149,7 @@ const Camera* CameraMetaData::addCamera(std::unique_ptr<Camera> cam) {
 void CameraMetaData::disableMake(std::string_view make) const {
   for (const auto& cam : cameras) {
     if (cam.second->make == make)
-      cam.second->supported = false;
+      cam.second->supportStatus = Camera::SupportStatus::Unsupported;
   }
 }
 
@@ -157,7 +157,7 @@ void CameraMetaData::disableCamera(std::string_view make,
                                    std::string_view model) const {
   for (const auto& cam : cameras) {
     if (cam.second->make == make && cam.second->model == model)
-      cam.second->supported = false;
+      cam.second->supportStatus = Camera::SupportStatus::Unsupported;
   }
 }
 

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -152,9 +152,11 @@ APPEND(ostringstream* oss, const char* format, ...) {
   *oss << line.data();
 }
 
-std::string img_hash(const RawImage& r) {
+std::string img_hash(const RawImage& r, bool noSamples) {
   ostringstream oss;
 
+  if (noSamples)
+    APPEND(&oss, "camera support status is unknown due to lack of samples\n");
   APPEND(&oss, "make: %s\n", r->metadata.make.c_str());
   APPEND(&oss, "model: %s\n", r->metadata.model.c_str());
   APPEND(&oss, "mode: %s\n", r->metadata.mode.c_str());
@@ -363,6 +365,7 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
 
   decoder->failOnUnknown = false;
   decoder->checkSupport(metadata);
+  bool noSamples = decoder->noSamples;
 
   decoder->decodeRaw();
   decoder->decodeMetaData(metadata);
@@ -382,12 +385,12 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
   if (o.create) {
     // write the hash. if force is set, then we are potentially overwriting here
     ofstream f(hashfile);
-    f << img_hash(raw);
+    f << img_hash(raw, noSamples);
     if (o.dump)
       writeImage(raw, filename);
   } else {
     // do generate the hash string regardless.
-    std::string h = img_hash(raw);
+    std::string h = img_hash(raw, noSamples);
 
     // normally, here we would compare the old hash with the new one
     // but if the force is set, and the hash does not exist, do nothing.


### PR DESCRIPTION
To be reverted in December 2022 (~+11 months from the date of this commit),
see https://github.com/darktable-org/rawspeed/issues/335#issuecomment-1008349986

