### PR TITLE
[ARW] Fix incorrect white levels and black levels on high iso

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13527,7 +13527,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-10" height="0"/>
-		<Sensor black="512" white="16383"/>
+		<Sensor black="512" white="15360"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">7460 -2365 -588</ColorMatrixRow>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13527,7 +13527,8 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-10" height="0"/>
-		<Sensor black="512" white="15360"/>
+		<Sensor black="512" white="15360" iso_max="80000"/>
+		<Sensor black="1024" white="15360" iso_min="102400"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">7460 -2365 -588</ColorMatrixRow>


### PR DESCRIPTION
While trying to debug this: https://github.com/darktable-org/darktable/issues/11323
I realized black level values change starting from ISO-102400 until max ISO, applying 1024 prevents blowing out all channels and restores a proper image interpretation as far as I can tell.

While checking the "Black level" and "White level" fields extracted from exiftool on all my raw files, I also noticed metadata always mentions white level values of 15360 instead of the current 16283 value, so I added another commit to address this.
Feel free to discard that second commit if there was a good reason to use 16283 instead ;)