### PR TITLE
add cosmetic support for Leica M246

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -16823,6 +16823,9 @@
 	<Camera make="Leica Camera AG" model="LEICA M (Typ 240)" mode="dng">
 		<ID make="Leica" model="M (Typ 240)">LEICA M (Typ 240)</ID>
 	</Camera>
+	<Camera make="Leica Camera AG" model="LEICA M MONOCHROM (Typ 246)" mode="dng">
+		<ID make="Leica" model="M Monochrom (Typ 246)">LEICA M MONOCHROM (Typ 246)</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X2" mode="dng">
 		<ID make="Leica" model="X2">LEICA X2</ID>
 		<ColorMatrices>


### PR DESCRIPTION
Metadata for the M246 looks very similar to that for the M240 (the Typ 246 is the monochrome version).