### PR TITLE
remove misspelled flag

### DIFF
--- a/cmake/compiler-warnings-gcc.cmake
+++ b/cmake/compiler-warnings-gcc.cmake
@@ -13,7 +13,6 @@ set (GCC_WARNING_FLAGS
   "extra-semi"
   "format=2"
 #  "missing-prototypes"
-  "old-style-casts"
   "pointer-arith"
 #  "strict-prototypes"
 #  "suggest-attribute=const"


### PR DESCRIPTION
Based on https://github.com/darktable-org/rawspeed/pull/344 , remove misspelled old-style-cast flag instead of correcting its spelling.