### PR TITLE
Update compiler-warnings-gcc.cmake

### DIFF
--- a/cmake/compiler-warnings-gcc.cmake
+++ b/cmake/compiler-warnings-gcc.cmake
@@ -13,7 +13,7 @@ set (GCC_WARNING_FLAGS
   "extra-semi"
   "format=2"
 #  "missing-prototypes"
-  "old-style-casts"
+  "old-style-cast"
   "pointer-arith"
 #  "strict-prototypes"
 #  "suggest-attribute=const"


### PR DESCRIPTION
typo mistake, I assume. Option old-stlyle-casts doesn't exit. It should rather be old-style-cast