### PR TITLE
Support for multiframe DNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cscope.out
 *.vcproj
 *.vcxproj
 .vscode/
+CMakeLists.txt.user
 
 # Compiled Object files
 *.slo

--- a/fuzz/librawspeed/decompressors/Cr2Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/Cr2Decompressor.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     using slice_type = uint16_t;
     const auto numSlices = bs.get<slice_type>();
@@ -48,7 +48,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
 
     const rawspeed::Cr2Slicing slicing(numSlices, sliceWidth, lastSliceWidth);
 
-    rawspeed::Cr2Decompressor c(bs, mRaw);
+    rawspeed::Cr2Decompressor c(bs, mRaw.get());
     mRaw->createData();
     c.decode(slicing);
 

--- a/fuzz/librawspeed/decompressors/CrwDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/CrwDecompressor.cpp
@@ -39,12 +39,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const uint32_t dec_table = bs.getU32();
     const uint32_t lowbits = bs.getU32();
 
-    rawspeed::CrwDecompressor c(mRaw, dec_table, lowbits,
+    rawspeed::CrwDecompressor c(mRaw.get(), dec_table, lowbits,
                                 bs.getStream(bs.getRemainSize()));
     mRaw->createData();
     c.decompress();

--- a/fuzz/librawspeed/decompressors/DummyLJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/DummyLJpegDecompressor.cpp
@@ -39,7 +39,7 @@ class DummyLJpegDecompressor final
 
 public:
   DummyLJpegDecompressor(const rawspeed::ByteStream& bs,
-                         const rawspeed::RawImage& img)
+                         rawspeed::RawImageData* img)
       : AbstractLJpegDecompressor(bs, img) {}
 
   void decode() { AbstractLJpegDecompressor::decode(); }
@@ -55,9 +55,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
-    DummyLJpegDecompressor d(bs, mRaw);
+    DummyLJpegDecompressor d(bs, mRaw.get());
     d.decode();
     mRaw->createData();
 

--- a/fuzz/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/FujiDecompressor.cpp
@@ -39,10 +39,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
     mRaw->cfa = CreateCFA(bs);
 
-    rawspeed::FujiDecompressor f(mRaw, bs.getStream(bs.getRemainSize()));
+    rawspeed::FujiDecompressor f(mRaw.get(), bs.getStream(bs.getRemainSize()));
     mRaw->createData();
     f.decompress();
 

--- a/fuzz/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -39,11 +39,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto pixelBaseOffset = bs.get<int>();
 
-    rawspeed::HasselbladDecompressor h(bs, mRaw);
+    rawspeed::HasselbladDecompressor h(bs, mRaw.get());
     mRaw->createData();
     h.decode(pixelBaseOffset);
 

--- a/fuzz/librawspeed/decompressors/KodakDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/KodakDecompressor.cpp
@@ -39,13 +39,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const bool bps = bs.getU32();
     const bool uncorrectedRawValues = bs.getU32();
 
-    rawspeed::KodakDecompressor k(mRaw, bs.getStream(bs.getRemainSize()), bps,
-                                  uncorrectedRawValues);
+    rawspeed::KodakDecompressor k(mRaw.get(), bs.getStream(bs.getRemainSize()),
+                                  bps, uncorrectedRawValues);
 
     mRaw->createData();
 

--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto offsetX = bs.getU32();
     const auto offsetY = bs.getU32();
@@ -47,7 +47,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const auto height = bs.getU32();
     const auto fixDng16Bug = bs.getU32();
 
-    rawspeed::LJpegDecompressor j(bs, mRaw);
+    rawspeed::LJpegDecompressor j(bs, mRaw.get());
     mRaw->createData();
     j.decode(offsetX, offsetY, width, height, fixDng16Bug);
 

--- a/fuzz/librawspeed/decompressors/NikonDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/NikonDecompressor.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto bitsPS = bs.get<uint32_t>();
     const auto uncorrectedRawValues = bs.get<uint32_t>();
@@ -47,7 +47,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     rawspeed::ByteStream metaData = bs.getStream(medataLength);
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::NikonDecompressor n(mRaw, metaData, bitsPS);
+    rawspeed::NikonDecompressor n(mRaw.get(), metaData, bitsPS);
     mRaw->createData();
     n.decompress(rawData, uncorrectedRawValues);
 

--- a/fuzz/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -39,9 +39,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
-    rawspeed::OlympusDecompressor o(mRaw);
+    rawspeed::OlympusDecompressor o(mRaw.get());
 
     mRaw->createData();
 

--- a/fuzz/librawspeed/decompressors/PanasonicV4Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PanasonicV4Decompressor.cpp
@@ -39,13 +39,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto zero_is_not_bad = bs.get<uint32_t>();
     const auto section_split_offset = bs.get<uint32_t>();
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::PanasonicV4Decompressor p(mRaw, rawData, zero_is_not_bad,
+    rawspeed::PanasonicV4Decompressor p(mRaw.get(), rawData, zero_is_not_bad,
                                         section_split_offset);
     mRaw->createData();
     p.decompress();

--- a/fuzz/librawspeed/decompressors/PanasonicV5Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PanasonicV5Decompressor.cpp
@@ -38,12 +38,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto bps = bs.get<uint32_t>();
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::PanasonicV5Decompressor p(mRaw, rawData, bps);
+    rawspeed::PanasonicV5Decompressor p(mRaw.get(), rawData, bps);
     mRaw->createData();
     p.decompress();
 

--- a/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -39,11 +39,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::PanasonicV6Decompressor p(mRaw, rawData);
+    rawspeed::PanasonicV6Decompressor p(mRaw.get(), rawData);
     mRaw->createData();
     p.decompress();
 

--- a/fuzz/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     std::optional<rawspeed::ByteStream> metaData;
 
@@ -51,7 +51,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
 
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::PentaxDecompressor p(mRaw, metaData);
+    rawspeed::PentaxDecompressor p(mRaw.get(), metaData);
     mRaw->createData();
     p.decompress(rawData);
 

--- a/fuzz/librawspeed/decompressors/PhaseOneDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PhaseOneDecompressor.cpp
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto numStrips = bs.getU32();
     std::vector<rawspeed::PhaseOneStrip> strips;
@@ -53,7 +53,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
                     });
     assert(strips.size() == numStrips);
 
-    rawspeed::PhaseOneDecompressor f(mRaw, std::move(strips));
+    rawspeed::PhaseOneDecompressor f(mRaw.get(), std::move(strips));
     mRaw->createData();
     f.decompress();
 

--- a/fuzz/librawspeed/decompressors/SamsungV0Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/SamsungV0Decompressor.cpp
@@ -39,13 +39,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto bsoLength = bs.get<uint32_t>();
     rawspeed::ByteStream bso = bs.getStream(bsoLength);
     rawspeed::ByteStream bsr = bs.getStream(bs.getRemainSize());
 
-    rawspeed::SamsungV0Decompressor p(mRaw, bso, bsr);
+    rawspeed::SamsungV0Decompressor p(mRaw.get(), bso, bsr);
     mRaw->createData();
     p.decompress();
 

--- a/fuzz/librawspeed/decompressors/SamsungV1Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/SamsungV1Decompressor.cpp
@@ -39,12 +39,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto bit = bs.get<uint32_t>();
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::SamsungV1Decompressor p(mRaw, rawData, bit);
+    rawspeed::SamsungV1Decompressor p(mRaw.get(), rawData, bit);
     mRaw->createData();
     p.decompress();
 

--- a/fuzz/librawspeed/decompressors/SamsungV2Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/SamsungV2Decompressor.cpp
@@ -39,12 +39,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
     const auto bit = bs.get<uint32_t>();
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::SamsungV2Decompressor p(mRaw, rawData, bit);
+    rawspeed::SamsungV2Decompressor p(mRaw.get(), rawData, bit);
     mRaw->createData();
     p.decompress();
 

--- a/fuzz/librawspeed/decompressors/SonyArw1Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/SonyArw1Decompressor.cpp
@@ -39,9 +39,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
-    rawspeed::SonyArw1Decompressor a(mRaw);
+    rawspeed::SonyArw1Decompressor a(mRaw.get());
 
     mRaw->createData();
 

--- a/fuzz/librawspeed/decompressors/SonyArw2Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/SonyArw2Decompressor.cpp
@@ -39,9 +39,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
 
-    rawspeed::SonyArw2Decompressor a(mRaw, bs.getStream(bs.getRemainSize()));
+    rawspeed::SonyArw2Decompressor a(mRaw.get(), bs.getStream(bs.getRemainSize()));
 
     mRaw->createData();
 

--- a/fuzz/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/VC5Decompressor.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const rawspeed::DataBuffer db(b, rawspeed::Endianness::little);
     rawspeed::ByteStream bs(db);
 
-    rawspeed::RawImage mRaw(CreateRawImage(bs));
+    auto mRaw(CreateRawImage(bs));
     mRaw->whitePoint = bs.getI32();
 
     const auto offsetX = bs.getU32();
@@ -47,7 +47,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const auto width = bs.getU32();
     const auto height = bs.getU32();
 
-    rawspeed::VC5Decompressor v(bs, mRaw);
+    rawspeed::VC5Decompressor v(bs, mRaw.get());
     mRaw->createData();
     v.decode(offsetX, offsetY, width, height);
 

--- a/fuzz/librawspeed/fuzz/Common.cpp
+++ b/fuzz/librawspeed/fuzz/Common.cpp
@@ -29,7 +29,7 @@
 #include <cstdint>                     // for uint32_t
 #include <limits>                      // for numeric_limits
 
-rawspeed::RawImage CreateRawImage(rawspeed::ByteStream& bs) {
+std::shared_ptr<rawspeed::RawImageData> CreateRawImage(rawspeed::ByteStream& bs) {
   const uint32_t width = bs.getU32();
   const uint32_t height = bs.getU32();
   const uint32_t type = bs.getU32();
@@ -40,8 +40,16 @@ rawspeed::RawImage CreateRawImage(rawspeed::ByteStream& bs) {
       type != static_cast<uint32_t>(rawspeed::RawImageType::F32))
     ThrowRSE("Unknown image type: %u", type);
 
-  rawspeed::RawImage mRaw(
-      rawspeed::RawImage::create(static_cast<rawspeed::RawImageType>(type)));
+  /*rawspeed::RawImage mRaw(
+      rawspeed::RawImage::create(static_cast<rawspeed::RawImageType>(type)));*/
+  std::shared_ptr<rawspeed::RawImageData> mRaw;
+
+  if(type != static_cast<uint32_t>(rawspeed::RawImageType::UINT16))
+    mRaw = std::make_shared<rawspeed::RawImageDataU16>();
+
+  if(type != static_cast<uint32_t>(rawspeed::RawImageType::F32))
+    mRaw = std::make_shared<rawspeed::RawImageDataFloat>();
+
 
   mRaw->dim =
       rawspeed::iPoint2D(static_cast<rawspeed::iPoint2D::value_type>(width),

--- a/fuzz/librawspeed/fuzz/Common.h
+++ b/fuzz/librawspeed/fuzz/Common.h
@@ -27,5 +27,5 @@ namespace rawspeed {
 class ByteStream;
 } // namespace rawspeed
 
-rawspeed::RawImage CreateRawImage(rawspeed::ByteStream& bs);
+std::shared_ptr<rawspeed::RawImageData> CreateRawImage(rawspeed::ByteStream& bs);
 rawspeed::ColorFilterArray CreateCFA(rawspeed::ByteStream& bs);

--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -81,7 +81,10 @@ public:
 
   void apply(RawImageData* ri) override {
     MutexLocker guard(&ri->mBadPixelMutex);
-    const CroppedArray2DRef<uint16_t> img(ri->getU16DataAsCroppedArray2DRef());
+    auto rawU16 = dynamic_cast<RawImageDataU16*>(ri);
+    assert(rawU16);
+    const CroppedArray2DRef<uint16_t> img(
+        rawU16->getU16DataAsCroppedArray2DRef());
     iPoint2D crop = ri->getCropOffset();
     uint32_t offset = crop.x | (crop.y << 16);
     for (auto row = 0; row < img.croppedHeight; ++row) {

--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -81,7 +81,7 @@ public:
 
   void apply(RawImageData* ri) override {
     MutexLocker guard(&ri->mBadPixelMutex);
-    auto rawU16 = dynamic_cast<RawImageDataU16*>(ri);
+    auto *rawU16 = dynamic_cast<RawImageDataU16*>(ri);
     assert(rawU16);
     const CroppedArray2DRef<uint16_t> img(
         rawU16->getU16DataAsCroppedArray2DRef());

--- a/src/librawspeed/common/DngOpcodes.h
+++ b/src/librawspeed/common/DngOpcodes.h
@@ -29,7 +29,7 @@
 
 namespace rawspeed {
 
-class RawImage;
+class RawImageData;
 
 class TiffEntry;
 
@@ -38,9 +38,9 @@ class ByteStream;
 class DngOpcodes
 {
 public:
-  DngOpcodes(const RawImage& ri, const TiffEntry* entry);
+  DngOpcodes(RawImageData* ri, const TiffEntry* entry);
   ~DngOpcodes();
-  void applyOpCodes(const RawImage& ri) const;
+  void applyOpCodes(RawImageData* ri) const;
 
 private:
   class DngOpcode;
@@ -62,10 +62,10 @@ protected:
   template <typename S> class ScalePerRowOrCol;
 
   template <class Opcode>
-  static std::unique_ptr<DngOpcode> constructor(const RawImage& ri,
+  static std::unique_ptr<DngOpcode> constructor(RawImageData* ri,
                                                 ByteStream& bs);
 
-  using constructor_t = std::unique_ptr<DngOpcode> (*)(const RawImage& ri,
+  using constructor_t = std::unique_ptr<DngOpcode> (*)(RawImageData* ri,
                                                        ByteStream& bs);
   static const std::map<uint32_t, std::pair<const char*, constructor_t>> Map;
 };

--- a/src/librawspeed/common/RawImage.cpp
+++ b/src/librawspeed/common/RawImage.cpp
@@ -280,16 +280,6 @@ void RawImageData::createBadPixelMap()
     ThrowRDE("Memory Allocation failed.");
 }
 
-RawImage::RawImage(RawImageData* p) : p_(p) {
-
-}
-
-RawImage::RawImage(const RawImage& p) : p_(p.p_) {
-
-}
-
-
-
 void RawImageData::transferBadPixelsToMap()
 {
   MutexLocker guard(&mBadPixelMutex);
@@ -413,7 +403,7 @@ void RawImageData::fixBadPixelsThread(int start_y, int end_y) {
   }
 }
 
-void RawImageData::blitFrom(const RawImage& src, const iPoint2D& srcPos,
+void RawImageData::blitFrom(RawImageData* src, const iPoint2D& srcPos,
                             const iPoint2D& size, const iPoint2D& destPos) {
   iRectangle2D src_rect(srcPos, size);
   iRectangle2D dest_rect(destPos, size);
@@ -486,25 +476,6 @@ void RawImageData::clearArea(iRectangle2D area, uint8_t val /*= 0*/) {
   for (int y = area.getTop(); y < area.getBottom(); y++)
     memset(getData(area.getLeft(), y), val,
            static_cast<size_t>(area.getWidth()) * bpp);
-}
-
-RawImage& RawImage::operator=(RawImage&& rhs) noexcept {
-  if (this == &rhs)
-    return *this;
-
-  std::swap(p_, rhs.p_);
-
-  return *this;
-}
-
-RawImage& RawImage::operator=(const RawImage& rhs) noexcept {
-  if (this == &rhs)
-    return *this;
-
-  RawImage tmp(rhs);
-  *this = std::move(tmp);
-
-  return *this;
 }
 
 RawImageWorker::RawImageWorker(RawImageData* _img, RawImageWorkerTask _task,

--- a/src/librawspeed/common/RawImage.cpp
+++ b/src/librawspeed/common/RawImage.cpp
@@ -57,7 +57,6 @@ RawImageData::RawImageData(const iPoint2D& _dim, int _bpc, int _cpp)
 }
 
 RawImageData::~RawImageData() {
-  assert(dataRefCount == 0);
   mOffset = iPoint2D(0, 0);
 
   destroyData();
@@ -282,28 +281,14 @@ void RawImageData::createBadPixelMap()
 }
 
 RawImage::RawImage(RawImageData* p) : p_(p) {
-  MutexLocker guard(&p_->mymutex);
-  ++p_->dataRefCount;
+
 }
 
 RawImage::RawImage(const RawImage& p) : p_(p.p_) {
-  MutexLocker guard(&p_->mymutex);
-  ++p_->dataRefCount;
+
 }
 
-RawImage::~RawImage() {
-  p_->mymutex.Lock();
 
-  --p_->dataRefCount;
-
-  if (p_->dataRefCount == 0) {
-    p_->mymutex.Unlock();
-    delete p_;
-    return;
-  }
-
-  p_->mymutex.Unlock();
-}
 
 void RawImageData::transferBadPixelsToMap()
 {

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -228,7 +228,6 @@ public:
   using storage_t = std::vector<frame_ptr_t>;
   using const_iterator = storage_t::const_iterator;
 
-public:
   [[nodiscard]] std::shared_ptr<RawImageData>
   get(storage_t::size_type pos) const {
     return data.at(pos);

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -172,8 +172,6 @@ public:
   Mutex mBadPixelMutex; // Mutex for 'mBadPixelPositions, must be used if more
                         // than 1 thread is accessing vector
 
-private:
-  uint32_t dataRefCount GUARDED_BY(mymutex) = 0;
 
 protected:
   RawImageType dataType;
@@ -191,7 +189,6 @@ protected:
   iPoint2D mOffset;
   iPoint2D uncropped_dim;
   std::unique_ptr<TableLookUp> table;
-  Mutex mymutex;
 };
 
 class RawImageDataU16 final : public RawImageData {
@@ -235,17 +232,16 @@ private:
    static RawImage create(const iPoint2D& dim,
                           RawImageType type = RawImageType::UINT16,
                           uint32_t componentsPerPixel = 1);
-   RawImageData* operator->() const { return p_; }
-   RawImageData& operator*() const { return *p_; }
+   RawImageData* operator->() const { return p_.operator->(); }
+   RawImageData& operator*() const { return p_.operator*(); }
    explicit RawImage(RawImageData* p); // p must not be NULL
-   ~RawImage();
    RawImage(const RawImage& p);
    RawImage& operator=(const RawImage& p) noexcept;
    RawImage& operator=(RawImage&& p) noexcept;
 
-   RawImageData* get() { return p_; }
+   RawImageData* get() { return p_.get(); }
  private:
-   RawImageData* p_;    // p_ is never NULL
+   std::shared_ptr<RawImageData> p_;    // p_ is never NULL
  };
 
 inline RawImage RawImage::create(RawImageType type)  {

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -224,13 +224,11 @@ private:
   friend class RawImage;
 };
 
-class RawImageAbstract
-{
-
-};
-
 class RawImage {
-  using storage_t = std::vector<std::shared_ptr<RawImageData>>;
+public:
+  using frame_ptr_t = std::shared_ptr<RawImageData>;
+  using storage_t = std::vector<frame_ptr_t>;
+  using const_iterator = storage_t::const_iterator;
 
 public:
   [[nodiscard]] std::shared_ptr<RawImageData>
@@ -241,8 +239,11 @@ public:
   void clear() { data.clear(); }
   void appendFrame(RawImageData* frame) { data.emplace_back(frame); }
 
+  const_iterator begin() const { return data.begin(); }
+  const_iterator end() const { return data.end(); }
+
 private:
-  std::vector<std::shared_ptr<RawImageData>> data;
+  storage_t data;
 };
 
 // setWithLookUp will set a single pixel by using the lookup table if supplied,

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -86,7 +86,6 @@ public:
   // corners are when the image is rotated 45 degrees in Fuji rotated sensors.
   uint32_t fujiRotationPos = 0;
 
-  iPoint2D subsampling = {1, 1};
   std::string make;
   std::string model;
   std::string mode;
@@ -161,8 +160,7 @@ public:
   uint32_t mBadPixelMapPitch = 0;
   bool mDitherScale =
       true; // Should upscaling be done with dither to minimize banding?
-  ImageMetaData metadata;
-
+  iPoint2D subsampling = {1, 1};
   Mutex mBadPixelMutex; // Mutex for 'mBadPixelPositions, must be used if more
                         // than 1 thread is accessing vector
 
@@ -237,12 +235,15 @@ public:
   }
   [[nodiscard]] storage_t::size_type numFrames() const { return data.size(); }
   void clear() { data.clear(); }
-  void appendFrame(std::shared_ptr<RawImageData> frame) {
+  void appendFrame(const std::shared_ptr<RawImageData>& frame) {
     data.emplace_back(frame);
   }
+  [[nodiscard]] storage_t::size_type size() const { return data.size(); }
 
-  const_iterator begin() const { return data.begin(); }
-  const_iterator end() const { return data.end(); }
+  [[nodiscard]] const_iterator begin() const { return data.begin(); }
+  [[nodiscard]] const_iterator end() const { return data.end(); }
+
+  ImageMetaData metadata;
 
 private:
   storage_t data;

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -237,7 +237,9 @@ public:
   }
   [[nodiscard]] storage_t::size_type numFrames() const { return data.size(); }
   void clear() { data.clear(); }
-  void appendFrame(RawImageData* frame) { data.emplace_back(frame); }
+  void appendFrame(std::shared_ptr<RawImageData> frame) {
+    data.emplace_back(frame);
+  }
 
   const_iterator begin() const { return data.begin(); }
   const_iterator end() const { return data.end(); }

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -41,8 +41,6 @@
 
 namespace rawspeed {
 
-class RawImage;
-
 class RawImageData;
 
 enum class RawImageType { UINT16, F32 };
@@ -224,6 +222,27 @@ private:
   void fixBadPixel(uint32_t x, uint32_t y, int component = 0) override;
   [[noreturn]] void doLookup(int start_y, int end_y) override;
   friend class RawImage;
+};
+
+class RawImageAbstract
+{
+
+};
+
+class RawImage {
+  using storage_t = std::vector<std::shared_ptr<RawImageData>>;
+
+public:
+  [[nodiscard]] std::shared_ptr<RawImageData>
+  get(storage_t::size_type pos) const {
+    return data.at(pos);
+  }
+  [[nodiscard]] storage_t::size_type numFrames() const { return data.size(); }
+  void clear() { data.clear(); }
+  void appendFrame(RawImageData* frame) { data.emplace_back(frame); }
+
+private:
+  std::vector<std::shared_ptr<RawImageData>> data;
 };
 
 // setWithLookUp will set a single pixel by using the lookup table if supplied,

--- a/src/librawspeed/common/RawImageDataFloat.cpp
+++ b/src/librawspeed/common/RawImageDataFloat.cpp
@@ -141,7 +141,7 @@ RawImageDataFloat::RawImageDataFloat() {
       calculateBlackAreas();
 
     startWorker(RawImageWorker::RawImageWorkerTask::SCALE_VALUES, true);
-}
+  }
 
 #if 0 // def WITH_SSE2
 

--- a/src/librawspeed/common/RawImageDataU16.cpp
+++ b/src/librawspeed/common/RawImageDataU16.cpp
@@ -152,8 +152,8 @@ void RawImageDataU16::scaleBlackWhite() {
     if (whitePoint >= 65536)
       whitePoint = m;
     writeLog(DEBUG_PRIO::INFO,
-             "ISO:%d, Estimated black:%d, Estimated white: %d",
-             metadata.isoSpeed, blackLevel, whitePoint);
+             "Estimated black:%d, Estimated white: %d",
+             blackLevel, whitePoint);
   }
 
   /* Skip, if not needed */

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -280,7 +280,7 @@ void ArwDecoder::DecodeARW2(const ByteStream& input, uint32_t w, uint32_t h,
   ThrowRDE("Unsupported bit depth");
 }
 
-void ArwDecoder::ParseA100WB() const {
+void ArwDecoder::ParseA100WB() {
   if (!mRootIFD->hasEntryRecursive(TiffTag::DNGPRIVATEDATA))
     return;
 
@@ -326,9 +326,9 @@ void ArwDecoder::ParseA100WB() const {
     for (auto& coeff : tmp)
       coeff = bs.getU16();
 
-    mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(tmp[0]);
-    mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(tmp[1]);
-    mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(tmp[3]);
+    mRaw.metadata.wbCoeffs[0] = static_cast<float>(tmp[0]);
+    mRaw.metadata.wbCoeffs[1] = static_cast<float>(tmp[1]);
+    mRaw.metadata.wbCoeffs[2] = static_cast<float>(tmp[3]);
 
     // only need this one block, no need to process any further
     break;
@@ -401,7 +401,7 @@ void ArwDecoder::SonyDecrypt(const uint32_t* ibuf, uint32_t* obuf, uint32_t len,
   }
 }
 
-void ArwDecoder::GetWB() const {
+void ArwDecoder::GetWB() {
   // Set the whitebalance for all the modern ARW formats (everything after A100)
   if (mRootIFD->hasEntryRecursive(TiffTag::DNGPRIVATEDATA)) {
     NORangesSet<Buffer> ifds_undecoded;
@@ -454,16 +454,16 @@ void ArwDecoder::GetWB() const {
       const TiffEntry* wb = encryptedIFD.getEntry(TiffTag::SONYGRBGLEVELS);
       if (wb->count != 4)
         ThrowRDE("WB has %d entries instead of 4", wb->count);
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(1);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(0);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(2);
+      mRaw.metadata.wbCoeffs[0] = wb->getFloat(1);
+      mRaw.metadata.wbCoeffs[1] = wb->getFloat(0);
+      mRaw.metadata.wbCoeffs[2] = wb->getFloat(2);
     } else if (encryptedIFD.hasEntry(TiffTag::SONYRGGBLEVELS)) {
       const TiffEntry* wb = encryptedIFD.getEntry(TiffTag::SONYRGGBLEVELS);
       if (wb->count != 4)
         ThrowRDE("WB has %d entries instead of 4", wb->count);
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(1);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(3);
+      mRaw.metadata.wbCoeffs[0] = wb->getFloat(0);
+      mRaw.metadata.wbCoeffs[1] = wb->getFloat(1);
+      mRaw.metadata.wbCoeffs[2] = wb->getFloat(3);
     }
   }
 }

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -42,14 +42,14 @@ public:
   ArwDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:
   void ParseA100WB() const;
 
   [[nodiscard]] int getDecoderVersion() const override { return 1; }
-  RawImage decodeSRF(const TiffIFD* raw);
+  void decodeSRF(const TiffIFD* raw);
   void DecodeARW2(const ByteStream& input, uint32_t w, uint32_t h,
                   uint32_t bpp);
   void DecodeUncompressed(const TiffIFD* raw) const;

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -46,7 +46,7 @@ public:
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:
-  void ParseA100WB() const;
+  void ParseA100WB();
 
   [[nodiscard]] int getDecoderVersion() const override { return 1; }
   void decodeSRF(const TiffIFD* raw);
@@ -55,7 +55,7 @@ private:
   void DecodeUncompressed(const TiffIFD* raw) const;
   static void SonyDecrypt(const uint32_t* ibuf, uint32_t* obuf, uint32_t len,
                           uint32_t key);
-  void GetWB() const;
+  void GetWB();
   ByteStream in;
   int mShiftDownScale = 0;
 };

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -373,7 +373,7 @@ void Cr2Decoder::sRawInterpolate() {
   mRaw.get(0)->subsampling = subsampledRaw->subsampling;
   mRaw.get(0)->isCFA = false;
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(subsampledRaw.get());
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(subsampledRaw.get());
   assert(rawU16);
   Cr2sRawInterpolator i(mRaw.get(0).get(),
                         rawU16->getU16DataAsUncroppedArray2DRef(),

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -369,7 +369,7 @@ void Cr2Decoder::sRawInterpolate() {
 
   mRaw.clear();
   //mRaw = std::make_shared<RawImageDataU16>(interpolatedDims, 3);
-  mRaw.appendFrame(new RawImageDataU16(interpolatedDims,3));
+  mRaw.appendFrame(std::make_shared<RawImageDataU16>(interpolatedDims,3));
   mRaw.get(0)->metadata.subsampling = subsampledRaw->metadata.subsampling;
   mRaw.get(0)->isCFA = false;
 

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -56,7 +56,7 @@ bool Cr2Decoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
          (make == "Kodak" && (model == "DCS520C" || model == "DCS560C"));
 }
 
-RawImage Cr2Decoder::decodeOldFormat() {
+void Cr2Decoder::decodeOldFormat() {
   uint32_t offset = 0;
   if (mRootIFD->getEntryRecursive(TiffTag::CANON_RAW_DATA_OFFSET)) {
     offset =
@@ -77,7 +77,7 @@ RawImage Cr2Decoder::decodeOldFormat() {
 
   // some old models (1D/1DS/D2000C) encode two lines as one
   // see: FIX_CANON_HALF_HEIGHT_DOUBLE_WIDTH
-  if (width > 2*height) {
+  if (width > 2 * height) {
     height *= 2;
     width /= 2;
   }
@@ -105,13 +105,11 @@ RawImage Cr2Decoder::decodeOldFormat() {
     if (!uncorrectedRawValues)
       mRaw->sixteenBitLookup();
   }
-
-  return mRaw;
 }
 
 // for technical details about Cr2 mRAW/sRAW, see http://lclevy.free.fr/cr2/
 
-RawImage Cr2Decoder::decodeNewFormat() {
+void Cr2Decoder::decodeNewFormat() {
   const TiffEntry* sensorInfoE =
       mRootIFD->getEntryRecursive(TiffTag::CANON_SENSOR_INFO);
   if (!sensorInfoE)
@@ -192,15 +190,13 @@ RawImage Cr2Decoder::decodeNewFormat() {
 
   if (mRaw->metadata.subsampling.x > 1 || mRaw->metadata.subsampling.y > 1)
     sRawInterpolate();
-
-  return mRaw;
 }
 
-RawImage Cr2Decoder::decodeRawInternal() {
+void Cr2Decoder::decodeRawInternal() {
   if (mRootIFD->getSubIFDs().size() < 4)
-    return decodeOldFormat();
+    decodeOldFormat();
   else // NOLINT ok, here it make sense
-    return decodeNewFormat();
+    decodeNewFormat();
 }
 
 void Cr2Decoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -371,8 +371,10 @@ void Cr2Decoder::sRawInterpolate() {
   mRaw->metadata.subsampling = subsampledRaw->metadata.subsampling;
   mRaw->isCFA = false;
 
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(subsampledRaw.get());
+  assert(rawU16);
   Cr2sRawInterpolator i(mRaw.get(),
-                        subsampledRaw->getU16DataAsUncroppedArray2DRef(),
+                        rawU16->getU16DataAsUncroppedArray2DRef(),
                         sraw_coeffs, hue);
 
   /* Determine sRaw coefficients */

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -39,14 +39,14 @@ public:
   Cr2Decoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:
   [[nodiscard]] int getDecoderVersion() const override { return 9; }
-  RawImage decodeOldFormat();
-  RawImage decodeNewFormat();
+  void decodeOldFormat();
+  void decodeNewFormat();
   void sRawInterpolate();
   [[nodiscard]] bool isSubSampled() const;
   [[nodiscard]] iPoint2D getSubSampling() const;

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -60,7 +60,7 @@ CrwDecoder::CrwDecoder(std::unique_ptr<const CiffIFD> rootIFD,
                        const Buffer& file)
     : RawDecoder(file), mRootIFD(std::move(rootIFD)) {}
 
-RawImage CrwDecoder::decodeRawInternal() {
+void CrwDecoder::decodeRawInternal() {
   const CiffEntry* rawData = mRootIFD->getEntry(CiffTag::RAWDATA);
   if (!rawData)
     ThrowRDE("Couldn't find the raw data chunk");
@@ -84,13 +84,11 @@ RawImage CrwDecoder::decodeRawInternal() {
   assert(decTable != nullptr);
   uint32_t dec_table = decTable->getU32();
 
-  bool lowbits = ! hints.has("no_decompressed_lowbits");
+  bool lowbits = !hints.has("no_decompressed_lowbits");
 
   CrwDecompressor c(mRaw, dec_table, lowbits, rawData->getData());
   mRaw->createData();
   c.decompress();
-
-  return mRaw;
 }
 
 void CrwDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -162,11 +162,11 @@ void CrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
             ThrowRDE("WB coefficient is zero!");
         }
 
-        mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(1024.0 / wbMuls[0]);
-        mRaw.get(0)->metadata.wbCoeffs[1] =
+        mRaw.metadata.wbCoeffs[0] = static_cast<float>(1024.0 / wbMuls[0]);
+        mRaw.metadata.wbCoeffs[1] =
             static_cast<float>((1024.0 / wbMuls[1]) + (1024.0 / wbMuls[2])) /
             2.0F;
-        mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(1024.0 / wbMuls[3]);
+        mRaw.metadata.wbCoeffs[2] = static_cast<float>(1024.0 / wbMuls[3]);
       } else if (wb->type == CiffDataType::BYTE &&
                  wb->count > 768) { // Other G series and S series cameras
         // correct offset for most cameras
@@ -177,11 +177,11 @@ void CrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
           key[0] = key[1] = 0;
 
         offset /= 2;
-        mRaw.get(0)->metadata.wbCoeffs[0] =
+        mRaw.metadata.wbCoeffs[0] =
             static_cast<float>(wb->getU16(offset + 1) ^ key[1]);
-        mRaw.get(0)->metadata.wbCoeffs[1] =
+        mRaw.metadata.wbCoeffs[1] =
             static_cast<float>(wb->getU16(offset + 0) ^ key[0]);
-        mRaw.get(0)->metadata.wbCoeffs[2] =
+        mRaw.metadata.wbCoeffs[2] =
             static_cast<float>(wb->getU16(offset + 2) ^ key[0]);
       }
     }
@@ -190,17 +190,17 @@ void CrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
           mRootIFD->getEntryRecursive(static_cast<CiffTag>(0x102c));
       if (entry->type == CiffDataType::SHORT && entry->getU16() > 512) {
         // G1/Pro90 CYGM pattern
-        mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(entry->getU16(62));
-        mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(entry->getU16(63));
-        mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(entry->getU16(60));
-        mRaw.get(0)->metadata.wbCoeffs[3] = static_cast<float>(entry->getU16(61));
+        mRaw.metadata.wbCoeffs[0] = static_cast<float>(entry->getU16(62));
+        mRaw.metadata.wbCoeffs[1] = static_cast<float>(entry->getU16(63));
+        mRaw.metadata.wbCoeffs[2] = static_cast<float>(entry->getU16(60));
+        mRaw.metadata.wbCoeffs[3] = static_cast<float>(entry->getU16(61));
       } else if (entry->type == CiffDataType::SHORT && entry->getU16() != 276) {
         /* G2, S30, S40 */
-        mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(entry->getU16(51));
-        mRaw.get(0)->metadata.wbCoeffs[1] = (static_cast<float>(entry->getU16(50)) +
+        mRaw.metadata.wbCoeffs[0] = static_cast<float>(entry->getU16(51));
+        mRaw.metadata.wbCoeffs[1] = (static_cast<float>(entry->getU16(50)) +
                                       static_cast<float>(entry->getU16(53))) /
                                      2.0F;
-        mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(entry->getU16(52));
+        mRaw.metadata.wbCoeffs[2] = static_cast<float>(entry->getU16(52));
       }
     }
     if (mRootIFD->hasEntryRecursive(CiffTag::SHOTINFO) &&
@@ -214,9 +214,9 @@ void CrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       if (wb_index > 9)
         ThrowRDE("Invalid white balance index");
       int wb_offset = 1 + ("0134567028"[wb_index]-'0') * 4;
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb_data->getU16(wb_offset + 0);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb_data->getU16(wb_offset + 1);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb_data->getU16(wb_offset + 3);
+      mRaw.metadata.wbCoeffs[0] = wb_data->getU16(wb_offset + 0);
+      mRaw.metadata.wbCoeffs[1] = wb_data->getU16(wb_offset + 1);
+      mRaw.metadata.wbCoeffs[2] = wb_data->getU16(wb_offset + 3);
     }
   } catch (const RawspeedException& e) {
     mRaw.get(0)->setError(e.what());

--- a/src/librawspeed/decoders/CrwDecoder.cpp
+++ b/src/librawspeed/decoders/CrwDecoder.cpp
@@ -86,7 +86,7 @@ void CrwDecoder::decodeRawInternal() {
 
   bool lowbits = !hints.has("no_decompressed_lowbits");
 
-  CrwDecompressor c(mRaw, dec_table, lowbits, rawData->getData());
+  CrwDecompressor c(mRaw.get(), dec_table, lowbits, rawData->getData());
   mRaw->createData();
   c.decompress();
 }

--- a/src/librawspeed/decoders/CrwDecoder.h
+++ b/src/librawspeed/decoders/CrwDecoder.h
@@ -38,7 +38,7 @@ class CrwDecoder final : public RawDecoder {
 
 public:
   CrwDecoder(std::unique_ptr<const CiffIFD> rootIFD, const Buffer& file);
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   static bool isCRW(const Buffer& input);

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -95,7 +95,7 @@ void DcrDecoder::decodeRawInternal() {
       const auto mul = blob->getU16(20 + i);
       if (0 == mul)
         ThrowRDE("WB coefficient is zero!");
-      mRaw.get(0)->metadata.wbCoeffs[i] = 2048.0F / mul;
+      mRaw.metadata.wbCoeffs[i] = 2048.0F / mul;
     }
   }
 

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -82,7 +82,7 @@ void DcrDecoder::decodeRawInternal() {
   assert(linearization != nullptr);
   auto linTable = linearization->getU16Array(linearization->count);
 
-  RawImageCurveGuard curveHandler(&mRaw, linTable, uncorrectedRawValues);
+  RawImageCurveGuard curveHandler(mRaw.get(), linTable, uncorrectedRawValues);
 
   // FIXME: dcraw does all sorts of crazy things besides this to fetch
   //        WB from what appear to be presets and calculate it in weird ways
@@ -110,7 +110,7 @@ void DcrDecoder::decodeRawInternal() {
     }
   }();
 
-  KodakDecompressor k(mRaw, input, bps, uncorrectedRawValues);
+  KodakDecompressor k(mRaw.get(), input, bps, uncorrectedRawValues);
   k.decompress();
 }
 

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -53,7 +53,7 @@ void DcrDecoder::checkImageDimensions() {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 }
 
-RawImage DcrDecoder::decodeRawInternal() {
+void DcrDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   ByteStream input(DataBuffer(mFile.getSubView(off), Endianness::little));
@@ -112,8 +112,6 @@ RawImage DcrDecoder::decodeRawInternal() {
 
   KodakDecompressor k(mRaw, input, bps, uncorrectedRawValues);
   k.decompress();
-
-  return mRaw;
 }
 
 void DcrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/DcrDecoder.cpp
+++ b/src/librawspeed/decoders/DcrDecoder.cpp
@@ -82,7 +82,7 @@ void DcrDecoder::decodeRawInternal() {
   assert(linearization != nullptr);
   auto linTable = linearization->getU16Array(linearization->count);
 
-  RawImageCurveGuard curveHandler(mRaw.get(), linTable, uncorrectedRawValues);
+  RawImageCurveGuard curveHandler(mRaw.get(0).get(), linTable, uncorrectedRawValues);
 
   // FIXME: dcraw does all sorts of crazy things besides this to fetch
   //        WB from what appear to be presets and calculate it in weird ways
@@ -95,7 +95,7 @@ void DcrDecoder::decodeRawInternal() {
       const auto mul = blob->getU16(20 + i);
       if (0 == mul)
         ThrowRDE("WB coefficient is zero!");
-      mRaw->metadata.wbCoeffs[i] = 2048.0F / mul;
+      mRaw.get(0)->metadata.wbCoeffs[i] = 2048.0F / mul;
     }
   }
 
@@ -110,7 +110,7 @@ void DcrDecoder::decodeRawInternal() {
     }
   }();
 
-  KodakDecompressor k(mRaw.get(), input, bps, uncorrectedRawValues);
+  KodakDecompressor k(mRaw.get(0).get(), input, bps, uncorrectedRawValues);
   k.decompress();
 }
 

--- a/src/librawspeed/decoders/DcrDecoder.h
+++ b/src/librawspeed/decoders/DcrDecoder.h
@@ -41,7 +41,7 @@ public:
   DcrDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : SimpleTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -63,11 +63,11 @@ void DcsDecoder::decodeRawInternal() {
   assert(linearization != nullptr);
   auto table = linearization->getU16Array(256);
 
-  RawImageCurveGuard curveHandler(&mRaw, table, uncorrectedRawValues);
+  RawImageCurveGuard curveHandler(mRaw.get(), table, uncorrectedRawValues);
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(off, c2), Endianness::little)),
-      mRaw);
+      mRaw.get());
 
   if (uncorrectedRawValues)
     u.decode8BitRaw<true>(width, height);

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -63,11 +63,11 @@ void DcsDecoder::decodeRawInternal() {
   assert(linearization != nullptr);
   auto table = linearization->getU16Array(256);
 
-  RawImageCurveGuard curveHandler(mRaw.get(), table, uncorrectedRawValues);
+  RawImageCurveGuard curveHandler(mRaw.get(0).get(), table, uncorrectedRawValues);
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(off, c2), Endianness::little)),
-      mRaw.get());
+      mRaw.get(0).get());
 
   if (uncorrectedRawValues)
     u.decode8BitRaw<true>(width, height);

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -51,7 +51,7 @@ void DcsDecoder::checkImageDimensions() {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 }
 
-RawImage DcsDecoder::decodeRawInternal() {
+void DcsDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   const TiffEntry* linearization =
@@ -73,8 +73,6 @@ RawImage DcsDecoder::decodeRawInternal() {
     u.decode8BitRaw<true>(width, height);
   else
     u.decode8BitRaw<false>(width, height);
-
-  return mRaw;
 }
 
 void DcsDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/DcsDecoder.h
+++ b/src/librawspeed/decoders/DcsDecoder.h
@@ -41,7 +41,7 @@ public:
   DcsDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : SimpleTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -335,7 +335,7 @@ void DngDecoder::decodeData(const TiffIFD* raw, uint32_t sample_format) const {
   slices.decompress();
 }
 
-RawImage DngDecoder::decodeRawInternal() {
+void DngDecoder::decodeRawInternal() {
   vector<const TiffIFD*> data = mRootIFD->getIFDsWithTag(TiffTag::COMPRESSION);
 
   if (data.empty())
@@ -419,8 +419,6 @@ RawImage DngDecoder::decodeRawInternal() {
   decodeData(raw, sample_format);
 
   handleMetadata(raw);
-
-  return mRaw;
 }
 
 void DngDecoder::handleMetadata(const TiffIFD* raw) {

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -147,7 +147,7 @@ void DngDecoder::dropUnsuportedChunks(std::vector<const TiffIFD*>* data) {
   }
 }
 
-void DngDecoder::parseCFA(const TiffIFD* raw, RawImage::frame_ptr_t frame) {
+void DngDecoder::parseCFA(const TiffIFD* raw, const RawImage::frame_ptr_t &frame) {
 
   // Check if layout is OK, if present
   if (raw->hasEntry(TiffTag::CFALAYOUT) &&
@@ -214,7 +214,7 @@ void DngDecoder::parseCFA(const TiffIFD* raw, RawImage::frame_ptr_t frame) {
 
 DngTilingDescription
 DngDecoder::getTilingDescription(const TiffIFD* raw,
-                                 RawImage::frame_ptr_t frame) {
+                                 const RawImage::frame_ptr_t &frame) {
   if (raw->hasEntry(TiffTag::TILEOFFSETS)) {
     const uint32_t tilew = raw->getEntry(TiffTag::TILEWIDTH)->getU32();
     const uint32_t tileh = raw->getEntry(TiffTag::TILELENGTH)->getU32();
@@ -274,7 +274,7 @@ DngDecoder::getTilingDescription(const TiffIFD* raw,
 
 void DngDecoder::decodeData(const TiffIFD* raw, uint32_t sample_format,
                             int compression, int bps,
-                            RawImage::frame_ptr_t frame) {
+                            const RawImage::frame_ptr_t &frame) {
   if (compression == 8 && sample_format != 3) {
     ThrowRDE("Only float format is supported for "
              "deflate-compressed data.");
@@ -429,7 +429,7 @@ void DngDecoder::decodeRawInternal() {
 }
 
 void DngDecoder::handleMetadata(const TiffIFD* raw, int compression, int bps,
-                                RawImage::frame_ptr_t frame) {
+                                const RawImage::frame_ptr_t &frame) {
   // Crop
   if (raw->hasEntry(TiffTag::ACTIVEAREA)) {
     const TiffEntry* active_area = raw->getEntry(TiffTag::ACTIVEAREA);
@@ -675,7 +675,7 @@ void DngDecoder::checkSupportInternal(const CameraMetaData* meta) {
 
 /* Decodes DNG masked areas into blackareas in the image */
 bool DngDecoder::decodeMaskedAreas(const TiffIFD* raw,
-                                   RawImage::frame_ptr_t frame) {
+                                   const RawImage::frame_ptr_t &frame) {
   const TiffEntry* masked = raw->getEntry(TiffTag::MASKEDAREAS);
 
   if (masked->type != TiffDataType::SHORT && masked->type != TiffDataType::LONG)
@@ -718,7 +718,7 @@ bool DngDecoder::decodeMaskedAreas(const TiffIFD* raw,
 }
 
 bool DngDecoder::decodeBlackLevels(const TiffIFD* raw,
-                                   RawImage::frame_ptr_t frame) {
+                                   const RawImage::frame_ptr_t &frame) {
   iPoint2D blackdim(1, 1);
   if (raw->hasEntry(TiffTag::BLACKLEVELREPEATDIM)) {
     const TiffEntry* bleveldim = raw->getEntry(TiffTag::BLACKLEVELREPEATDIM);
@@ -815,7 +815,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw,
   return true;
 }
 
-void DngDecoder::setBlack(const TiffIFD* raw, RawImage::frame_ptr_t frame) {
+void DngDecoder::setBlack(const TiffIFD* raw, const RawImage::frame_ptr_t &frame) {
 
   if (raw->hasEntry(TiffTag::MASKEDAREAS) && decodeMaskedAreas(raw, frame))
     return;

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -49,14 +49,17 @@ private:
   bool mFixLjpeg;
   static void dropUnsuportedChunks(std::vector<const TiffIFD*>* data);
   static void parseCFA(const TiffIFD* raw, RawImage::frame_ptr_t frame);
-  DngTilingDescription getTilingDescription(const TiffIFD* raw) const;
+  static DngTilingDescription getTilingDescription(const TiffIFD* raw,
+                                                   RawImage::frame_ptr_t frame);
   void decodeData(const TiffIFD* raw, uint32_t sample_format, int compression,
                   int bps, RawImage::frame_ptr_t frame);
   void handleMetadata(const TiffIFD* raw, int compression, int bps,
                       RawImage::frame_ptr_t frame);
-  bool decodeMaskedAreas(const TiffIFD* raw) const;
-  bool decodeBlackLevels(const TiffIFD* raw) const;
-  void setBlack(const TiffIFD* raw) const;
+  static bool decodeMaskedAreas(const TiffIFD* raw,
+                                RawImage::frame_ptr_t frame);
+  static bool decodeBlackLevels(const TiffIFD* raw,
+                                RawImage::frame_ptr_t frame);
+  static void setBlack(const TiffIFD* raw, RawImage::frame_ptr_t frame);
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -34,8 +34,7 @@ class Buffer;
 
 struct DngTilingDescription;
 
-class DngDecoder final : public AbstractTiffDecoder
-{
+class DngDecoder final : public AbstractTiffDecoder {
 public:
   static bool isAppropriateDecoder(const TiffRootIFD* rootIFD,
                                    const Buffer& file);
@@ -49,16 +48,15 @@ private:
   [[nodiscard]] int getDecoderVersion() const override { return 0; }
   bool mFixLjpeg;
   static void dropUnsuportedChunks(std::vector<const TiffIFD*>* data);
-  void parseCFA(const TiffIFD* raw) const;
+  static void parseCFA(const TiffIFD* raw, RawImage::frame_ptr_t frame);
   DngTilingDescription getTilingDescription(const TiffIFD* raw) const;
-  void decodeData(const TiffIFD* raw, uint32_t sample_format) const;
-  void handleMetadata(const TiffIFD* raw);
+  void decodeData(const TiffIFD* raw, uint32_t sample_format, int compression,
+                  int bps, RawImage::frame_ptr_t frame);
+  void handleMetadata(const TiffIFD* raw, int compression, int bps,
+                      RawImage::frame_ptr_t frame);
   bool decodeMaskedAreas(const TiffIFD* raw) const;
   bool decodeBlackLevels(const TiffIFD* raw) const;
   void setBlack(const TiffIFD* raw) const;
-
-  int bps = -1;
-  int compression = -1;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -41,7 +41,7 @@ public:
                                    const Buffer& file);
   DngDecoder(TiffRootIFDOwner&& rootIFD, const Buffer& file);
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   void checkSupportInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -48,18 +48,18 @@ private:
   [[nodiscard]] int getDecoderVersion() const override { return 0; }
   bool mFixLjpeg;
   static void dropUnsuportedChunks(std::vector<const TiffIFD*>* data);
-  static void parseCFA(const TiffIFD* raw, RawImage::frame_ptr_t frame);
+  static void parseCFA(const TiffIFD* raw, const RawImage::frame_ptr_t &frame);
   static DngTilingDescription getTilingDescription(const TiffIFD* raw,
-                                                   RawImage::frame_ptr_t frame);
+                                                   const RawImage::frame_ptr_t &frame);
   void decodeData(const TiffIFD* raw, uint32_t sample_format, int compression,
-                  int bps, RawImage::frame_ptr_t frame);
+                  int bps, const RawImage::frame_ptr_t &frame);
   void handleMetadata(const TiffIFD* raw, int compression, int bps,
-                      RawImage::frame_ptr_t frame);
+                      const RawImage::frame_ptr_t &frame);
   static bool decodeMaskedAreas(const TiffIFD* raw,
-                                RawImage::frame_ptr_t frame);
+                                const RawImage::frame_ptr_t &frame);
   static bool decodeBlackLevels(const TiffIFD* raw,
-                                RawImage::frame_ptr_t frame);
-  static void setBlack(const TiffIFD* raw, RawImage::frame_ptr_t frame);
+                                const RawImage::frame_ptr_t &frame);
+  static void setBlack(const TiffIFD* raw, const RawImage::frame_ptr_t &frame);
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -51,7 +51,7 @@ void ErfDecoder::checkImageDimensions() {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 }
 
-RawImage ErfDecoder::decodeRawInternal() {
+void ErfDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   UncompressedDecompressor u(
@@ -59,8 +59,6 @@ RawImage ErfDecoder::decodeRawInternal() {
       mRaw);
 
   u.decode12BitRaw<Endianness::big, false, true>(width, height);
-
-  return mRaw;
 }
 
 void ErfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -56,7 +56,7 @@ void ErfDecoder::decodeRawInternal() {
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(off, c2), Endianness::little)),
-      mRaw);
+      mRaw.get());
 
   u.decode12BitRaw<Endianness::big, false, true>(width, height);
 }

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -68,10 +68,10 @@ void ErfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::EPSONWB);
     if (wb->count == 256) {
       // Magic values taken directly from dcraw
-      mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(24)) * 508.0F *
+      mRaw.metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(24)) * 508.0F *
                                    1.078F / static_cast<float>(0x10000);
-      mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
-      mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(25)) * 382.0F *
+      mRaw.metadata.wbCoeffs[1] = 1.0F;
+      mRaw.metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(25)) * 382.0F *
                                    1.173F / static_cast<float>(0x10000);
     }
   }

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -56,7 +56,7 @@ void ErfDecoder::decodeRawInternal() {
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(off, c2), Endianness::little)),
-      mRaw.get());
+      mRaw.get(0).get());
 
   u.decode12BitRaw<Endianness::big, false, true>(width, height);
 }
@@ -68,10 +68,10 @@ void ErfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::EPSONWB);
     if (wb->count == 256) {
       // Magic values taken directly from dcraw
-      mRaw->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(24)) * 508.0F *
+      mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(24)) * 508.0F *
                                    1.078F / static_cast<float>(0x10000);
-      mRaw->metadata.wbCoeffs[1] = 1.0F;
-      mRaw->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(25)) * 382.0F *
+      mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
+      mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(25)) * 382.0F *
                                    1.173F / static_cast<float>(0x10000);
     }
   }

--- a/src/librawspeed/decoders/ErfDecoder.h
+++ b/src/librawspeed/decoders/ErfDecoder.h
@@ -41,7 +41,7 @@ public:
   ErfDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : SimpleTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -111,7 +111,7 @@ IiqDecoder::computeSripes(const Buffer& raw_data,
   return slices;
 }
 
-RawImage IiqDecoder::decodeRawInternal() {
+void IiqDecoder::decodeRawInternal() {
   const Buffer buf(mFile.getSubView(8));
   const DataBuffer db(buf, Endianness::little);
   ByteStream bs(db);
@@ -218,8 +218,6 @@ RawImage IiqDecoder::decodeRawInternal() {
 
   for (int i = 0; i < 3; i++)
     mRaw->metadata.wbCoeffs[i] = wb.getFloat();
-
-  return mRaw;
 }
 
 void IiqDecoder::CorrectPhaseOneC(ByteStream meta_data, uint32_t split_row,

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -209,7 +209,7 @@ void IiqDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
 
-  PhaseOneDecompressor p(mRaw, std::move(strips));
+  PhaseOneDecompressor p(mRaw.get(), std::move(strips));
   mRaw->createData();
   p.decompress();
 

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -311,7 +311,9 @@ void IiqDecoder::CorrectQuadrantMultipliersCombined(ByteStream data,
 
   for (int quadRow = 0; quadRow < 2; quadRow++) {
     for (int quadCol = 0; quadCol < 2; quadCol++) {
-      const Array2DRef<uint16_t> img(mRaw->getU16DataAsUncroppedArray2DRef());
+      auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+      assert(rawU16);
+      const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
       const Spline<> s(control_points[quadRow][quadCol]);
       const std::vector<uint16_t> curve = s.calculateCurve();
@@ -387,7 +389,9 @@ void IiqDecoder::handleBadPixel(const uint16_t col, const uint16_t row) const {
 }
 
 void IiqDecoder::correctBadColumn(const uint16_t col) const {
-  const Array2DRef<uint16_t> img(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+  assert(rawU16);
+  const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
   for (int row = 2; row < mRaw->dim.y - 2; row++) {
     if (mRaw->cfa.getColorAt(col, row) == CFAColor::GREEN) {

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -311,7 +311,7 @@ void IiqDecoder::CorrectQuadrantMultipliersCombined(ByteStream data,
 
   for (int quadRow = 0; quadRow < 2; quadRow++) {
     for (int quadCol = 0; quadCol < 2; quadCol++) {
-      auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
+      auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
       assert(rawU16);
       const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -389,7 +389,7 @@ void IiqDecoder::handleBadPixel(const uint16_t col, const uint16_t row) const {
 }
 
 void IiqDecoder::correctBadColumn(const uint16_t col) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
   assert(rawU16);
   const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -217,7 +217,7 @@ void IiqDecoder::decodeRawInternal() {
     CorrectPhaseOneC(correction_meta_data, split_row, split_col);
 
   for (int i = 0; i < 3; i++)
-    mRaw.get(0)->metadata.wbCoeffs[i] = wb.getFloat();
+    mRaw.metadata.wbCoeffs[i] = wb.getFloat();
 }
 
 void IiqDecoder::CorrectPhaseOneC(ByteStream meta_data, uint32_t split_row,
@@ -345,7 +345,7 @@ void IiqDecoder::checkSupportInternal(const CameraMetaData* meta) {
   checkCameraSupported(meta, mRootIFD->getID(), "");
 
   auto id = mRootIFD->getID();
-  const Camera* cam = meta->getCamera(id.make, id.model, mRaw.get(0)->metadata.mode);
+  const Camera* cam = meta->getCamera(id.make, id.model, mRaw.metadata.mode);
   if (!cam)
     ThrowRDE("Couldn't find camera %s %s", id.make.c_str(), id.model.c_str());
 

--- a/src/librawspeed/decoders/IiqDecoder.h
+++ b/src/librawspeed/decoders/IiqDecoder.h
@@ -56,7 +56,7 @@ public:
   IiqDecoder(TiffRootIFDOwner&& rootIFD, const Buffer& file)
       : AbstractTiffDecoder(std::move(rootIFD), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -81,7 +81,7 @@ Buffer KdcDecoder::getInputBuffer() const {
   return mFile.getSubView(off, bytes);
 }
 
-RawImage KdcDecoder::decodeRawInternal() {
+void KdcDecoder::decodeRawInternal() {
   if (!mRootIFD->hasEntryRecursive(TiffTag::COMPRESSION))
     ThrowRDE("Couldn't find compression setting");
 
@@ -120,8 +120,6 @@ RawImage KdcDecoder::decodeRawInternal() {
       ByteStream(DataBuffer(inputBuffer, Endianness::little)), mRaw);
 
   u.decode12BitRaw<Endianness::big>(width, height);
-
-  return mRaw;
 }
 
 void KdcDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -117,7 +117,7 @@ void KdcDecoder::decodeRawInternal() {
   mRaw->createData();
 
   UncompressedDecompressor u(
-      ByteStream(DataBuffer(inputBuffer, Endianness::little)), mRaw);
+      ByteStream(DataBuffer(inputBuffer, Endianness::little)), mRaw.get());
 
   u.decode12BitRaw<Endianness::big>(width, height);
 }

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -69,7 +69,7 @@ Buffer KdcDecoder::getInputBuffer() const {
   if (off > mFile.getSize())
     ThrowRDE("offset is out of bounds");
 
-  const auto area = mRaw->dim.area();
+  const auto area = mRaw.get(0)->dim.area();
   if (area > std::numeric_limits<decltype(area)>::max() / 12) // round down
     ThrowRDE("Image dimensions are way too large, potential for overflow");
 
@@ -110,14 +110,14 @@ void KdcDecoder::decodeRawInternal() {
   uint32_t width = ew->getU32();
   uint32_t height = eh->getU32();
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   const Buffer inputBuffer = KdcDecoder::getInputBuffer();
 
-  mRaw->createData();
+  mRaw.get(0)->createData();
 
   UncompressedDecompressor u(
-      ByteStream(DataBuffer(inputBuffer, Endianness::little)), mRaw.get());
+      ByteStream(DataBuffer(inputBuffer, Endianness::little)), mRaw.get(0).get());
 
   u.decode12BitRaw<Endianness::big>(width, height);
 }
@@ -138,13 +138,13 @@ void KdcDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       if (kodakifd.hasEntryRecursive(TiffTag::KODAK_KDC_WB)) {
         const TiffEntry* wb = kodakifd.getEntryRecursive(TiffTag::KODAK_KDC_WB);
         if (wb->count == 3) {
-          mRaw->metadata.wbCoeffs[0] = wb->getFloat(0);
-          mRaw->metadata.wbCoeffs[1] = wb->getFloat(1);
-          mRaw->metadata.wbCoeffs[2] = wb->getFloat(2);
+          mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
+          mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(1);
+          mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(2);
         }
       }
     } catch (const TiffParserException& e) {
-      mRaw->setError(e.what());
+      mRaw.get(0)->setError(e.what());
     }
   }
 
@@ -152,12 +152,12 @@ void KdcDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (mRootIFD->hasEntryRecursive(TiffTag::KODAKWB)) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::KODAKWB);
     if (wb->count == 734 || wb->count == 1502) {
-      mRaw->metadata.wbCoeffs[0] =
+      mRaw.get(0)->metadata.wbCoeffs[0] =
           static_cast<float>(((static_cast<uint16_t>(wb->getByte(148))) << 8) |
                              wb->getByte(149)) /
           256.0F;
-      mRaw->metadata.wbCoeffs[1] = 1.0F;
-      mRaw->metadata.wbCoeffs[2] =
+      mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
+      mRaw.get(0)->metadata.wbCoeffs[2] =
           static_cast<float>(((static_cast<uint16_t>(wb->getByte(150))) << 8) |
                              wb->getByte(151)) /
           256.0F;

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -138,9 +138,9 @@ void KdcDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       if (kodakifd.hasEntryRecursive(TiffTag::KODAK_KDC_WB)) {
         const TiffEntry* wb = kodakifd.getEntryRecursive(TiffTag::KODAK_KDC_WB);
         if (wb->count == 3) {
-          mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
-          mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(1);
-          mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(2);
+          mRaw.metadata.wbCoeffs[0] = wb->getFloat(0);
+          mRaw.metadata.wbCoeffs[1] = wb->getFloat(1);
+          mRaw.metadata.wbCoeffs[2] = wb->getFloat(2);
         }
       }
     } catch (const TiffParserException& e) {
@@ -152,12 +152,12 @@ void KdcDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (mRootIFD->hasEntryRecursive(TiffTag::KODAKWB)) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::KODAKWB);
     if (wb->count == 734 || wb->count == 1502) {
-      mRaw.get(0)->metadata.wbCoeffs[0] =
+      mRaw.metadata.wbCoeffs[0] =
           static_cast<float>(((static_cast<uint16_t>(wb->getByte(148))) << 8) |
                              wb->getByte(149)) /
           256.0F;
-      mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
-      mRaw.get(0)->metadata.wbCoeffs[2] =
+      mRaw.metadata.wbCoeffs[1] = 1.0F;
+      mRaw.metadata.wbCoeffs[2] =
           static_cast<float>(((static_cast<uint16_t>(wb->getByte(150))) << 8) |
                              wb->getByte(151)) /
           256.0F;

--- a/src/librawspeed/decoders/KdcDecoder.h
+++ b/src/librawspeed/decoders/KdcDecoder.h
@@ -41,7 +41,7 @@ public:
   KdcDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -48,7 +48,7 @@ void MefDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   UncompressedDecompressor u(
-      ByteStream(DataBuffer(mFile.getSubView(off), Endianness::little)), mRaw);
+      ByteStream(DataBuffer(mFile.getSubView(off), Endianness::little)), mRaw.get());
 
   u.decode12BitRaw<Endianness::big>(width, height);
 }

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -48,7 +48,7 @@ void MefDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   UncompressedDecompressor u(
-      ByteStream(DataBuffer(mFile.getSubView(off), Endianness::little)), mRaw.get());
+      ByteStream(DataBuffer(mFile.getSubView(off), Endianness::little)), mRaw.get(0).get());
 
   u.decode12BitRaw<Endianness::big>(width, height);
 }

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -44,15 +44,13 @@ void MefDecoder::checkImageDimensions() {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 }
 
-RawImage MefDecoder::decodeRawInternal() {
+void MefDecoder::decodeRawInternal() {
   SimpleTiffDecoder::prepareForRawDecoding();
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(off), Endianness::little)), mRaw);
 
   u.decode12BitRaw<Endianness::big>(width, height);
-
-  return mRaw;
 }
 
 void MefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/MefDecoder.h
+++ b/src/librawspeed/decoders/MefDecoder.h
@@ -40,7 +40,7 @@ public:
   MefDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : SimpleTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -122,7 +122,7 @@ void MosDecoder::decodeRawInternal() {
   if (bs.getRemainSize() == 0)
     ThrowRDE("Input buffer is empty");
 
-  UncompressedDecompressor u(bs, mRaw);
+  UncompressedDecompressor u(bs, mRaw.get());
 
   if (int compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
       1 == compression) {

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -169,9 +169,9 @@ void MosDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         iss >> tmp[0] >> tmp[1] >> tmp[2] >> tmp[3];
         if (!iss.fail() && tmp[0] > 0 && tmp[1] > 0 && tmp[2] > 0 &&
             tmp[3] > 0) {
-          mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(tmp[0]) / tmp[1];
-          mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(tmp[0]) / tmp[2];
-          mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(tmp[0]) / tmp[3];
+          mRaw.metadata.wbCoeffs[0] = static_cast<float>(tmp[0]) / tmp[1];
+          mRaw.metadata.wbCoeffs[1] = static_cast<float>(tmp[0]) / tmp[2];
+          mRaw.metadata.wbCoeffs[2] = static_cast<float>(tmp[0]) / tmp[3];
         }
         break;
       }

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -115,14 +115,14 @@ void MosDecoder::decodeRawInternal() {
   if (width == 0 || height == 0 || width > 10328 || height > 7760)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
-  mRaw->dim = iPoint2D(width, height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(width, height);
+  mRaw.get(0)->createData();
 
   const ByteStream bs(DataBuffer(mFile.getSubView(off), Endianness::little));
   if (bs.getRemainSize() == 0)
     ThrowRDE("Input buffer is empty");
 
-  UncompressedDecompressor u(bs, mRaw.get());
+  UncompressedDecompressor u(bs, mRaw.get(0).get());
 
   if (int compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
       1 == compression) {
@@ -169,9 +169,9 @@ void MosDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         iss >> tmp[0] >> tmp[1] >> tmp[2] >> tmp[3];
         if (!iss.fail() && tmp[0] > 0 && tmp[1] > 0 && tmp[2] > 0 &&
             tmp[3] > 0) {
-          mRaw->metadata.wbCoeffs[0] = static_cast<float>(tmp[0]) / tmp[1];
-          mRaw->metadata.wbCoeffs[1] = static_cast<float>(tmp[0]) / tmp[2];
-          mRaw->metadata.wbCoeffs[2] = static_cast<float>(tmp[0]) / tmp[3];
+          mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(tmp[0]) / tmp[1];
+          mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(tmp[0]) / tmp[2];
+          mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(tmp[0]) / tmp[3];
         }
         break;
       }

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -95,10 +95,10 @@ std::string MosDecoder::getXMPTag(std::string_view xmp, std::string_view tag) {
   return std::string(xmp.substr(start + startlen, end - start - startlen));
 }
 
-RawImage MosDecoder::decodeRawInternal() {
+void MosDecoder::decodeRawInternal() {
   uint32_t off = 0;
 
-  const TiffIFD *raw = nullptr;
+  const TiffIFD* raw = nullptr;
 
   if (mRootIFD->hasEntryRecursive(TiffTag::TILEOFFSETS)) {
     raw = mRootIFD->getIFDWithTag(TiffTag::TILEOFFSETS);
@@ -139,8 +139,6 @@ RawImage MosDecoder::decodeRawInternal() {
     // l.startDecoder(off, mFile.getSize()-off, 0, 0);
   } else
     ThrowRDE("Unsupported compression: %d", compression);
-
-  return mRaw;
 }
 
 void MosDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/MosDecoder.h
+++ b/src/librawspeed/decoders/MosDecoder.h
@@ -38,7 +38,7 @@ public:
                                    const Buffer& file);
   MosDecoder(TiffRootIFDOwner&& rootIFD, const Buffer& file);
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -152,12 +152,12 @@ void MrwDecoder::parseHeader() {
 }
 
 void MrwDecoder::decodeRawInternal() {
-  mRaw->dim = iPoint2D(raw_width, raw_height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(raw_width, raw_height);
+  mRaw.get(0)->createData();
 
   DataBuffer db(imageData, Endianness::big);
   ByteStream bs(db);
-  UncompressedDecompressor u(bs, mRaw.get());
+  UncompressedDecompressor u(bs, mRaw.get(0).get());
 
   if (packed)
     u.decode12BitRaw<Endianness::big>(raw_width, raw_height);
@@ -184,13 +184,13 @@ void MrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   setMetaData(meta, id.make, id.model, "", iso);
 
   if (hints.has("swapped_wb")) {
-    mRaw->metadata.wbCoeffs[0] = wb_coeffs[2];
-    mRaw->metadata.wbCoeffs[1] = wb_coeffs[0];
-    mRaw->metadata.wbCoeffs[2] = wb_coeffs[1];
+    mRaw.get(0)->metadata.wbCoeffs[0] = wb_coeffs[2];
+    mRaw.get(0)->metadata.wbCoeffs[1] = wb_coeffs[0];
+    mRaw.get(0)->metadata.wbCoeffs[2] = wb_coeffs[1];
   } else {
-    mRaw->metadata.wbCoeffs[0] = wb_coeffs[0];
-    mRaw->metadata.wbCoeffs[1] = wb_coeffs[1];
-    mRaw->metadata.wbCoeffs[2] = wb_coeffs[3];
+    mRaw.get(0)->metadata.wbCoeffs[0] = wb_coeffs[0];
+    mRaw.get(0)->metadata.wbCoeffs[1] = wb_coeffs[1];
+    mRaw.get(0)->metadata.wbCoeffs[2] = wb_coeffs[3];
   }
 }
 

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -184,13 +184,13 @@ void MrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   setMetaData(meta, id.make, id.model, "", iso);
 
   if (hints.has("swapped_wb")) {
-    mRaw.get(0)->metadata.wbCoeffs[0] = wb_coeffs[2];
-    mRaw.get(0)->metadata.wbCoeffs[1] = wb_coeffs[0];
-    mRaw.get(0)->metadata.wbCoeffs[2] = wb_coeffs[1];
+    mRaw.metadata.wbCoeffs[0] = wb_coeffs[2];
+    mRaw.metadata.wbCoeffs[1] = wb_coeffs[0];
+    mRaw.metadata.wbCoeffs[2] = wb_coeffs[1];
   } else {
-    mRaw.get(0)->metadata.wbCoeffs[0] = wb_coeffs[0];
-    mRaw.get(0)->metadata.wbCoeffs[1] = wb_coeffs[1];
-    mRaw.get(0)->metadata.wbCoeffs[2] = wb_coeffs[3];
+    mRaw.metadata.wbCoeffs[0] = wb_coeffs[0];
+    mRaw.metadata.wbCoeffs[1] = wb_coeffs[1];
+    mRaw.metadata.wbCoeffs[2] = wb_coeffs[3];
   }
 }
 

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -157,7 +157,7 @@ void MrwDecoder::decodeRawInternal() {
 
   DataBuffer db(imageData, Endianness::big);
   ByteStream bs(db);
-  UncompressedDecompressor u(bs, mRaw);
+  UncompressedDecompressor u(bs, mRaw.get());
 
   if (packed)
     u.decode12BitRaw<Endianness::big>(raw_width, raw_height);

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -151,7 +151,7 @@ void MrwDecoder::parseHeader() {
   imageData = db.getSubView(bs.getPosition(), imageBits / 8);
 }
 
-RawImage MrwDecoder::decodeRawInternal() {
+void MrwDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(raw_width, raw_height);
   mRaw->createData();
 
@@ -163,8 +163,6 @@ RawImage MrwDecoder::decodeRawInternal() {
     u.decode12BitRaw<Endianness::big>(raw_width, raw_height);
   else
     u.decodeRawUnpacked<12, Endianness::big>(raw_width, raw_height);
-
-  return mRaw;
 }
 
 void MrwDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/MrwDecoder.h
+++ b/src/librawspeed/decoders/MrwDecoder.h
@@ -45,7 +45,7 @@ class MrwDecoder final : public RawDecoder {
 
 public:
   explicit MrwDecoder(const Buffer& file);
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   static int isMRW(const Buffer& input);

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -88,15 +88,15 @@ void NakedDecoder::parseHints() {
 void NakedDecoder::decodeRawInternal() {
   parseHints();
 
-  mRaw->dim = iPoint2D(width, height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(width, height);
+  mRaw.get(0)->createData();
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
-      mRaw.get());
+      mRaw.get(0).get());
 
   iPoint2D pos(0, 0);
-  u.readUncompressedRaw(mRaw->dim, pos, width * bits / 8, bits, bo);
+  u.readUncompressedRaw(mRaw.get(0)->dim, pos, width * bits / 8, bits, bo);
 }
 
 void NakedDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -85,7 +85,7 @@ void NakedDecoder::parseHints() {
   }
 }
 
-RawImage NakedDecoder::decodeRawInternal() {
+void NakedDecoder::decodeRawInternal() {
   parseHints();
 
   mRaw->dim = iPoint2D(width, height);
@@ -97,8 +97,6 @@ RawImage NakedDecoder::decodeRawInternal() {
 
   iPoint2D pos(0, 0);
   u.readUncompressedRaw(mRaw->dim, pos, width * bits / 8, bits, bo);
-
-  return mRaw;
 }
 
 void NakedDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -93,7 +93,7 @@ void NakedDecoder::decodeRawInternal() {
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
-      mRaw);
+      mRaw.get());
 
   iPoint2D pos(0, 0);
   u.readUncompressedRaw(mRaw->dim, pos, width * bits / 8, bits, bo);

--- a/src/librawspeed/decoders/NakedDecoder.h
+++ b/src/librawspeed/decoders/NakedDecoder.h
@@ -49,7 +49,7 @@ class NakedDecoder final : public RawDecoder {
 
 public:
   NakedDecoder(const Buffer& file, const Camera* c);
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void checkSupportInternal(const CameraMetaData* meta) override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -305,7 +305,9 @@ void NefDecoder::DecodeUncompressed() const {
 void NefDecoder::readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
                                      const iPoint2D& offset,
                                      int inputPitch) const {
-  const Array2DRef<uint16_t> img(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+  assert(rawU16);
+  const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
   if (size.y % 2 != 0)
     ThrowRDE("Odd number of rows");
@@ -659,7 +661,9 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
   uint16_t tmp;
   auto* tmpch = reinterpret_cast<uint8_t*>(&tmp);
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   const uint8_t* in = input.peekData(out.width * out.height);
 
   for (int row = 0; row < out.height; row++) {

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -124,7 +124,7 @@ void NefDecoder::decodeRawInternal() {
       DataBuffer(mFile.getSubView(offsets->getU32(), counts->getU32()),
                  Endianness::little));
 
-  NikonDecompressor n(mRaw, meta->getData(), bitPerPixel);
+  NikonDecompressor n(mRaw.get(), meta->getData(), bitPerPixel);
   mRaw->createData();
   n.decompress(rawData, uncorrectedRawValues);
 }
@@ -282,14 +282,14 @@ void NefDecoder::DecodeUncompressed() const {
     iPoint2D pos(0, offY);
 
     if (hints.has("coolpixmangled")) {
-      UncompressedDecompressor u(in, mRaw);
+      UncompressedDecompressor u(in, mRaw.get());
       u.readUncompressedRaw(size, pos, width * bitPerPixel / 8, 12,
                             BitOrder::MSB32);
     } else {
       if (hints.has("coolpixsplit"))
         readCoolpixSplitRaw(in, size, pos, width * bitPerPixel / 8);
       else {
-        UncompressedDecompressor u(in, mRaw);
+        UncompressedDecompressor u(in, mRaw.get());
         if (in.getSize() % size.y != 0)
           ThrowRDE("Inconsistent row size");
         const auto inputPitchBytes = in.getSize() / size.y;
@@ -357,7 +357,7 @@ void NefDecoder::DecodeD100Uncompressed() const {
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
-      mRaw);
+      mRaw.get());
 
   u.decode12BitRaw<Endianness::big, false, true>(width, height);
 }
@@ -654,7 +654,7 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
 
   curve.resize(4095);
 
-  RawImageCurveGuard curveHandler(&mRaw, curve, false);
+  RawImageCurveGuard curveHandler(mRaw.get(), curve, false);
 
   uint16_t tmp;
   auto* tmpch = reinterpret_cast<uint8_t*>(&tmp);

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -109,7 +109,7 @@ void NefDecoder::decodeRawInternal() {
   uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
   uint32_t bitPerPixel = raw->getEntry(TiffTag::BITSPERSAMPLE)->getU32();
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   raw = mRootIFD->getIFDWithTag(static_cast<TiffTag>(0x8c));
 
@@ -124,8 +124,8 @@ void NefDecoder::decodeRawInternal() {
       DataBuffer(mFile.getSubView(offsets->getU32(), counts->getU32()),
                  Endianness::little));
 
-  NikonDecompressor n(mRaw.get(), meta->getData(), bitPerPixel);
-  mRaw->createData();
+  NikonDecompressor n(mRaw.get(0).get(), meta->getData(), bitPerPixel);
+  mRaw.get(0)->createData();
   n.decompress(rawData, uncorrectedRawValues);
 }
 
@@ -209,7 +209,7 @@ void NefDecoder::DecodeUncompressed() const {
   uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
   uint32_t bitPerPixel = raw->getEntry(TiffTag::BITSPERSAMPLE)->getU32();
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   if (width == 0 || height == 0 || width > 8288 || height > 5520)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
@@ -220,10 +220,10 @@ void NefDecoder::DecodeUncompressed() const {
              counts->count, offsets->count);
   }
 
-  if (yPerSlice == 0 || yPerSlice > static_cast<uint32_t>(mRaw->dim.y) ||
-      roundUpDivision(mRaw->dim.y, yPerSlice) != counts->count) {
+  if (yPerSlice == 0 || yPerSlice > static_cast<uint32_t>(mRaw.get(0)->dim.y) ||
+      roundUpDivision(mRaw.get(0)->dim.y, yPerSlice) != counts->count) {
     ThrowRDE("Invalid y per slice %u or strip count %u (height = %u)",
-             yPerSlice, counts->count, mRaw->dim.y);
+             yPerSlice, counts->count, mRaw.get(0)->dim.y);
   }
 
   vector<NefSlice> slices;
@@ -257,7 +257,7 @@ void NefDecoder::DecodeUncompressed() const {
   assert(height == offY);
   assert(slices.size() == counts->count);
 
-  mRaw->createData();
+  mRaw.get(0)->createData();
   if (bitPerPixel == 14 && width*slices[0].h*2 == slices[0].count)
     bitPerPixel = 16; // D3 & D810
 
@@ -282,14 +282,14 @@ void NefDecoder::DecodeUncompressed() const {
     iPoint2D pos(0, offY);
 
     if (hints.has("coolpixmangled")) {
-      UncompressedDecompressor u(in, mRaw.get());
+      UncompressedDecompressor u(in, mRaw.get(0).get());
       u.readUncompressedRaw(size, pos, width * bitPerPixel / 8, 12,
                             BitOrder::MSB32);
     } else {
       if (hints.has("coolpixsplit"))
         readCoolpixSplitRaw(in, size, pos, width * bitPerPixel / 8);
       else {
-        UncompressedDecompressor u(in, mRaw.get());
+        UncompressedDecompressor u(in, mRaw.get(0).get());
         if (in.getSize() % size.y != 0)
           ThrowRDE("Inconsistent row size");
         const auto inputPitchBytes = in.getSize() / size.y;
@@ -305,7 +305,7 @@ void NefDecoder::DecodeUncompressed() const {
 void NefDecoder::readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
                                      const iPoint2D& offset,
                                      int inputPitch) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
   assert(rawU16);
   const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -321,9 +321,9 @@ void NefDecoder::readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
   // know where the first input bit for first odd row is, the input slice width
   // must be a multiple of 8 pixels.
 
-  if (offset.x > mRaw->dim.x || offset.y > mRaw->dim.y)
+  if (offset.x > mRaw.get(0)->dim.x || offset.y > mRaw.get(0)->dim.y)
     ThrowRDE("All pixels outside of image");
-  if (offset.x + size.x > mRaw->dim.x || offset.y + size.y > mRaw->dim.y)
+  if (offset.x + size.x > mRaw.get(0)->dim.x || offset.y + size.y > mRaw.get(0)->dim.y)
     ThrowRDE("Output is partailly out of image");
 
   // The input bytes are laid out in the memory in the following way:
@@ -350,8 +350,8 @@ void NefDecoder::DecodeD100Uncompressed() const {
   uint32_t width = 3040;
   uint32_t height = 2024;
 
-  mRaw->dim = iPoint2D(width, height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(width, height);
+  mRaw.get(0)->createData();
 
   if (ByteStream bs(DataBuffer(mFile.getSubView(offset), Endianness::little));
       bs.getRemainSize() == 0)
@@ -359,7 +359,7 @@ void NefDecoder::DecodeD100Uncompressed() const {
 
   UncompressedDecompressor u(
       ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
-      mRaw.get());
+      mRaw.get(0).get());
 
   u.decode12BitRaw<Endianness::big, false, true>(width, height);
 }
@@ -374,10 +374,10 @@ void NefDecoder::DecodeSNefUncompressed() const {
       height > 2456)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
-  mRaw->dim = iPoint2D(width, height);
-  mRaw->setCpp(3);
-  mRaw->isCFA = false;
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(width, height);
+  mRaw.get(0)->setCpp(3);
+  mRaw.get(0)->isCFA = false;
+  mRaw.get(0)->createData();
 
   ByteStream in(DataBuffer(mFile.getSubView(offset), Endianness::little));
   DecodeNikonSNef(in);
@@ -472,11 +472,11 @@ const std::array<uint8_t, 256> NefDecoder::keymap = {
 
 void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
+  mRaw.get(0)->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
                    CFAColor::GREEN, CFAColor::BLUE);
 
-  int white = mRaw->whitePoint;
-  int black = mRaw->blackLevel;
+  int white = mRaw.get(0)->whitePoint;
+  int black = mRaw.get(0)->blackLevel;
 
   if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(TiffTag::ISOSPEEDRATINGS)->getU32();
@@ -486,11 +486,11 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (mRootIFD->hasEntryRecursive(static_cast<TiffTag>(12))) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(static_cast<TiffTag>(12));
     if (wb->count == 4) {
-      mRaw->metadata.wbCoeffs[0] = wb->getFloat(0);
-      mRaw->metadata.wbCoeffs[1] = wb->getFloat(2);
-      mRaw->metadata.wbCoeffs[2] = wb->getFloat(1);
-      if (mRaw->metadata.wbCoeffs[1] <= 0.0F)
-        mRaw->metadata.wbCoeffs[1] = 1.0F;
+      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
+      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(2);
+      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(1);
+      if (mRaw.get(0)->metadata.wbCoeffs[1] <= 0.0F)
+        mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
     }
   } else if (mRootIFD->hasEntryRecursive(static_cast<TiffTag>(0x0097))) {
     const TiffEntry* wb =
@@ -506,14 +506,14 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 
       if (version == 0x100 && wb->count >= 80 &&
           wb->type == TiffDataType::UNDEFINED) {
-        mRaw->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(36));
-        mRaw->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(37));
-        mRaw->metadata.wbCoeffs[1] = static_cast<float>(wb->getU16(38));
+        mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(36));
+        mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(37));
+        mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(wb->getU16(38));
       } else if (version == 0x103 && wb->count >= 26 &&
                  wb->type == TiffDataType::UNDEFINED) {
-        mRaw->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(10));
-        mRaw->metadata.wbCoeffs[1] = static_cast<float>(wb->getU16(11));
-        mRaw->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(12));
+        mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(wb->getU16(10));
+        mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(wb->getU16(11));
+        mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(wb->getU16(12));
       } else if (((version == 0x204 && wb->count >= 564) ||
                   (version == 0x205 && wb->count >= 284)) &&
                  mRootIFD->hasEntryRecursive(static_cast<TiffTag>(0x001d)) &&
@@ -555,11 +555,11 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 
         // Finally set the WB coeffs
         uint32_t off = (version == 0x204) ? 6 : 14;
-        mRaw->metadata.wbCoeffs[0] =
+        mRaw.get(0)->metadata.wbCoeffs[0] =
             static_cast<float>(getU16BE(buf.data() + off + 0));
-        mRaw->metadata.wbCoeffs[1] =
+        mRaw.get(0)->metadata.wbCoeffs[1] =
             static_cast<float>(getU16BE(buf.data() + off + 2));
-        mRaw->metadata.wbCoeffs[2] =
+        mRaw.get(0)->metadata.wbCoeffs[2] =
             static_cast<float>(getU16BE(buf.data() + off + 6));
       }
     }
@@ -570,9 +570,9 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     if (wb->count == 2560 && wb->type == TiffDataType::UNDEFINED) {
       bs.skipBytes(1248);
       bs.setByteOrder(Endianness::big);
-      mRaw->metadata.wbCoeffs[0] = static_cast<float>(bs.getU16()) / 256.0;
-      mRaw->metadata.wbCoeffs[1] = 1.0F;
-      mRaw->metadata.wbCoeffs[2] = static_cast<float>(bs.getU16()) / 256.0;
+      mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(bs.getU16()) / 256.0;
+      mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
+      mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(bs.getU16()) / 256.0;
     } else if (bs.hasPatternAt("NRW ", 4, 0)) {
       uint32_t offset = 0;
       if (!bs.hasPatternAt("0100", 4, 4) && wb->count > 72)
@@ -583,17 +583,17 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       if (offset) {
         bs.skipBytes(offset);
         bs.setByteOrder(Endianness::little);
-        mRaw->metadata.wbCoeffs[0] = 4.0 * bs.getU32();
-        mRaw->metadata.wbCoeffs[1] = bs.getU32();
-        mRaw->metadata.wbCoeffs[1] += bs.getU32();
-        mRaw->metadata.wbCoeffs[2] = 4.0 * bs.getU32();
+        mRaw.get(0)->metadata.wbCoeffs[0] = 4.0 * bs.getU32();
+        mRaw.get(0)->metadata.wbCoeffs[1] = bs.getU32();
+        mRaw.get(0)->metadata.wbCoeffs[1] += bs.getU32();
+        mRaw.get(0)->metadata.wbCoeffs[2] = 4.0 * bs.getU32();
       }
     }
   }
 
   if (hints.has("nikon_wb_adjustment")) {
-    mRaw->metadata.wbCoeffs[0] *= 256/527.0;
-    mRaw->metadata.wbCoeffs[2] *= 256/317.0;
+    mRaw.get(0)->metadata.wbCoeffs[0] *= 256/527.0;
+    mRaw.get(0)->metadata.wbCoeffs[2] *= 256/317.0;
   }
 
   auto id = mRootIFD->getID();
@@ -608,9 +608,9 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   }
 
   if (white != 65536)
-    mRaw->whitePoint = white;
+    mRaw.get(0)->whitePoint = white;
   if (black != -1)
-    mRaw->blackLevel = black;
+    mRaw.get(0)->blackLevel = black;
 }
 
 
@@ -619,8 +619,8 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 // Note that values are scaled. See comment below on details.
 // OPTME: It would be trivial to run this multithreaded.
 void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
-  if (mRaw->dim.x < 6)
-    ThrowIOE("got a %u wide sNEF, aborting", mRaw->dim.x);
+  if (mRaw.get(0)->dim.x < 6)
+    ThrowIOE("got a %u wide sNEF, aborting", mRaw.get(0)->dim.x);
 
   // We need to read the applied whitebalance, since we should return
   // data before whitebalance, so we "unapply" it.
@@ -640,9 +640,9 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
       wb_r < lower_limit || wb_b < lower_limit || wb_r > 10.0F || wb_b > 10.0F)
     ThrowRDE("Whitebalance has bad values (%f, %f)", wb_r, wb_b);
 
-  mRaw->metadata.wbCoeffs[0] = wb_r;
-  mRaw->metadata.wbCoeffs[1] = 1.0F;
-  mRaw->metadata.wbCoeffs[2] = wb_b;
+  mRaw.get(0)->metadata.wbCoeffs[0] = wb_r;
+  mRaw.get(0)->metadata.wbCoeffs[1] = 1.0F;
+  mRaw.get(0)->metadata.wbCoeffs[2] = wb_b;
 
   auto inv_wb_r = static_cast<int>(1024.0 / wb_r);
   auto inv_wb_b = static_cast<int>(1024.0 / wb_b);
@@ -656,12 +656,12 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
 
   curve.resize(4095);
 
-  RawImageCurveGuard curveHandler(mRaw.get(), curve, false);
+  RawImageCurveGuard curveHandler(mRaw.get(0).get(), curve, false);
 
   uint16_t tmp;
   auto* tmpch = reinterpret_cast<uint8_t*>(&tmp);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   const uint8_t* in = input.peekData(out.width * out.height);
@@ -698,27 +698,27 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) const {
       cb2 -= 2048;
       cr2 -= 2048;
 
-      mRaw->setWithLookUp(clampBits(static_cast<int>(y1 + 1.370705 * cr), 12),
+      mRaw.get(0)->setWithLookUp(clampBits(static_cast<int>(y1 + 1.370705 * cr), 12),
                           tmpch, &random);
       out(row, col) = clampBits((inv_wb_r * tmp + (1 << 9)) >> 10, 15);
 
-      mRaw->setWithLookUp(
+      mRaw.get(0)->setWithLookUp(
           clampBits(static_cast<int>(y1 - 0.337633 * cb - 0.698001 * cr), 12),
           reinterpret_cast<uint8_t*>(&out(row, col + 1)), &random);
 
-      mRaw->setWithLookUp(clampBits(static_cast<int>(y1 + 1.732446 * cb), 12),
+      mRaw.get(0)->setWithLookUp(clampBits(static_cast<int>(y1 + 1.732446 * cb), 12),
                           tmpch, &random);
       out(row, col + 2) = clampBits((inv_wb_b * tmp + (1 << 9)) >> 10, 15);
 
-      mRaw->setWithLookUp(clampBits(static_cast<int>(y2 + 1.370705 * cr2), 12),
+      mRaw.get(0)->setWithLookUp(clampBits(static_cast<int>(y2 + 1.370705 * cr2), 12),
                           tmpch, &random);
       out(row, col + 3) = clampBits((inv_wb_r * tmp + (1 << 9)) >> 10, 15);
 
-      mRaw->setWithLookUp(
+      mRaw.get(0)->setWithLookUp(
           clampBits(static_cast<int>(y2 - 0.337633 * cb2 - 0.698001 * cr2), 12),
           reinterpret_cast<uint8_t*>(&out(row, col + 4)), &random);
 
-      mRaw->setWithLookUp(clampBits(static_cast<int>(y2 + 1.732446 * cb2), 12),
+      mRaw.get(0)->setWithLookUp(clampBits(static_cast<int>(y2 + 1.732446 * cb2), 12),
                           tmpch, &random);
       out(row, col + 5) = clampBits((inv_wb_b * tmp + (1 << 9)) >> 10, 15);
     }

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -305,7 +305,7 @@ void NefDecoder::DecodeUncompressed() const {
 void NefDecoder::readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
                                      const iPoint2D& offset,
                                      int inputPitch) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
   assert(rawU16);
   const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -661,7 +661,7 @@ void NefDecoder::DecodeNikonSNef(const ByteStream& input) {
   uint16_t tmp;
   auto* tmpch = reinterpret_cast<uint8_t*>(&tmp);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   const uint8_t* in = input.peekData(out.width * out.height);

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -63,7 +63,7 @@ bool NefDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   return make == "NIKON CORPORATION" || make == "NIKON";
 }
 
-RawImage NefDecoder::decodeRawInternal() {
+void NefDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::CFAPATTERN);
   auto compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
 
@@ -76,19 +76,19 @@ RawImage NefDecoder::decodeRawInternal() {
       ThrowRDE("Image data outside of file.");
     if (!D100IsCompressed(offsets->getU32())) {
       DecodeD100Uncompressed();
-      return mRaw;
+      return;
     }
   }
 
   if (compression == 1 || (hints.has("force_uncompressed")) ||
       NEFIsUncompressed(raw)) {
     DecodeUncompressed();
-    return mRaw;
+    return;
   }
 
   if (NEFIsUncompressedRGB(raw)) {
     DecodeSNefUncompressed();
-    return mRaw;
+    return;
   }
 
   if (offsets->count != 1) {
@@ -127,8 +127,6 @@ RawImage NefDecoder::decodeRawInternal() {
   NikonDecompressor n(mRaw, meta->getData(), bitPerPixel);
   mRaw->createData();
   n.decompress(rawData, uncorrectedRawValues);
-
-  return mRaw;
 }
 
 /*

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -45,7 +45,7 @@ public:
   NefDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   void checkSupportInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -58,10 +58,10 @@ private:
   static bool NEFIsUncompressedRGB(const TiffIFD* raw);
   void DecodeUncompressed() const;
   void DecodeD100Uncompressed() const;
-  void DecodeSNefUncompressed() const;
+  void DecodeSNefUncompressed();
   void readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
                            const iPoint2D& offset, int inputPitch) const;
-  void DecodeNikonSNef(const ByteStream& input) const;
+  void DecodeNikonSNef(const ByteStream& input);
   [[nodiscard]] std::string getMode() const;
   [[nodiscard]] std::string getExtendedMode(const std::string& mode) const;
   static std::vector<uint16_t> gammaCurve(double pwr, double ts, int mode,

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -123,14 +123,14 @@ void OrfDecoder::decodeRawInternal() {
     ThrowRDE("%u stripes, and not uncompressed. Unsupported.",
              raw->getEntry(TiffTag::STRIPOFFSETS)->count);
 
-  OlympusDecompressor o(mRaw);
+  OlympusDecompressor o(mRaw.get());
   mRaw->createData();
   o.decompress(std::move(input));
 }
 
 bool OrfDecoder::decodeUncompressed(const ByteStream& s, uint32_t w, uint32_t h,
                                     uint32_t size) const {
-  UncompressedDecompressor u(s, mRaw);
+  UncompressedDecompressor u(s, mRaw.get());
   // FIXME: most of this logic should be in UncompressedDecompressor,
   // one way or another.
 

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -220,10 +220,10 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 
   if (mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSREDMULTIPLIER) &&
       mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSBLUEMULTIPLIER)) {
-    mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[0] = static_cast<float>(
         mRootIFD->getEntryRecursive(TiffTag::OLYMPUSREDMULTIPLIER)->getU16());
-    mRaw.get(0)->metadata.wbCoeffs[1] = 256.0F;
-    mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[1] = 256.0F;
+    mRaw.metadata.wbCoeffs[2] = static_cast<float>(
         mRootIFD->getEntryRecursive(TiffTag::OLYMPUSBLUEMULTIPLIER)->getU16());
   } else if (mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSIMAGEPROCESSING)) {
     // Newer cameras process the Image Processing SubIFD in the makernote
@@ -240,9 +240,9 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       const TiffEntry* wb =
           image_processing.getEntry(static_cast<TiffTag>(0x0100));
       if (wb->count == 2 || wb->count == 4) {
-        mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
-        mRaw.get(0)->metadata.wbCoeffs[1] = 256.0F;
-        mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(1);
+        mRaw.metadata.wbCoeffs[0] = wb->getFloat(0);
+        mRaw.metadata.wbCoeffs[1] = 256.0F;
+        mRaw.metadata.wbCoeffs[2] = wb->getFloat(1);
       }
     }
 

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -99,7 +99,7 @@ ByteStream OrfDecoder::handleSlices() const {
   return input.getStream(size);
 }
 
-RawImage OrfDecoder::decodeRawInternal() {
+void OrfDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS);
 
   if (int compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
@@ -117,7 +117,7 @@ RawImage OrfDecoder::decodeRawInternal() {
   ByteStream input(handleSlices());
 
   if (decodeUncompressed(input, width, height, input.getSize()))
-    return mRaw;
+    return;
 
   if (raw->getEntry(TiffTag::STRIPOFFSETS)->count != 1)
     ThrowRDE("%u stripes, and not uncompressed. Unsupported.",
@@ -126,8 +126,6 @@ RawImage OrfDecoder::decodeRawInternal() {
   OlympusDecompressor o(mRaw);
   mRaw->createData();
   o.decompress(std::move(input));
-
-  return mRaw;
 }
 
 bool OrfDecoder::decodeUncompressed(const ByteStream& s, uint32_t w, uint32_t h,

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -112,7 +112,7 @@ void OrfDecoder::decodeRawInternal() {
   if (!width || !height || width % 2 != 0 || width > 10400 || height > 7796)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   ByteStream input(handleSlices());
 
@@ -123,20 +123,20 @@ void OrfDecoder::decodeRawInternal() {
     ThrowRDE("%u stripes, and not uncompressed. Unsupported.",
              raw->getEntry(TiffTag::STRIPOFFSETS)->count);
 
-  OlympusDecompressor o(mRaw.get());
-  mRaw->createData();
+  OlympusDecompressor o(mRaw.get(0).get());
+  mRaw.get(0)->createData();
   o.decompress(std::move(input));
 }
 
 bool OrfDecoder::decodeUncompressed(const ByteStream& s, uint32_t w, uint32_t h,
                                     uint32_t size) const {
-  UncompressedDecompressor u(s, mRaw.get());
+  UncompressedDecompressor u(s, mRaw.get(0).get());
   // FIXME: most of this logic should be in UncompressedDecompressor,
   // one way or another.
 
   if (size == h * ((w * 12 / 8) + ((w + 2) / 10))) {
     // 12-bit  packed 'with control' raw
-    mRaw->createData();
+    mRaw.get(0)->createData();
     u.decode12BitRaw<Endianness::little, false, true>(w, h);
     return true;
   }
@@ -144,13 +144,13 @@ bool OrfDecoder::decodeUncompressed(const ByteStream& s, uint32_t w, uint32_t h,
   if (size == w * h * 12 / 8) { // We're in a 12-bit packed raw
     iPoint2D dimensions(w, h);
     iPoint2D pos(0, 0);
-    mRaw->createData();
+    mRaw.get(0)->createData();
     u.readUncompressedRaw(dimensions, pos, w * 12 / 8, 12, BitOrder::MSB32);
     return true;
   }
 
   if (size == w * h * 2) { // We're in an unpacked raw
-    mRaw->createData();
+    mRaw.get(0)->createData();
     // FIXME: seems fishy
     if (s.getByteOrder() == getHostEndianness())
       u.decodeRawUnpacked<12, Endianness::little>(w, h);
@@ -161,7 +161,7 @@ bool OrfDecoder::decodeUncompressed(const ByteStream& s, uint32_t w, uint32_t h,
 
   if (size >
       w * h * 3 / 2) { // We're in one of those weird interlaced packed raws
-    mRaw->createData();
+    mRaw.get(0)->createData();
     u.decode12BitRaw<Endianness::big, true>(w, h);
     return true;
   }
@@ -184,7 +184,7 @@ void OrfDecoder::parseCFA() const {
   if (cfaSize != iPoint2D{2, 2})
     ThrowRDE("Bad CFA size: (%i, %i)", cfaSize.x, cfaSize.y);
 
-  mRaw->cfa.setSize(cfaSize);
+  mRaw.get(0)->cfa.setSize(cfaSize);
 
   auto int2enum = [](uint8_t i) {
     switch (i) {
@@ -203,7 +203,7 @@ void OrfDecoder::parseCFA() const {
     for (int x = 0; x < cfaSize.x; x++) {
       uint8_t c1 = CFA->getByte(4 + x + y * cfaSize.x);
       CFAColor c2 = int2enum(c1);
-      mRaw->cfa.setColorAt(iPoint2D(x, y), c2);
+      mRaw.get(0)->cfa.setColorAt(iPoint2D(x, y), c2);
     }
   }
 }
@@ -220,10 +220,10 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 
   if (mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSREDMULTIPLIER) &&
       mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSBLUEMULTIPLIER)) {
-    mRaw->metadata.wbCoeffs[0] = static_cast<float>(
+    mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(
         mRootIFD->getEntryRecursive(TiffTag::OLYMPUSREDMULTIPLIER)->getU16());
-    mRaw->metadata.wbCoeffs[1] = 256.0F;
-    mRaw->metadata.wbCoeffs[2] = static_cast<float>(
+    mRaw.get(0)->metadata.wbCoeffs[1] = 256.0F;
+    mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(
         mRootIFD->getEntryRecursive(TiffTag::OLYMPUSBLUEMULTIPLIER)->getU16());
   } else if (mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSIMAGEPROCESSING)) {
     // Newer cameras process the Image Processing SubIFD in the makernote
@@ -240,9 +240,9 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       const TiffEntry* wb =
           image_processing.getEntry(static_cast<TiffTag>(0x0100));
       if (wb->count == 2 || wb->count == 4) {
-        mRaw->metadata.wbCoeffs[0] = wb->getFloat(0);
-        mRaw->metadata.wbCoeffs[1] = 256.0F;
-        mRaw->metadata.wbCoeffs[2] = wb->getFloat(1);
+        mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(0);
+        mRaw.get(0)->metadata.wbCoeffs[1] = 256.0F;
+        mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(1);
       }
     }
 
@@ -253,7 +253,7 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       // Order is assumed to be RGGB
       if (blackEntry->count == 4) {
         for (int i = 0; i < 4; i++) {
-          auto c = mRaw->cfa.getColorAt(i & 1, i >> 1);
+          auto c = mRaw.get(0)->cfa.getColorAt(i & 1, i >> 1);
           int j;
           switch (c) {
           case CFAColor::RED:
@@ -269,11 +269,11 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
             ThrowRDE("Unexpected CFA color: %u", static_cast<unsigned>(c));
           }
 
-          mRaw->blackLevelSeparate[i] = blackEntry->getU16(j);
+          mRaw.get(0)->blackLevelSeparate[i] = blackEntry->getU16(j);
         }
         // Adjust whitelevel based on the read black (we assume the dynamic
         // range is the same)
-        mRaw->whitePoint -= (mRaw->blackLevel - mRaw->blackLevelSeparate[0]);
+        mRaw.get(0)->whitePoint -= (mRaw.get(0)->blackLevel - mRaw.get(0)->blackLevelSeparate[0]);
       }
     }
   }

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -43,7 +43,7 @@ public:
   OrfDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -49,14 +49,14 @@ bool PefDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
          make == "RICOH IMAGING COMPANY, LTD." || make == "PENTAX";
 }
 
-RawImage PefDecoder::decodeRawInternal() {
+void PefDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS);
 
   int compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
 
   if (1 == compression || compression == 32773) {
     decodeUncompressed(raw, BitOrder::MSB);
-    return mRaw;
+    return;
   }
 
   if (65535 != compression)
@@ -96,8 +96,6 @@ RawImage PefDecoder::decodeRawInternal() {
   PentaxDecompressor p(mRaw, metaData);
   mRaw->createData();
   p.decompress(bs);
-
-  return mRaw;
 }
 
 void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -123,9 +123,9 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb =
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x0201));
     if (wb->count == 4) {
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getU32(0);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getU32(1);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getU32(3);
+      mRaw.metadata.wbCoeffs[0] = wb->getU32(0);
+      mRaw.metadata.wbCoeffs[1] = wb->getU32(1);
+      mRaw.metadata.wbCoeffs[2] = wb->getU32(3);
     }
   }
 }

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -93,7 +93,7 @@ void PefDecoder::decodeRawInternal() {
     metaData = t->getData();
   }
 
-  PentaxDecompressor p(mRaw, metaData);
+  PentaxDecompressor p(mRaw.get(), metaData);
   mRaw->createData();
   p.decompress(bs);
 }

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -80,7 +80,7 @@ void PefDecoder::decodeRawInternal() {
   uint32_t width = raw->getEntry(TiffTag::IMAGEWIDTH)->getU32();
   uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   std::optional<ByteStream> metaData;
   if (getRootIFD()->hasEntryRecursive(static_cast<TiffTag>(0x220))) {
@@ -93,14 +93,14 @@ void PefDecoder::decodeRawInternal() {
     metaData = t->getData();
   }
 
-  PentaxDecompressor p(mRaw.get(), metaData);
-  mRaw->createData();
+  PentaxDecompressor p(mRaw.get(0).get(), metaData);
+  mRaw.get(0)->createData();
   p.decompress(bs);
 }
 
 void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
+  mRaw.get(0)->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
                    CFAColor::GREEN, CFAColor::BLUE);
 
   if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
@@ -114,7 +114,7 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x200));
     if (black->count == 4) {
       for (int i = 0; i < 4; i++)
-        mRaw->blackLevelSeparate[i] = black->getU32(i);
+        mRaw.get(0)->blackLevelSeparate[i] = black->getU32(i);
     }
   }
 
@@ -123,9 +123,9 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb =
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x0201));
     if (wb->count == 4) {
-      mRaw->metadata.wbCoeffs[0] = wb->getU32(0);
-      mRaw->metadata.wbCoeffs[1] = wb->getU32(1);
-      mRaw->metadata.wbCoeffs[2] = wb->getU32(3);
+      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getU32(0);
+      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getU32(1);
+      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getU32(3);
     }
   }
 }

--- a/src/librawspeed/decoders/PefDecoder.h
+++ b/src/librawspeed/decoders/PefDecoder.h
@@ -38,7 +38,7 @@ public:
   PefDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -64,7 +64,7 @@ bool RafDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   return make == "FUJIFILM";
 }
 
-RawImage RafDecoder::decodeRawInternal() {
+void RafDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::FUJI_STRIPOFFSETS);
   uint32_t height = 0;
   uint32_t width = 0;
@@ -107,7 +107,7 @@ RawImage RafDecoder::decodeRawInternal() {
 
     f.decompress();
 
-    return mRaw;
+    return;
   }
 
   // x-trans sensors report 14bpp, but data isn't packed
@@ -169,8 +169,6 @@ RawImage RafDecoder::decodeRawInternal() {
                             BitOrder::LSB);
     }
   }
-
-  return mRaw;
 }
 
 void RafDecoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -223,7 +223,7 @@ void RafDecoder::applyCorrections(const Camera* cam) {
 
     iPoint2D final_size(rotatedsize, rotatedsize-1);
     auto rotated =
-        new RawImageDataU16(final_size, 1);
+        std::make_shared<RawImageDataU16>(final_size, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
     rotated->metadata = mRaw.get(0)->metadata;
     rotated->metadata.fujiRotationPos = rotationPos;

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -97,7 +97,7 @@ void RafDecoder::decodeRawInternal() {
   input = input.getSubStream(offsets->getU32(), counts->getU32());
 
   if (isCompressed()) {
-    mRaw.get(0)->metadata.mode = "compressed";
+    mRaw.metadata.mode = "compressed";
 
     mRaw.get(0)->dim = iPoint2D(width, height);
 
@@ -176,10 +176,10 @@ void RafDecoder::checkSupportInternal(const CameraMetaData* meta) {
     ThrowRDE("Unknown camera. Will not guess.");
 
   if (isCompressed()) {
-    mRaw.get(0)->metadata.mode = "compressed";
+    mRaw.metadata.mode = "compressed";
 
     auto id = mRootIFD->getID();
-    const Camera* cam = meta->getCamera(id.make, id.model, mRaw.get(0)->metadata.mode);
+    const Camera* cam = meta->getCamera(id.make, id.model, mRaw.metadata.mode);
     if (!cam)
       ThrowRDE("Couldn't find camera %s %s", id.make.c_str(), id.model.c_str());
 
@@ -225,8 +225,7 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     auto rotated =
         std::make_shared<RawImageDataU16>(final_size, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
-    rotated->metadata = mRaw.get(0)->metadata;
-    rotated->metadata.fujiRotationPos = rotationPos;
+    mRaw.metadata.fujiRotationPos = rotationPos;
 
     auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
     assert(rawU16);
@@ -261,12 +260,12 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   int iso = 0;
   if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(TiffTag::ISOSPEEDRATINGS)->getU32();
-  mRaw.get(0)->metadata.isoSpeed = iso;
+  mRaw.metadata.isoSpeed = iso;
 
   // This is where we'd normally call setMetaData but since we may still need
   // to rotate the image for SuperCCD cameras we do everything ourselves
   auto id = mRootIFD->getID();
-  const Camera* cam = meta->getCamera(id.make, id.model, mRaw.get(0)->metadata.mode);
+  const Camera* cam = meta->getCamera(id.make, id.model, mRaw.metadata.mode);
   if (!cam)
     ThrowRDE("Couldn't find camera");
 
@@ -304,28 +303,28 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   mRaw.get(0)->blackAreas = cam->blackAreas;
   mRaw.get(0)->cfa = cam->cfa;
   if (!cam->color_matrix.empty())
-    mRaw.get(0)->metadata.colorMatrix = cam->color_matrix;
-  mRaw.get(0)->metadata.canonical_make = cam->canonical_make;
-  mRaw.get(0)->metadata.canonical_model = cam->canonical_model;
-  mRaw.get(0)->metadata.canonical_alias = cam->canonical_alias;
-  mRaw.get(0)->metadata.canonical_id = cam->canonical_id;
-  mRaw.get(0)->metadata.make = id.make;
-  mRaw.get(0)->metadata.model = id.model;
+    mRaw.metadata.colorMatrix = cam->color_matrix;
+  mRaw.metadata.canonical_make = cam->canonical_make;
+  mRaw.metadata.canonical_model = cam->canonical_model;
+  mRaw.metadata.canonical_alias = cam->canonical_alias;
+  mRaw.metadata.canonical_id = cam->canonical_id;
+  mRaw.metadata.make = id.make;
+  mRaw.metadata.model = id.model;
 
   if (mRootIFD->hasEntryRecursive(TiffTag::FUJI_WB_GRBLEVELS)) {
     const TiffEntry* wb =
         mRootIFD->getEntryRecursive(TiffTag::FUJI_WB_GRBLEVELS);
     if (wb->count == 3) {
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(1);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(0);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(2);
+      mRaw.metadata.wbCoeffs[0] = wb->getFloat(1);
+      mRaw.metadata.wbCoeffs[1] = wb->getFloat(0);
+      mRaw.metadata.wbCoeffs[2] = wb->getFloat(2);
     }
   } else if (mRootIFD->hasEntryRecursive(TiffTag::FUJIOLDWB)) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::FUJIOLDWB);
     if (wb->count == 8) {
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(1);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(0);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(3);
+      mRaw.metadata.wbCoeffs[0] = wb->getFloat(1);
+      mRaw.metadata.wbCoeffs[1] = wb->getFloat(0);
+      mRaw.metadata.wbCoeffs[2] = wb->getFloat(3);
     }
   }
 }

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -97,13 +97,13 @@ void RafDecoder::decodeRawInternal() {
   input = input.getSubStream(offsets->getU32(), counts->getU32());
 
   if (isCompressed()) {
-    mRaw->metadata.mode = "compressed";
+    mRaw.get(0)->metadata.mode = "compressed";
 
-    mRaw->dim = iPoint2D(width, height);
+    mRaw.get(0)->dim = iPoint2D(width, height);
 
-    FujiDecompressor f(mRaw.get(), input);
+    FujiDecompressor f(mRaw.get(0).get(), input);
 
-    mRaw->createData();
+    mRaw.get(0)->createData();
 
     f.decompress();
 
@@ -148,10 +148,10 @@ void RafDecoder::decodeRawInternal() {
   double_width = hints.has("double_width_unpacked");
   const uint32_t real_width = double_width ? 2U * width : width;
 
-  mRaw->dim = iPoint2D(real_width, height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(real_width, height);
+  mRaw.get(0)->createData();
 
-  UncompressedDecompressor u(input, mRaw.get());
+  UncompressedDecompressor u(input, mRaw.get(0).get());
 
   if (double_width) {
     u.decodeRawUnpacked<16, Endianness::little>(width * 2, height);
@@ -162,10 +162,10 @@ void RafDecoder::decodeRawInternal() {
   } else {
     iPoint2D pos(0, 0);
     if (hints.has("jpeg32_bitorder")) {
-      u.readUncompressedRaw(mRaw->dim, pos, width * bps / 8, bps,
+      u.readUncompressedRaw(mRaw.get(0)->dim, pos, width * bps / 8, bps,
                             BitOrder::MSB32);
     } else {
-      u.readUncompressedRaw(mRaw->dim, pos, width * bps / 8, bps,
+      u.readUncompressedRaw(mRaw.get(0)->dim, pos, width * bps / 8, bps,
                             BitOrder::LSB);
     }
   }
@@ -176,19 +176,19 @@ void RafDecoder::checkSupportInternal(const CameraMetaData* meta) {
     ThrowRDE("Unknown camera. Will not guess.");
 
   if (isCompressed()) {
-    mRaw->metadata.mode = "compressed";
+    mRaw.get(0)->metadata.mode = "compressed";
 
     auto id = mRootIFD->getID();
-    const Camera* cam = meta->getCamera(id.make, id.model, mRaw->metadata.mode);
+    const Camera* cam = meta->getCamera(id.make, id.model, mRaw.get(0)->metadata.mode);
     if (!cam)
       ThrowRDE("Couldn't find camera %s %s", id.make.c_str(), id.model.c_str());
 
-    mRaw->cfa = cam->cfa;
+    mRaw.get(0)->cfa = cam->cfa;
   }
 }
 
 void RafDecoder::applyCorrections(const Camera* cam) {
-  iPoint2D new_size(mRaw->dim);
+  iPoint2D new_size(mRaw.get(0)->dim);
   iPoint2D crop_offset(0, 0);
 
   if (applyCrop) {
@@ -197,11 +197,11 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     bool double_width = hints.has("double_width_unpacked");
     // If crop size is negative, use relative cropping
     if (new_size.x <= 0)
-      new_size.x = mRaw->dim.x / (double_width ? 2 : 1) - cam->cropPos.x + new_size.x;
+      new_size.x = mRaw.get(0)->dim.x / (double_width ? 2 : 1) - cam->cropPos.x + new_size.x;
     else
       new_size.x /= (double_width ? 2 : 1);
     if (new_size.y <= 0)
-      new_size.y = mRaw->dim.y - cam->cropPos.y + new_size.y;
+      new_size.y = mRaw.get(0)->dim.y - cam->cropPos.y + new_size.y;
   }
 
   bool rotate = hints.has("fuji_rotate");
@@ -222,18 +222,16 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     }
 
     iPoint2D final_size(rotatedsize, rotatedsize-1);
-    std::shared_ptr<RawImageData> rotated =
-        std::make_shared<RawImageDataU16>(final_size, 1);
+    auto rotated =
+        new RawImageDataU16(final_size, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
-    rotated->metadata = mRaw->metadata;
+    rotated->metadata = mRaw.get(0)->metadata;
     rotated->metadata.fujiRotationPos = rotationPos;
 
-    auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+    auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
     assert(rawU16);
     auto srcImg = rawU16->getU16DataAsUncroppedArray2DRef();
-    auto rotatedU16 = dynamic_cast<RawImageDataU16*>(rotated.get());
-    assert(rotatedU16);
-    auto dstImg = rotatedU16->getU16DataAsUncroppedArray2DRef();
+    auto dstImg = rotated->getU16DataAsUncroppedArray2DRef();
 
     for (int y = 0; y < new_size.y; y++) {
       for (int x = 0; x < new_size.x; x++) {
@@ -252,9 +250,10 @@ void RafDecoder::applyCorrections(const Camera* cam) {
           ThrowRDE("Trying to write out of bounds");
       }
     }
-    mRaw = rotated;
+    mRaw.clear();
+    mRaw.appendFrame(rotated);
   } else if (applyCrop) {
-    mRaw->subFrame(iRectangle2D(crop_offset, new_size));
+    mRaw.get(0)->subFrame(iRectangle2D(crop_offset, new_size));
   }
 }
 
@@ -262,12 +261,12 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   int iso = 0;
   if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
     iso = mRootIFD->getEntryRecursive(TiffTag::ISOSPEEDRATINGS)->getU32();
-  mRaw->metadata.isoSpeed = iso;
+  mRaw.get(0)->metadata.isoSpeed = iso;
 
   // This is where we'd normally call setMetaData but since we may still need
   // to rotate the image for SuperCCD cameras we do everything ourselves
   auto id = mRootIFD->getID();
-  const Camera* cam = meta->getCamera(id.make, id.model, mRaw->metadata.mode);
+  const Camera* cam = meta->getCamera(id.make, id.model, mRaw.get(0)->metadata.mode);
   if (!cam)
     ThrowRDE("Couldn't find camera");
 
@@ -276,7 +275,7 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   applyCorrections(cam);
 
   const CameraSensorInfo *sensor = cam->getSensorInfo(iso);
-  mRaw->blackLevel = sensor->mBlackLevel;
+  mRaw.get(0)->blackLevel = sensor->mBlackLevel;
 
   // at least the (bayer sensor) X100 comes with a tag like this:
   if (mRootIFD->hasEntryRecursive(TiffTag::FUJI_BLACKLEVEL)) {
@@ -285,48 +284,48 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     if (sep_black->count == 4)
     {
       for(int k=0;k<4;k++)
-        mRaw->blackLevelSeparate[k] = sep_black->getU32(k);
+        mRaw.get(0)->blackLevelSeparate[k] = sep_black->getU32(k);
     } else if (sep_black->count == 36) {
-      for (int& k : mRaw->blackLevelSeparate)
+      for (int& k : mRaw.get(0)->blackLevelSeparate)
         k = 0;
 
       for (int y = 0; y < 6; y++) {
         for (int x = 0; x < 6; x++)
-          mRaw->blackLevelSeparate[2 * (y % 2) + (x % 2)] +=
+          mRaw.get(0)->blackLevelSeparate[2 * (y % 2) + (x % 2)] +=
               sep_black->getU32(6 * y + x);
       }
 
-      for (int& k : mRaw->blackLevelSeparate)
+      for (int& k : mRaw.get(0)->blackLevelSeparate)
         k /= 9;
     }
   }
 
-  mRaw->whitePoint = sensor->mWhiteLevel;
-  mRaw->blackAreas = cam->blackAreas;
-  mRaw->cfa = cam->cfa;
+  mRaw.get(0)->whitePoint = sensor->mWhiteLevel;
+  mRaw.get(0)->blackAreas = cam->blackAreas;
+  mRaw.get(0)->cfa = cam->cfa;
   if (!cam->color_matrix.empty())
-    mRaw->metadata.colorMatrix = cam->color_matrix;
-  mRaw->metadata.canonical_make = cam->canonical_make;
-  mRaw->metadata.canonical_model = cam->canonical_model;
-  mRaw->metadata.canonical_alias = cam->canonical_alias;
-  mRaw->metadata.canonical_id = cam->canonical_id;
-  mRaw->metadata.make = id.make;
-  mRaw->metadata.model = id.model;
+    mRaw.get(0)->metadata.colorMatrix = cam->color_matrix;
+  mRaw.get(0)->metadata.canonical_make = cam->canonical_make;
+  mRaw.get(0)->metadata.canonical_model = cam->canonical_model;
+  mRaw.get(0)->metadata.canonical_alias = cam->canonical_alias;
+  mRaw.get(0)->metadata.canonical_id = cam->canonical_id;
+  mRaw.get(0)->metadata.make = id.make;
+  mRaw.get(0)->metadata.model = id.model;
 
   if (mRootIFD->hasEntryRecursive(TiffTag::FUJI_WB_GRBLEVELS)) {
     const TiffEntry* wb =
         mRootIFD->getEntryRecursive(TiffTag::FUJI_WB_GRBLEVELS);
     if (wb->count == 3) {
-      mRaw->metadata.wbCoeffs[0] = wb->getFloat(1);
-      mRaw->metadata.wbCoeffs[1] = wb->getFloat(0);
-      mRaw->metadata.wbCoeffs[2] = wb->getFloat(2);
+      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(1);
+      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(0);
+      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(2);
     }
   } else if (mRootIFD->hasEntryRecursive(TiffTag::FUJIOLDWB)) {
     const TiffEntry* wb = mRootIFD->getEntryRecursive(TiffTag::FUJIOLDWB);
     if (wb->count == 8) {
-      mRaw->metadata.wbCoeffs[0] = wb->getFloat(1);
-      mRaw->metadata.wbCoeffs[1] = wb->getFloat(0);
-      mRaw->metadata.wbCoeffs[2] = wb->getFloat(3);
+      mRaw.get(0)->metadata.wbCoeffs[0] = wb->getFloat(1);
+      mRaw.get(0)->metadata.wbCoeffs[1] = wb->getFloat(0);
+      mRaw.get(0)->metadata.wbCoeffs[2] = wb->getFloat(3);
     }
   }
 }

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -123,22 +123,16 @@ void RafDecoder::decodeRawInternal() {
 
   if (8UL * counts->getU32() >= 2UL * 16UL * width * height) {
     bps = 16;
-    double_width = true;
   } else if (8UL * counts->getU32() >= 2UL * 14UL * width * height) {
     bps = 14;
-    double_width = true;
   } else if (8UL * counts->getU32() >= 2UL * 12UL * width * height) {
     bps = 12;
-    double_width = true;
   } else if (8UL * counts->getU32() >= 16UL * width * height) {
     bps = 16;
-    double_width = false;
   } else if (8UL * counts->getU32() >= 14UL * width * height) {
     bps = 14;
-    double_width = false;
   } else if (8UL * counts->getU32() >= 12UL * width * height) {
     bps = 12;
-    double_width = false;
   } else {
     ThrowRDE("Can not detect bitdepth. StripByteCounts = %u, width = %u, "
              "height = %u",

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -101,7 +101,7 @@ void RafDecoder::decodeRawInternal() {
 
     mRaw->dim = iPoint2D(width, height);
 
-    FujiDecompressor f(mRaw, input);
+    FujiDecompressor f(mRaw.get(), input);
 
     mRaw->createData();
 
@@ -151,7 +151,7 @@ void RafDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(real_width, height);
   mRaw->createData();
 
-  UncompressedDecompressor u(input, mRaw);
+  UncompressedDecompressor u(input, mRaw.get());
 
   if (double_width) {
     u.decodeRawUnpacked<16, Endianness::little>(width * 2, height);
@@ -222,7 +222,8 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     }
 
     iPoint2D final_size(rotatedsize, rotatedsize-1);
-    RawImage rotated = RawImage::create(final_size, RawImageType::UINT16, 1);
+    std::shared_ptr<RawImageData> rotated =
+        std::make_shared<RawImageDataU16>(final_size, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
     rotated->metadata = mRaw->metadata;
     rotated->metadata.fujiRotationPos = rotationPos;

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -228,8 +228,12 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     rotated->metadata = mRaw->metadata;
     rotated->metadata.fujiRotationPos = rotationPos;
 
-    auto srcImg = mRaw->getU16DataAsUncroppedArray2DRef();
-    auto dstImg = rotated->getU16DataAsUncroppedArray2DRef();
+    auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get());
+    assert(rawU16);
+    auto srcImg = rawU16->getU16DataAsUncroppedArray2DRef();
+    auto rotatedU16 = dynamic_cast<RawImageDataU16*>(rotated.get());
+    assert(rotatedU16);
+    auto dstImg = rotatedU16->getU16DataAsUncroppedArray2DRef();
 
     for (int y = 0; y < new_size.y; y++) {
       for (int x = 0; x < new_size.x; x++) {

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -227,7 +227,7 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
     mRaw.metadata.fujiRotationPos = rotationPos;
 
-    auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
+    auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw.get(0).get());
     assert(rawU16);
     auto srcImg = rawU16->getU16DataAsUncroppedArray2DRef();
     auto dstImg = rotated->getU16DataAsUncroppedArray2DRef();

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -121,17 +121,14 @@ void RafDecoder::decodeRawInternal() {
 
   assert(!isCompressed());
 
-  if (8UL * counts->getU32() >= 2UL * 16UL * width * height) {
+  if ((8UL * counts->getU32() >= 2UL * 16UL * width * height)
+      || (8UL * counts->getU32() >= 16UL * width * height)) {
     bps = 16;
-  } else if (8UL * counts->getU32() >= 2UL * 14UL * width * height) {
+  } else if ((8UL * counts->getU32() >= 2UL * 14UL * width * height)
+             || (8UL * counts->getU32() >= 14UL * width * height)) {
     bps = 14;
-  } else if (8UL * counts->getU32() >= 2UL * 12UL * width * height) {
-    bps = 12;
-  } else if (8UL * counts->getU32() >= 16UL * width * height) {
-    bps = 16;
-  } else if (8UL * counts->getU32() >= 14UL * width * height) {
-    bps = 14;
-  } else if (8UL * counts->getU32() >= 12UL * width * height) {
+  } else if ((8UL * counts->getU32() >= 2UL * 12UL * width * height)
+             || (8UL * counts->getU32() >= 12UL * width * height)) {
     bps = 12;
   } else {
     ThrowRDE("Can not detect bitdepth. StripByteCounts = %u, width = %u, "

--- a/src/librawspeed/decoders/RafDecoder.h
+++ b/src/librawspeed/decoders/RafDecoder.h
@@ -41,7 +41,7 @@ public:
   RafDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void applyCorrections(const Camera* cam);
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   void checkSupportInternal(const CameraMetaData* meta) override;

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -160,8 +160,8 @@ bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
                                       const std::string& make,
                                       const std::string& model,
                                       const std::string& mode) {
-  mRaw.get(0)->metadata.make = make;
-  mRaw.get(0)->metadata.model = model;
+  mRaw.metadata.make = make;
+  mRaw.metadata.model = model;
   const Camera* cam = meta->getCamera(make, model, mode);
   if (!cam) {
     askForSamples(meta, make, model, mode);
@@ -198,7 +198,7 @@ bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
 void RawDecoder::setMetaData(const CameraMetaData* meta,
                              const std::string& make, const std::string& model,
                              const std::string& mode, int iso_speed) {
-  mRaw.get(0)->metadata.isoSpeed = iso_speed;
+  mRaw.metadata.isoSpeed = iso_speed;
   const Camera* cam = meta->getCamera(make, model, mode);
   if (!cam) {
     askForSamples(meta, make, model, mode);
@@ -215,15 +215,15 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
     mRaw.get(0)->cfa = cam->cfa;
 
   if (!cam->color_matrix.empty())
-    mRaw.get(0)->metadata.colorMatrix = cam->color_matrix;
+    mRaw.metadata.colorMatrix = cam->color_matrix;
 
-  mRaw.get(0)->metadata.canonical_make = cam->canonical_make;
-  mRaw.get(0)->metadata.canonical_model = cam->canonical_model;
-  mRaw.get(0)->metadata.canonical_alias = cam->canonical_alias;
-  mRaw.get(0)->metadata.canonical_id = cam->canonical_id;
-  mRaw.get(0)->metadata.make = make;
-  mRaw.get(0)->metadata.model = model;
-  mRaw.get(0)->metadata.mode = mode;
+  mRaw.metadata.canonical_make = cam->canonical_make;
+  mRaw.metadata.canonical_model = cam->canonical_model;
+  mRaw.metadata.canonical_alias = cam->canonical_alias;
+  mRaw.metadata.canonical_id = cam->canonical_id;
+  mRaw.metadata.make = make;
+  mRaw.metadata.model = model;
+  mRaw.metadata.mode = mode;
 
   if (applyCrop) {
     iPoint2D new_size = cam->cropSize;
@@ -276,17 +276,17 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
 void RawDecoder::decodeRaw() {
   try {
     decodeRawInternal();
-    ///TODO paralelize?
+    /// TODO paralelize?
     for (auto raw : mRaw) {
       mRaw.get(0)->checkMemIsInitialized();
 
-      mRaw.get(0)->metadata.pixelAspectRatio = hints.get(
-          "pixel_aspect_ratio", mRaw.get(0)->metadata.pixelAspectRatio);
       if (interpolateBadPixels) {
         mRaw.get(0)->fixBadPixels();
         mRaw.get(0)->checkMemIsInitialized();
       }
     }
+    mRaw.metadata.pixelAspectRatio =
+        hints.get("pixel_aspect_ratio", mRaw.metadata.pixelAspectRatio);
 
   } catch (const TiffParserException& e) {
     ThrowRDE("%s", e.what());

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -276,15 +276,17 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
 void RawDecoder::decodeRaw() {
   try {
     decodeRawInternal();
-    mRaw.get(0)->checkMemIsInitialized();
-
-    mRaw.get(0)->metadata.pixelAspectRatio =
-        hints.get("pixel_aspect_ratio", mRaw.get(0)->metadata.pixelAspectRatio);
-    if (interpolateBadPixels) {
-      mRaw.get(0)->fixBadPixels();
+    ///TODO paralelize?
+    for (auto raw : mRaw) {
       mRaw.get(0)->checkMemIsInitialized();
-    }
 
+      mRaw.get(0)->metadata.pixelAspectRatio = hints.get(
+          "pixel_aspect_ratio", mRaw.get(0)->metadata.pixelAspectRatio);
+      if (interpolateBadPixels) {
+        mRaw.get(0)->fixBadPixels();
+        mRaw.get(0)->checkMemIsInitialized();
+      }
+    }
 
   } catch (const TiffParserException& e) {
     ThrowRDE("%s", e.what());

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -51,7 +51,7 @@ namespace rawspeed {
 RawDecoder::RawDecoder(const Buffer& file)
     : failOnUnknown(false), interpolateBadPixels(true),
       applyStage1DngOpcodes(true), applyCrop(true), uncorrectedRawValues(false),
-      fujiRotate(true), mFile(file) {mRaw.appendFrame(new RawImageDataU16());}
+      fujiRotate(true), mFile(file) {mRaw.appendFrame(std::make_shared<RawImageDataU16>());}
 
 void RawDecoder::decodeUncompressed(const TiffIFD* rawIFD,
                                     BitOrder order) const {

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -49,9 +49,9 @@ using std::vector;
 namespace rawspeed {
 
 RawDecoder::RawDecoder(const Buffer& file)
-    : mRaw(RawImage::create()), failOnUnknown(false),
-      interpolateBadPixels(true), applyStage1DngOpcodes(true), applyCrop(true),
-      uncorrectedRawValues(false), fujiRotate(true), mFile(file) {}
+    : failOnUnknown(false), interpolateBadPixels(true),
+      applyStage1DngOpcodes(true), applyCrop(true), uncorrectedRawValues(false),
+      fujiRotate(true), mFile(file) {}
 
 void RawDecoder::decodeUncompressed(const TiffIFD* rawIFD,
                                     BitOrder order) const {
@@ -128,7 +128,7 @@ void RawDecoder::decodeUncompressed(const TiffIFD* rawIFD,
     UncompressedDecompressor u(
         ByteStream(DataBuffer(mFile.getSubView(slice.offset, slice.count),
                               Endianness::little)),
-        mRaw);
+        mRaw.get());
     iPoint2D size(width, slice.h);
     iPoint2D pos(0, offY);
     bitPerPixel = (static_cast<uint64_t>(slice.count) * 8U) / (slice.h * width);

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -49,7 +49,7 @@ using std::vector;
 namespace rawspeed {
 
 RawDecoder::RawDecoder(const Buffer& file)
-    : failOnUnknown(false), interpolateBadPixels(true),
+    : mRaw(new RawImageDataU16()), failOnUnknown(false), interpolateBadPixels(true),
       applyStage1DngOpcodes(true), applyCrop(true), uncorrectedRawValues(false),
       fujiRotate(true), mFile(file) {}
 

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -273,19 +273,19 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
   }
 }
 
-rawspeed::RawImage RawDecoder::decodeRaw() {
+void RawDecoder::decodeRaw() {
   try {
-    RawImage raw = decodeRawInternal();
-    raw->checkMemIsInitialized();
+    decodeRawInternal();
+    mRaw->checkMemIsInitialized();
 
-    raw->metadata.pixelAspectRatio =
-        hints.get("pixel_aspect_ratio", raw->metadata.pixelAspectRatio);
+    mRaw->metadata.pixelAspectRatio =
+        hints.get("pixel_aspect_ratio", mRaw->metadata.pixelAspectRatio);
     if (interpolateBadPixels) {
-      raw->fixBadPixels();
-      raw->checkMemIsInitialized();
+      mRaw->fixBadPixels();
+      mRaw->checkMemIsInitialized();
     }
 
-    return raw;
+
   } catch (const TiffParserException& e) {
     ThrowRDE("%s", e.what());
   } catch (const FileIOException& e) {

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -277,12 +277,12 @@ void RawDecoder::decodeRaw() {
   try {
     decodeRawInternal();
     /// TODO paralelize?
-    for (auto raw : mRaw) {
-      mRaw.get(0)->checkMemIsInitialized();
+    for (const auto &raw : mRaw) {
+      raw->checkMemIsInitialized();
 
       if (interpolateBadPixels) {
-        mRaw.get(0)->fixBadPixels();
-        mRaw.get(0)->checkMemIsInitialized();
+        raw->fixBadPixels();
+        raw->checkMemIsInitialized();
       }
     }
     mRaw.metadata.pixelAspectRatio =

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -72,7 +72,7 @@ public:
 
   /* The decoded image - undefined if image has not or could not be decoded. */
   /* Remember this is automatically refcounted, so a reference is retained until this class is destroyed */
-  RawImage mRaw;
+  std::shared_ptr<RawImageData> mRaw;
 
   /* You can set this if you do not want Rawspeed to attempt to decode images, */
   /* where it does not have reliable information about CFA, cropping, black and white point */

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -72,7 +72,8 @@ public:
 
   /* The decoded image - undefined if image has not or could not be decoded. */
   /* Remember this is automatically refcounted, so a reference is retained until this class is destroyed */
-  std::shared_ptr<RawImageData> mRaw;
+  //std::shared_ptr<RawImageData> mRaw;
+  RawImage mRaw;
 
   /* You can set this if you do not want Rawspeed to attempt to decode images, */
   /* where it does not have reliable information about CFA, cropping, black and white point */

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -55,7 +55,7 @@ public:
   /* Attempt to decode the image */
   /* A RawDecoderException will be thrown if the image cannot be decoded, */
   /* and there will not be any data in the mRaw image. */
-  RawImage decodeRaw();
+  void decodeRaw();
 
   /* This will apply metadata information from the camera database, */
   /* such as crop, black+white level, etc. */
@@ -118,7 +118,7 @@ protected:
   /* A RawDecoderException will be thrown if the image cannot be decoded, */
   /* and there will not be any data in the mRaw image. */
   /* This function must be overridden by actual decoders. */
-  virtual RawImage decodeRawInternal() = 0;
+  virtual void decodeRawInternal() = 0;
   virtual void decodeMetaDataInternal(const CameraMetaData* meta) = 0;
   virtual void checkSupportInternal(const CameraMetaData* meta) = 0;
 

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -72,7 +72,6 @@ public:
 
   /* The decoded image - undefined if image has not or could not be decoded. */
   /* Remember this is automatically refcounted, so a reference is retained until this class is destroyed */
-  //std::shared_ptr<RawImageData> mRaw;
   RawImage mRaw;
 
   /* You can set this if you do not want Rawspeed to attempt to decode images, */

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -205,7 +205,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (this->checkCameraSupported(meta, id, mode)) {
     setMetaData(meta, id, mode, iso);
   } else {
-    mRaw.get(0)->metadata.mode = mode;
+    mRaw.metadata.mode = mode;
     writeLog(DEBUG_PRIO::EXTRA, "Mode not found in DB: %s", mode.c_str());
     setMetaData(meta, id, "", iso);
   }
@@ -270,18 +270,18 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (raw->hasEntry(static_cast<TiffTag>(0x0024)) &&
       raw->hasEntry(static_cast<TiffTag>(0x0025)) &&
       raw->hasEntry(static_cast<TiffTag>(0x0026))) {
-    mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[0] = static_cast<float>(
         raw->getEntry(static_cast<TiffTag>(0x0024))->getU16());
-    mRaw.get(0)->metadata.wbCoeffs[1] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[1] = static_cast<float>(
         raw->getEntry(static_cast<TiffTag>(0x0025))->getU16());
-    mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[2] = static_cast<float>(
         raw->getEntry(static_cast<TiffTag>(0x0026))->getU16());
   } else if (raw->hasEntry(static_cast<TiffTag>(0x0011)) &&
              raw->hasEntry(static_cast<TiffTag>(0x0012))) {
-    mRaw.get(0)->metadata.wbCoeffs[0] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[0] = static_cast<float>(
         raw->getEntry(static_cast<TiffTag>(0x0011))->getU16());
-    mRaw.get(0)->metadata.wbCoeffs[1] = 256.0F;
-    mRaw.get(0)->metadata.wbCoeffs[2] = static_cast<float>(
+    mRaw.metadata.wbCoeffs[1] = 256.0F;
+    mRaw.metadata.wbCoeffs[2] = static_cast<float>(
         raw->getEntry(static_cast<TiffTag>(0x0012))->getU16());
   }
 }

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -90,7 +90,7 @@ void Rw2Decoder::decodeRawInternal() {
 
     UncompressedDecompressor u(
         ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
-        mRaw);
+        mRaw.get());
 
     if (size >= width * height * 2) {
       // It's completely unpacked little-endian
@@ -103,7 +103,7 @@ void Rw2Decoder::decodeRawInternal() {
     } else {
       uint32_t section_split_offset = 0;
       PanasonicV4Decompressor p(
-          mRaw,
+          mRaw.get(),
           ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
           hints.has("zero_is_not_bad"), section_split_offset);
       mRaw->createData();
@@ -130,20 +130,20 @@ void Rw2Decoder::decodeRawInternal() {
                 raw->getEntry(TiffTag::PANASONIC_RAWFORMAT)->getU16()) {
     case 4: {
       uint32_t section_split_offset = 0x1FF8;
-      PanasonicV4Decompressor p(mRaw, bs, hints.has("zero_is_not_bad"),
+      PanasonicV4Decompressor p(mRaw.get(), bs, hints.has("zero_is_not_bad"),
                                 section_split_offset);
       mRaw->createData();
       p.decompress();
       return;
     }
     case 5: {
-      PanasonicV5Decompressor v5(mRaw, bs, bitsPerSample);
+      PanasonicV5Decompressor v5(mRaw.get(), bs, bitsPerSample);
       mRaw->createData();
       v5.decompress();
       return;
     }
     case 6: {
-      PanasonicV6Decompressor v6(mRaw, bs);
+      PanasonicV6Decompressor v6(mRaw.get(), bs);
       mRaw->createData();
       v6.decompress();
       return;

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -57,13 +57,13 @@ bool Rw2Decoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   return make == "Panasonic" || make == "LEICA" || make == "LEICA CAMERA AG";
 }
 
-RawImage Rw2Decoder::decodeRawInternal() {
+void Rw2Decoder::decodeRawInternal() {
 
   const TiffIFD* raw = nullptr;
   bool isOldPanasonic =
       !mRootIFD->hasEntryRecursive(TiffTag::PANASONIC_STRIPOFFSET);
 
-  if (! isOldPanasonic)
+  if (!isOldPanasonic)
     raw = mRootIFD->getIFDWithTag(TiffTag::PANASONIC_STRIPOFFSET);
   else
     raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS);
@@ -92,11 +92,11 @@ RawImage Rw2Decoder::decodeRawInternal() {
         ByteStream(DataBuffer(mFile.getSubView(offset), Endianness::little)),
         mRaw);
 
-    if (size >= width*height*2) {
+    if (size >= width * height * 2) {
       // It's completely unpacked little-endian
       mRaw->createData();
       u.decodeRawUnpacked<12, Endianness::little>(width, height);
-    } else if (size >= width*height*3/2) {
+    } else if (size >= width * height * 3 / 2) {
       // It's a packed format
       mRaw->createData();
       u.decode12BitRaw<Endianness::little, false, true>(width, height);
@@ -134,26 +134,24 @@ RawImage Rw2Decoder::decodeRawInternal() {
                                 section_split_offset);
       mRaw->createData();
       p.decompress();
-      return mRaw;
+      return;
     }
     case 5: {
       PanasonicV5Decompressor v5(mRaw, bs, bitsPerSample);
       mRaw->createData();
       v5.decompress();
-      return mRaw;
+      return;
     }
     case 6: {
       PanasonicV6Decompressor v6(mRaw, bs);
       mRaw->createData();
       v6.decompress();
-      return mRaw;
+      return;
     }
     default:
       ThrowRDE("Version %i is unsupported", version);
     }
   }
-
-  return mRaw;
 }
 
 void Rw2Decoder::checkSupportInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -40,7 +40,7 @@ public:
   Rw2Decoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   void checkSupportInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/SimpleTiffDecoder.cpp
+++ b/src/librawspeed/decoders/SimpleTiffDecoder.cpp
@@ -49,8 +49,8 @@ void SimpleTiffDecoder::prepareForRawDecoding() {
 
   checkImageDimensions();
 
-  mRaw->dim = iPoint2D(width, height);
-  mRaw->createData();
+  mRaw.get(0)->dim = iPoint2D(width, height);
+  mRaw.get(0)->createData();
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -96,7 +96,7 @@ void SrwDecoder::decodeRawInternal() {
     Buffer rbuf(mFile.getSubView(offset, count));
     ByteStream bsr(DataBuffer(rbuf, Endianness::little));
 
-    SamsungV0Decompressor s0(mRaw, bso, bsr);
+    SamsungV0Decompressor s0(mRaw.get(), bso, bsr);
 
     mRaw->createData();
 
@@ -110,7 +110,7 @@ void SrwDecoder::decodeRawInternal() {
     const ByteStream bs(
         DataBuffer(mFile.getSubView(offset, count), Endianness::little));
 
-    SamsungV1Decompressor s1(mRaw, bs, bits);
+    SamsungV1Decompressor s1(mRaw.get(), bs, bits);
 
     mRaw->createData();
 
@@ -124,7 +124,7 @@ void SrwDecoder::decodeRawInternal() {
     const ByteStream bs(
         DataBuffer(mFile.getSubView(offset, count), Endianness::little));
 
-    SamsungV2Decompressor s2(mRaw, bs, bits);
+    SamsungV2Decompressor s2(mRaw.get(), bs, bits);
 
     mRaw->createData();
 

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -175,9 +175,9 @@ void SrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb_black =
         mRootIFD->getEntryRecursive(TiffTag::SAMSUNG_WB_RGGBLEVELSBLACK);
     if (wb_levels->count == 4 && wb_black->count == 4) {
-      mRaw.get(0)->metadata.wbCoeffs[0] = wb_levels->getFloat(0) - wb_black->getFloat(0);
-      mRaw.get(0)->metadata.wbCoeffs[1] = wb_levels->getFloat(1) - wb_black->getFloat(1);
-      mRaw.get(0)->metadata.wbCoeffs[2] = wb_levels->getFloat(3) - wb_black->getFloat(3);
+      mRaw.metadata.wbCoeffs[0] = wb_levels->getFloat(0) - wb_black->getFloat(0);
+      mRaw.metadata.wbCoeffs[1] = wb_levels->getFloat(1) - wb_black->getFloat(1);
+      mRaw.metadata.wbCoeffs[2] = wb_levels->getFloat(3) - wb_black->getFloat(3);
     }
   }
 }

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -53,7 +53,7 @@ bool SrwDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   return make == "SAMSUNG";
 }
 
-RawImage SrwDecoder::decodeRawInternal() {
+void SrwDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS);
 
   int compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
@@ -62,7 +62,8 @@ RawImage SrwDecoder::decodeRawInternal() {
   if (12 != bits && 14 != bits)
     ThrowRDE("Unsupported bits per sample");
 
-  if (32769 != compression && 32770 != compression && 32772 != compression && 32773 != compression)
+  if (32769 != compression && 32770 != compression && 32772 != compression &&
+      32773 != compression)
     ThrowRDE("Unsupported compression");
 
   if (uint32_t nslices = raw->getEntry(TiffTag::STRIPOFFSETS)->count;
@@ -74,15 +75,14 @@ RawImage SrwDecoder::decodeRawInternal() {
       32769 == compression || wrongComp) {
     bool bit_order = hints.get("msb_override", wrongComp ? bits == 12 : false);
     this->decodeUncompressed(raw, bit_order ? BitOrder::MSB : BitOrder::LSB);
-    return mRaw;
+    return;
   }
 
   const uint32_t width = raw->getEntry(TiffTag::IMAGEWIDTH)->getU32();
   const uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
   mRaw->dim = iPoint2D(width, height);
 
-  if (32770 == compression)
-  {
+  if (32770 == compression) {
     const TiffEntry* sliceOffsets = raw->getEntry(static_cast<TiffTag>(40976));
     if (sliceOffsets->type != TiffDataType::LONG || sliceOffsets->count != 1)
       ThrowRDE("Entry 40976 is corrupt");
@@ -102,10 +102,9 @@ RawImage SrwDecoder::decodeRawInternal() {
 
     s0.decompress();
 
-    return mRaw;
+    return;
   }
-  if (32772 == compression)
-  {
+  if (32772 == compression) {
     uint32_t offset = raw->getEntry(TiffTag::STRIPOFFSETS)->getU32();
     uint32_t count = raw->getEntry(TiffTag::STRIPBYTECOUNTS)->getU32();
     const ByteStream bs(
@@ -117,10 +116,9 @@ RawImage SrwDecoder::decodeRawInternal() {
 
     s1.decompress();
 
-    return mRaw;
+    return;
   }
-  if (32773 == compression)
-  {
+  if (32773 == compression) {
     uint32_t offset = raw->getEntry(TiffTag::STRIPOFFSETS)->getU32();
     uint32_t count = raw->getEntry(TiffTag::STRIPBYTECOUNTS)->getU32();
     const ByteStream bs(
@@ -132,7 +130,7 @@ RawImage SrwDecoder::decodeRawInternal() {
 
     s2.decompress();
 
-    return mRaw;
+    return;
   }
   ThrowRDE("Unsupported compression");
 }

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -80,7 +80,7 @@ void SrwDecoder::decodeRawInternal() {
 
   const uint32_t width = raw->getEntry(TiffTag::IMAGEWIDTH)->getU32();
   const uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
   if (32770 == compression) {
     const TiffEntry* sliceOffsets = raw->getEntry(static_cast<TiffTag>(40976));
@@ -96,9 +96,9 @@ void SrwDecoder::decodeRawInternal() {
     Buffer rbuf(mFile.getSubView(offset, count));
     ByteStream bsr(DataBuffer(rbuf, Endianness::little));
 
-    SamsungV0Decompressor s0(mRaw.get(), bso, bsr);
+    SamsungV0Decompressor s0(mRaw.get(0).get(), bso, bsr);
 
-    mRaw->createData();
+    mRaw.get(0)->createData();
 
     s0.decompress();
 
@@ -110,9 +110,9 @@ void SrwDecoder::decodeRawInternal() {
     const ByteStream bs(
         DataBuffer(mFile.getSubView(offset, count), Endianness::little));
 
-    SamsungV1Decompressor s1(mRaw.get(), bs, bits);
+    SamsungV1Decompressor s1(mRaw.get(0).get(), bs, bits);
 
-    mRaw->createData();
+    mRaw.get(0)->createData();
 
     s1.decompress();
 
@@ -124,9 +124,9 @@ void SrwDecoder::decodeRawInternal() {
     const ByteStream bs(
         DataBuffer(mFile.getSubView(offset, count), Endianness::little));
 
-    SamsungV2Decompressor s2(mRaw.get(), bs, bits);
+    SamsungV2Decompressor s2(mRaw.get(0).get(), bs, bits);
 
-    mRaw->createData();
+    mRaw.get(0)->createData();
 
     s2.decompress();
 
@@ -175,9 +175,9 @@ void SrwDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* wb_black =
         mRootIFD->getEntryRecursive(TiffTag::SAMSUNG_WB_RGGBLEVELSBLACK);
     if (wb_levels->count == 4 && wb_black->count == 4) {
-      mRaw->metadata.wbCoeffs[0] = wb_levels->getFloat(0) - wb_black->getFloat(0);
-      mRaw->metadata.wbCoeffs[1] = wb_levels->getFloat(1) - wb_black->getFloat(1);
-      mRaw->metadata.wbCoeffs[2] = wb_levels->getFloat(3) - wb_black->getFloat(3);
+      mRaw.get(0)->metadata.wbCoeffs[0] = wb_levels->getFloat(0) - wb_black->getFloat(0);
+      mRaw.get(0)->metadata.wbCoeffs[1] = wb_levels->getFloat(1) - wb_black->getFloat(1);
+      mRaw.get(0)->metadata.wbCoeffs[2] = wb_levels->getFloat(3) - wb_black->getFloat(3);
     }
   }
 }

--- a/src/librawspeed/decoders/SrwDecoder.h
+++ b/src/librawspeed/decoders/SrwDecoder.h
@@ -39,7 +39,7 @@ public:
   SrwDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
   void checkSupportInternal(const CameraMetaData* meta) override;
 

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -59,17 +59,17 @@ void ThreefrDecoder::decodeRawInternal() {
 
   const ByteStream bs(DataBuffer(mFile.getSubView(off), Endianness::little));
 
-  mRaw->dim = iPoint2D(width, height);
+  mRaw.get(0)->dim = iPoint2D(width, height);
 
-  HasselbladDecompressor l(bs, mRaw.get());
-  mRaw->createData();
+  HasselbladDecompressor l(bs, mRaw.get(0).get());
+  mRaw.get(0)->createData();
 
   int pixelBaseOffset = hints.get("pixelBaseOffset", 0);
   l.decode(pixelBaseOffset);
 }
 
 void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
-  mRaw->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
+  mRaw.get(0)->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
                    CFAColor::GREEN, CFAColor::BLUE);
 
   setMetaData(meta, "", 0);
@@ -77,13 +77,13 @@ void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (mRootIFD->hasEntryRecursive(TiffTag::BLACKLEVEL)) {
     const TiffEntry* bl = mRootIFD->getEntryRecursive(TiffTag::BLACKLEVEL);
     if (bl->count == 1)
-      mRaw->blackLevel = bl->getFloat();
+      mRaw.get(0)->blackLevel = bl->getFloat();
   }
 
   if (mRootIFD->hasEntryRecursive(TiffTag::WHITELEVEL)) {
     const TiffEntry* wl = mRootIFD->getEntryRecursive(TiffTag::WHITELEVEL);
     if (wl->count == 1)
-      mRaw->whitePoint = wl->getFloat();
+      mRaw.get(0)->whitePoint = wl->getFloat();
   }
 
   // Fetch the white balance
@@ -95,7 +95,7 @@ void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         if (div == 0.0F)
           ThrowRDE("Can not decode WB, multiplier is zero/");
 
-        mRaw->metadata.wbCoeffs[i] = 1.0F / div;
+        mRaw.get(0)->metadata.wbCoeffs[i] = 1.0F / div;
       }
     }
   }

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -61,7 +61,7 @@ void ThreefrDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
 
-  HasselbladDecompressor l(bs, mRaw);
+  HasselbladDecompressor l(bs, mRaw.get());
   mRaw->createData();
 
   int pixelBaseOffset = hints.get("pixelBaseOffset", 0);

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -95,7 +95,7 @@ void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         if (div == 0.0F)
           ThrowRDE("Can not decode WB, multiplier is zero/");
 
-        mRaw.get(0)->metadata.wbCoeffs[i] = 1.0F / div;
+        mRaw.metadata.wbCoeffs[i] = 1.0F / div;
       }
     }
   }

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -50,7 +50,7 @@ bool ThreefrDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   return make == "Hasselblad";
 }
 
-RawImage ThreefrDecoder::decodeRawInternal() {
+void ThreefrDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS, 1);
   uint32_t width = raw->getEntry(TiffTag::IMAGEWIDTH)->getU32();
   uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
@@ -66,8 +66,6 @@ RawImage ThreefrDecoder::decodeRawInternal() {
 
   int pixelBaseOffset = hints.get("pixelBaseOffset", 0);
   l.decode(pixelBaseOffset);
-
-  return mRaw;
 }
 
 void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -39,7 +39,7 @@ public:
   ThreefrDecoder(TiffRootIFDOwner&& root, const Buffer& file)
       : AbstractTiffDecoder(std::move(root), file) {}
 
-  RawImage decodeRawInternal() override;
+  void decodeRawInternal() override;
   void decodeMetaDataInternal(const CameraMetaData* meta) override;
 
 private:

--- a/src/librawspeed/decompressors/AbstractDngDecompressor.h
+++ b/src/librawspeed/decompressors/AbstractDngDecompressor.h
@@ -122,14 +122,14 @@ struct DngSliceElement final {
 };
 
 class AbstractDngDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   template <int compression> void decompressThread() const noexcept;
 
   void decompressThread() const noexcept;
 
 public:
-  AbstractDngDecompressor(const RawImage& img, const DngTilingDescription& dsc_,
+  AbstractDngDecompressor(RawImageData* img, const DngTilingDescription& dsc_,
                           int compression_, bool mFixLjpeg_, uint32_t mBps_,
                           uint32_t mPredictor_)
       : mRaw(img), dsc(dsc_), compression(compression_), mFixLjpeg(mFixLjpeg_),

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
@@ -36,7 +36,7 @@
 namespace rawspeed {
 
 AbstractLJpegDecompressor::AbstractLJpegDecompressor(ByteStream bs,
-                                                     const RawImage& img)
+                                                     RawImageData *img)
     : input(std::move(bs)), mRaw(img) {
   input.setByteOrder(Endianness::big);
 

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.cpp
@@ -158,8 +158,8 @@ void AbstractLJpegDecompressor::parseSOF(ByteStream sofInput, SOFInfo* sof) {
   }
 
   if (static_cast<int>(sof->compInfo[0].superH) !=
-          mRaw->metadata.subsampling.x ||
-      static_cast<int>(sof->compInfo[0].superV) != mRaw->metadata.subsampling.y)
+          mRaw->subsampling.x ||
+      static_cast<int>(sof->compInfo[0].superV) != mRaw->subsampling.y)
     ThrowRDE("LJpeg's subsampling does not match image's subsampling.");
 
   sof->initialized = true;

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
@@ -155,7 +155,7 @@ class AbstractLJpegDecompressor : public AbstractDecompressor {
   std::array<HuffmanTable*, 4> huff{{}}; // 4 pointers into the store
 
 public:
-  AbstractLJpegDecompressor(ByteStream bs, const RawImage& img);
+  AbstractLJpegDecompressor(ByteStream bs, RawImageData* img);
 
   virtual ~AbstractLJpegDecompressor() = default;
 
@@ -201,7 +201,7 @@ protected:
   virtual void decodeScan() = 0;
 
   ByteStream input;
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   SOFInfo frame;
   uint32_t predictorMode = 0;

--- a/src/librawspeed/decompressors/AbstractSamsungDecompressor.h
+++ b/src/librawspeed/decompressors/AbstractSamsungDecompressor.h
@@ -27,10 +27,10 @@ namespace rawspeed {
 
 class AbstractSamsungDecompressor : public AbstractDecompressor {
 protected:
-  RawImage mRaw;
+  RawImageData* mRaw;
 
 public:
-  explicit AbstractSamsungDecompressor(const RawImage& raw) : mRaw(raw) {}
+  explicit AbstractSamsungDecompressor(RawImageData* raw) : mRaw(raw) {}
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/Cr2Decompressor.cpp
+++ b/src/librawspeed/decompressors/Cr2Decompressor.cpp
@@ -35,7 +35,7 @@ namespace rawspeed {
 
 class ByteStream;
 
-Cr2Decompressor::Cr2Decompressor(const ByteStream& bs, const RawImage& img)
+Cr2Decompressor::Cr2Decompressor(const ByteStream& bs, RawImageData *img)
     : AbstractLJpegDecompressor(bs, img) {
   if (mRaw->getDataType() != RawImageType::UINT16)
     ThrowRDE("Unexpected data type");

--- a/src/librawspeed/decompressors/Cr2Decompressor.cpp
+++ b/src/librawspeed/decompressors/Cr2Decompressor.cpp
@@ -131,7 +131,7 @@ void Cr2Decompressor::decode(const Cr2Slicing& slicing_) {
 template <int N_COMP, int X_S_F, int Y_S_F>
 void Cr2Decompressor::decodeN_X_Y()
 {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/Cr2Decompressor.cpp
+++ b/src/librawspeed/decompressors/Cr2Decompressor.cpp
@@ -131,7 +131,9 @@ void Cr2Decompressor::decode(const Cr2Slicing& slicing_) {
 template <int N_COMP, int X_S_F, int Y_S_F>
 void Cr2Decompressor::decodeN_X_Y()
 {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   // To understand the CR2 slice handling and sampling factor behavior, see
   // https://github.com/lclevy/libcraw2/blob/master/docs/cr2_lossless.pdf?raw=true

--- a/src/librawspeed/decompressors/Cr2Decompressor.h
+++ b/src/librawspeed/decompressors/Cr2Decompressor.h
@@ -29,7 +29,6 @@
 namespace rawspeed {
 
 class ByteStream;
-class RawImage;
 
 class Cr2Slicing {
   int numSlices = 0;
@@ -77,7 +76,7 @@ class Cr2Decompressor final : public AbstractLJpegDecompressor
   template<int N_COMP, int X_S_F, int Y_S_F> void decodeN_X_Y();
 
 public:
-  Cr2Decompressor(const ByteStream& bs, const RawImage& img);
+  Cr2Decompressor(const ByteStream& bs, RawImageData* img);
   void decode(const Cr2Slicing& slicing);
 };
 

--- a/src/librawspeed/decompressors/CrwDecompressor.cpp
+++ b/src/librawspeed/decompressors/CrwDecompressor.cpp
@@ -38,7 +38,7 @@ using std::array;
 
 namespace rawspeed {
 
-CrwDecompressor::CrwDecompressor(const RawImage& img, uint32_t dec_table,
+CrwDecompressor::CrwDecompressor(RawImageData* img, uint32_t dec_table,
                                  bool lowbits_, ByteStream rawData)
     : mRaw(img), lowbits(lowbits_) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||

--- a/src/librawspeed/decompressors/CrwDecompressor.cpp
+++ b/src/librawspeed/decompressors/CrwDecompressor.cpp
@@ -204,7 +204,7 @@ inline void CrwDecompressor::decodeBlock(std::array<int16_t, 64>* diffBuf,
 
 // FIXME: this function is horrible.
 void CrwDecompressor::decompress() {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/CrwDecompressor.cpp
+++ b/src/librawspeed/decompressors/CrwDecompressor.cpp
@@ -204,7 +204,9 @@ inline void CrwDecompressor::decodeBlock(std::array<int16_t, 64>* diffBuf,
 
 // FIXME: this function is horrible.
 void CrwDecompressor::decompress() {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
   assert(out.width % 4 == 0);
   assert(out.height > 0);

--- a/src/librawspeed/decompressors/CrwDecompressor.h
+++ b/src/librawspeed/decompressors/CrwDecompressor.h
@@ -35,7 +35,7 @@ namespace rawspeed {
 class CrwDecompressor final : public AbstractDecompressor {
   using crw_hts = std::array<HuffmanTable, 2>;
 
-  RawImage mRaw;
+  RawImageData* mRaw;
   crw_hts mHuff;
   const bool lowbits;
 
@@ -43,7 +43,7 @@ class CrwDecompressor final : public AbstractDecompressor {
   ByteStream rawInput;
 
 public:
-  CrwDecompressor(const RawImage& img, uint32_t dec_table_, bool lowbits_,
+  CrwDecompressor(RawImageData *img, uint32_t dec_table_, bool lowbits_,
                   ByteStream rawData);
 
   void decompress();

--- a/src/librawspeed/decompressors/DeflateDecompressor.h
+++ b/src/librawspeed/decompressors/DeflateDecompressor.h
@@ -36,12 +36,12 @@ class iPoint2D;
 
 class DeflateDecompressor final : public AbstractDecompressor {
   ByteStream input;
-  RawImage mRaw;
+  RawImageData* mRaw;
   int predictor;
   int bps;
 
 public:
-  DeflateDecompressor(ByteStream bs, const RawImage& img, int predictor_,
+  DeflateDecompressor(ByteStream bs, RawImageData* img, int predictor_,
                       int bps_)
       : input(std::move(bs)), mRaw(img), predictor(predictor_), bps(bps_) {}
 

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -178,7 +178,7 @@ template <typename T>
 void FujiDecompressor::copy_line(fuji_compressed_block* info,
                                  const FujiStrip& strip, int cur_line,
                                  T&& idx) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -178,7 +178,9 @@ template <typename T>
 void FujiDecompressor::copy_line(fuji_compressed_block* info,
                                  const FujiStrip& strip, int cur_line,
                                  T&& idx) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   std::array<uint16_t*, 3> lineBufB;
   std::array<uint16_t*, 6> lineBufG;

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -39,7 +39,7 @@
 
 namespace rawspeed {
 
-FujiDecompressor::FujiDecompressor(const RawImage& img, ByteStream input_)
+FujiDecompressor::FujiDecompressor(RawImageData *img, ByteStream input_)
     : mRaw(img), input(std::move(input_)) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))

--- a/src/librawspeed/decompressors/FujiDecompressor.h
+++ b/src/librawspeed/decompressors/FujiDecompressor.h
@@ -35,7 +35,7 @@
 namespace rawspeed {
 
 class FujiDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   void decompressThread() const noexcept;
 
@@ -110,7 +110,7 @@ public:
     [[nodiscard]] int offsetX() const { return h.block_size * n; }
   };
 
-  FujiDecompressor(const RawImage& img, ByteStream input);
+  FujiDecompressor(RawImageData* img, ByteStream input);
 
   void fuji_compressed_load_raw();
 

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -67,7 +67,9 @@ void HasselbladDecompressor::decodeScan() {
              frame.w, frame.h, mRaw->dim.x, mRaw->dim.y);
   }
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   assert(out.height > 0);
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -67,7 +67,7 @@ void HasselbladDecompressor::decodeScan() {
              frame.w, frame.h, mRaw->dim.x, mRaw->dim.y);
   }
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -34,7 +34,7 @@
 namespace rawspeed {
 
 HasselbladDecompressor::HasselbladDecompressor(const ByteStream& bs,
-                                               const RawImage& img)
+                                               RawImageData* img)
     : AbstractLJpegDecompressor(bs, img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))

--- a/src/librawspeed/decompressors/HasselbladDecompressor.h
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.h
@@ -27,7 +27,6 @@
 namespace rawspeed {
 
 class ByteStream;
-class RawImage;
 
 class HasselbladDecompressor final : public AbstractLJpegDecompressor
 {
@@ -36,7 +35,7 @@ class HasselbladDecompressor final : public AbstractLJpegDecompressor
   void decodeScan() override;
 
 public:
-  HasselbladDecompressor(const ByteStream& bs, const RawImage& img);
+  HasselbladDecompressor(const ByteStream& bs, RawImageData *img);
 
   void decode(int pixelBaseOffset_);
 

--- a/src/librawspeed/decompressors/JpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/JpegDecompressor.cpp
@@ -154,7 +154,9 @@ void JpegDecompressor::decode(uint32_t offX,
   int copy_w = min(mRaw->dim.x - offX, dinfo.output_width);
   int copy_h = min(mRaw->dim.y - offY, dinfo.output_height);
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   for (int row = 0; row < copy_h; row++) {
     for (int col = 0; col < dinfo.output_components * copy_w; col++)
       out(row + offY, dinfo.output_components * offX + col) = tmp(row, col);

--- a/src/librawspeed/decompressors/JpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/JpegDecompressor.cpp
@@ -154,7 +154,7 @@ void JpegDecompressor::decode(uint32_t offX,
   int copy_w = min(mRaw->dim.x - offX, dinfo.output_width);
   int copy_h = min(mRaw->dim.y - offY, dinfo.output_height);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   for (int row = 0; row < copy_h; row++) {

--- a/src/librawspeed/decompressors/JpegDecompressor.h
+++ b/src/librawspeed/decompressors/JpegDecompressor.h
@@ -36,10 +36,10 @@ namespace rawspeed {
 class JpegDecompressor final : public AbstractDecompressor {
   struct JpegDecompressStruct;
   ByteStream input;
-  RawImage mRaw;
+  RawImageData* mRaw;
 
 public:
-  JpegDecompressor(ByteStream bs, const RawImage& img)
+  JpegDecompressor(ByteStream bs, RawImageData* img)
       : input(std::move(bs)), mRaw(img) {
     input.setByteOrder(Endianness::big);
   }

--- a/src/librawspeed/decompressors/KodakDecompressor.cpp
+++ b/src/librawspeed/decompressors/KodakDecompressor.cpp
@@ -110,7 +110,7 @@ KodakDecompressor::decodeSegment(const uint32_t bsize) {
 }
 
 void KodakDecompressor::decompress() {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/KodakDecompressor.cpp
+++ b/src/librawspeed/decompressors/KodakDecompressor.cpp
@@ -110,7 +110,9 @@ KodakDecompressor::decodeSegment(const uint32_t bsize) {
 }
 
 void KodakDecompressor::decompress() {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   uint32_t random = 0;
   for (int row = 0; row < out.height; row++) {

--- a/src/librawspeed/decompressors/KodakDecompressor.cpp
+++ b/src/librawspeed/decompressors/KodakDecompressor.cpp
@@ -36,7 +36,7 @@
 
 namespace rawspeed {
 
-KodakDecompressor::KodakDecompressor(const RawImage& img, ByteStream bs,
+KodakDecompressor::KodakDecompressor(RawImageData *img, ByteStream bs,
                                      int bps_, bool uncorrectedRawValues_)
     : mRaw(img), input(std::move(bs)), bps(bps_),
       uncorrectedRawValues(uncorrectedRawValues_) {

--- a/src/librawspeed/decompressors/KodakDecompressor.h
+++ b/src/librawspeed/decompressors/KodakDecompressor.h
@@ -31,7 +31,7 @@
 namespace rawspeed {
 
 class KodakDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
   ByteStream input;
   int bps;
   bool uncorrectedRawValues;
@@ -42,7 +42,7 @@ class KodakDecompressor final : public AbstractDecompressor {
   segment decodeSegment(uint32_t bsize);
 
 public:
-  KodakDecompressor(const RawImage& img, ByteStream bs, int bps,
+  KodakDecompressor(RawImageData* img, ByteStream bs, int bps,
                     bool uncorrectedRawValues_);
 
   void decompress();

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -167,7 +167,9 @@ template <int N_COMP, bool WeirdWidth> void LJpegDecompressor::decodeN() {
   assert(mRaw->dim.x >= N_COMP);
   assert((mRaw->getCpp() * (mRaw->dim.x - offX)) >= N_COMP);
 
-  const CroppedArray2DRef img(mRaw->getU16DataAsUncroppedArray2DRef(),
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const CroppedArray2DRef img(rawU16->getU16DataAsUncroppedArray2DRef(),
                               mRaw->getCpp() * offX, offY, mRaw->getCpp() * w,
                               h);
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -33,7 +33,7 @@ using std::copy_n;
 
 namespace rawspeed {
 
-LJpegDecompressor::LJpegDecompressor(const ByteStream& bs, const RawImage& img)
+LJpegDecompressor::LJpegDecompressor(const ByteStream& bs, RawImageData* img)
     : AbstractLJpegDecompressor(bs, img) {
   if (mRaw->getDataType() != RawImageType::UINT16)
     ThrowRDE("Unexpected data type (%u)",

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -167,7 +167,7 @@ template <int N_COMP, bool WeirdWidth> void LJpegDecompressor::decodeN() {
   assert(mRaw->dim.x >= N_COMP);
   assert((mRaw->getCpp() * (mRaw->dim.x - offX)) >= N_COMP);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const CroppedArray2DRef img(rawU16->getU16DataAsUncroppedArray2DRef(),
                               mRaw->getCpp() * offX, offY, mRaw->getCpp() * w,

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -26,7 +26,6 @@
 namespace rawspeed {
 
 class ByteStream;
-class RawImage;
 
 // Decompresses Lossless JPEGs, with 2-4 components
 
@@ -44,7 +43,7 @@ class LJpegDecompressor final : public AbstractLJpegDecompressor
   uint32_t trailingPixels = 0;
 
 public:
-  LJpegDecompressor(const ByteStream& bs, const RawImage& img);
+  LJpegDecompressor(const ByteStream& bs, RawImageData *img);
 
   void decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
               uint32_t height, bool fixDng16Bug_);

--- a/src/librawspeed/decompressors/NikonDecompressor.cpp
+++ b/src/librawspeed/decompressors/NikonDecompressor.cpp
@@ -441,7 +441,7 @@ Huffman NikonDecompressor::createHuffmanTable(uint32_t huffSelect) {
   return ht;
 }
 
-NikonDecompressor::NikonDecompressor(const RawImage& raw, ByteStream metadata,
+NikonDecompressor::NikonDecompressor(RawImageData *raw, ByteStream metadata,
                                      uint32_t bitsPS_)
     : mRaw(raw), bitsPS(bitsPS_) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
@@ -492,8 +492,8 @@ void NikonDecompressor::decompress(BitPumpMSB& bits, int start_y, int end_y) {
 
   const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
 
-  // allow gcc to devirtualize the calls below
-  auto* rawdata = reinterpret_cast<RawImageDataU16*>(mRaw.get());
+  auto* rawdata = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawdata);
 
   assert(out.width % 2 == 0);
   assert(out.width >= 2);
@@ -512,7 +512,7 @@ void NikonDecompressor::decompress(BitPumpMSB& bits, int start_y, int end_y) {
 
 void NikonDecompressor::decompress(const ByteStream& data,
                                    bool uncorrectedRawValues) {
-  RawImageCurveGuard curveHandler(&mRaw, curve, uncorrectedRawValues);
+  RawImageCurveGuard curveHandler(mRaw, curve, uncorrectedRawValues);
 
   BitPumpMSB bits(data);
 

--- a/src/librawspeed/decompressors/NikonDecompressor.cpp
+++ b/src/librawspeed/decompressors/NikonDecompressor.cpp
@@ -490,7 +490,9 @@ template <typename Huffman>
 void NikonDecompressor::decompress(BitPumpMSB& bits, int start_y, int end_y) {
   auto ht = createHuffmanTable<Huffman>(huffSelect);
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   auto* rawdata = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawdata);

--- a/src/librawspeed/decompressors/NikonDecompressor.cpp
+++ b/src/librawspeed/decompressors/NikonDecompressor.cpp
@@ -490,7 +490,7 @@ template <typename Huffman>
 void NikonDecompressor::decompress(BitPumpMSB& bits, int start_y, int end_y) {
   auto ht = createHuffmanTable<Huffman>(huffSelect);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/NikonDecompressor.h
+++ b/src/librawspeed/decompressors/NikonDecompressor.h
@@ -34,7 +34,7 @@ class ByteStream;
 namespace rawspeed {
 
 class NikonDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
   uint32_t bitsPS;
 
   uint32_t huffSelect = 0;
@@ -47,7 +47,7 @@ class NikonDecompressor final : public AbstractDecompressor {
   uint32_t random;
 
 public:
-  NikonDecompressor(const RawImage& raw, ByteStream metadata, uint32_t bitsPS);
+  NikonDecompressor(RawImageData* raw, ByteStream metadata, uint32_t bitsPS);
 
   void decompress(const ByteStream& data, bool uncorrectedRawValues);
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -137,7 +137,9 @@ void OlympusDecompressor::decompressRow(BitPumpMSB& bits, int row) const {
   assert(mRaw->dim.x > 0);
   assert(mRaw->dim.x % 2 == 0);
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   std::array<std::array<int, 3>, 2> acarry{{}};
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -48,7 +48,7 @@ constexpr __attribute__((const)) bool SignBit(T x) {
 
 namespace rawspeed {
 
-OlympusDecompressor::OlympusDecompressor(const RawImage& img) : mRaw(img) {
+OlympusDecompressor::OlympusDecompressor(RawImageData *img) : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))
     ThrowRDE("Unexpected component count / data type");

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -137,7 +137,7 @@ void OlympusDecompressor::decompressRow(BitPumpMSB& bits, int row) const {
   assert(mRaw->dim.x > 0);
   assert(mRaw->dim.x % 2 == 0);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.h
+++ b/src/librawspeed/decompressors/OlympusDecompressor.h
@@ -36,7 +36,7 @@ class ByteStream;
 template <class T> class Array2DRef;
 
 class OlympusDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   // A table to quickly look up "high" value
   const SimpleLUT<char, 12> bittable{
@@ -56,7 +56,7 @@ class OlympusDecompressor final : public AbstractDecompressor {
   void decompressRow(BitPumpMSB& bits, int row) const;
 
 public:
-  explicit OlympusDecompressor(const RawImage& img);
+  explicit OlympusDecompressor(RawImageData* img);
   void decompress(ByteStream input) const;
 };
 

--- a/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
@@ -166,7 +166,7 @@ public:
 inline void PanasonicV4Decompressor::processPixelPacket(
     ProxyStream& bits, int row, int col,
     std::vector<uint32_t>* zero_pos) const noexcept {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
@@ -41,7 +41,7 @@
 
 namespace rawspeed {
 
-PanasonicV4Decompressor::PanasonicV4Decompressor(const RawImage& img,
+PanasonicV4Decompressor::PanasonicV4Decompressor(RawImageData* img,
                                                  const ByteStream& input_,
                                                  bool zero_is_not_bad,
                                                  uint32_t section_split_offset_)

--- a/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV4Decompressor.cpp
@@ -166,7 +166,9 @@ public:
 inline void PanasonicV4Decompressor::processPixelPacket(
     ProxyStream& bits, int row, int col,
     std::vector<uint32_t>* zero_pos) const noexcept {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   int sh = 0;
 

--- a/src/librawspeed/decompressors/PanasonicV4Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV4Decompressor.h
@@ -43,7 +43,7 @@ class PanasonicV4Decompressor final : public AbstractDecompressor {
 
   class ProxyStream;
 
-  RawImage mRaw;
+  RawImageData* mRaw;
   ByteStream input;
   bool zero_is_bad;
 
@@ -83,7 +83,7 @@ class PanasonicV4Decompressor final : public AbstractDecompressor {
   void decompressThread() const noexcept;
 
 public:
-  PanasonicV4Decompressor(const RawImage& img, const ByteStream& input_,
+  PanasonicV4Decompressor(RawImageData* img, const ByteStream& input_,
                           bool zero_is_not_bad, uint32_t section_split_offset_);
 
   void decompress() const noexcept;

--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
@@ -59,7 +59,7 @@ constexpr PanasonicV5Decompressor::PacketDsc
     PanasonicV5Decompressor::FourteenBitPacket =
         PanasonicV5Decompressor::PacketDsc(/*bps=*/14);
 
-PanasonicV5Decompressor::PanasonicV5Decompressor(const RawImage& img,
+PanasonicV5Decompressor::PanasonicV5Decompressor(RawImageData *img,
                                                  const ByteStream& input_,
                                                  uint32_t bps_)
     : mRaw(img), bps(bps_) {

--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
@@ -181,7 +181,7 @@ inline void PanasonicV5Decompressor::processPixelPacket(BitPumpLSB& bs, int row,
   static_assert(dsc.pixelsPerPacket > 0, "dsc should be compile-time const");
   static_assert(dsc.bps > 0 && dsc.bps <= 16);
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
@@ -181,7 +181,9 @@ inline void PanasonicV5Decompressor::processPixelPacket(BitPumpLSB& bs, int row,
   static_assert(dsc.pixelsPerPacket > 0, "dsc should be compile-time const");
   static_assert(dsc.bps > 0 && dsc.bps <= 16);
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   assert(bs.getFillLevel() == 0);
 

--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.h
@@ -63,7 +63,7 @@ class PanasonicV5Decompressor final : public AbstractDecompressor {
   // Takes care of unsplitting&swapping back the block at sectionSplitOffset.
   class ProxyStream;
 
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   // The full input buffer, containing all the blocks.
   ByteStream input;
@@ -98,7 +98,7 @@ class PanasonicV5Decompressor final : public AbstractDecompressor {
   template <const PacketDsc& dsc> void decompressInternal() const noexcept;
 
 public:
-  PanasonicV5Decompressor(const RawImage& img, const ByteStream& input_,
+  PanasonicV5Decompressor(RawImageData* img, const ByteStream& input_,
                           uint32_t bps_);
 
   void decompress() const noexcept;

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -118,7 +118,7 @@ inline void __attribute__((always_inline))
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
 PanasonicV6Decompressor::decompressBlock(ByteStream& rowInput, int row,
                                          int col) const noexcept {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -118,7 +118,9 @@ inline void __attribute__((always_inline))
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
 PanasonicV6Decompressor::decompressBlock(ByteStream& rowInput, int row,
                                          int col) const noexcept {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   pana_cs6_page_decoder page(
       rowInput.getStream(PanasonicV6Decompressor::BytesPerBlock));

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -88,7 +88,7 @@ struct pana_cs6_page_decoder {
 };
 } // namespace
 
-PanasonicV6Decompressor::PanasonicV6Decompressor(const RawImage& img,
+PanasonicV6Decompressor::PanasonicV6Decompressor(RawImageData *img,
                                                  const ByteStream& input_)
     : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.h
@@ -27,7 +27,7 @@
 namespace rawspeed {
 
 class PanasonicV6Decompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   ByteStream input;
 
@@ -42,7 +42,7 @@ class PanasonicV6Decompressor final : public AbstractDecompressor {
   void decompressRow(int row) const noexcept;
 
 public:
-  PanasonicV6Decompressor(const RawImage& img, const ByteStream& input_);
+  PanasonicV6Decompressor(RawImageData* img, const ByteStream& input_);
 
   void decompress() const;
 };

--- a/src/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/src/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -140,7 +140,7 @@ PentaxDecompressor::SetupHuffmanTable(std::optional<ByteStream> metaData) {
 }
 
 void PentaxDecompressor::decompress(const ByteStream& data) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/src/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -42,7 +42,7 @@ const std::array<std::array<std::array<uint8_t, 16>, 2>, 1>
           {3, 4, 2, 5, 1, 6, 0, 7, 8, 9, 10, 11, 12}}},
     }};
 
-PentaxDecompressor::PentaxDecompressor(const RawImage& img,
+PentaxDecompressor::PentaxDecompressor(RawImageData *img,
                                        std::optional<ByteStream> metaData)
     : mRaw(img), ht(SetupHuffmanTable(std::move(metaData))) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||

--- a/src/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/src/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -140,7 +140,9 @@ PentaxDecompressor::SetupHuffmanTable(std::optional<ByteStream> metaData) {
 }
 
 void PentaxDecompressor::decompress(const ByteStream& data) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   assert(out.height > 0);
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/PentaxDecompressor.h
+++ b/src/librawspeed/decompressors/PentaxDecompressor.h
@@ -33,11 +33,11 @@ namespace rawspeed {
 class ByteStream;
 
 class PentaxDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
   const HuffmanTable ht;
 
 public:
-  PentaxDecompressor(const RawImage& img, std::optional<ByteStream> metaData);
+  PentaxDecompressor(RawImageData* img, std::optional<ByteStream> metaData);
 
   void decompress(const ByteStream& data) const;
 

--- a/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
+++ b/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
@@ -83,7 +83,7 @@ void PhaseOneDecompressor::prepareStrips() {
 }
 
 void PhaseOneDecompressor::decompressStrip(const PhaseOneStrip& strip) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
+++ b/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
@@ -40,7 +40,7 @@
 
 namespace rawspeed {
 
-PhaseOneDecompressor::PhaseOneDecompressor(const RawImage& img,
+PhaseOneDecompressor::PhaseOneDecompressor(RawImageData *img,
                                            std::vector<PhaseOneStrip>&& strips_)
     : mRaw(img), strips(std::move(strips_)) {
   if (mRaw->getDataType() != RawImageType::UINT16)

--- a/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
+++ b/src/librawspeed/decompressors/PhaseOneDecompressor.cpp
@@ -83,7 +83,9 @@ void PhaseOneDecompressor::prepareStrips() {
 }
 
 void PhaseOneDecompressor::decompressStrip(const PhaseOneStrip& strip) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   assert(out.width > 0);
   assert(out.width % 2 == 0);

--- a/src/librawspeed/decompressors/PhaseOneDecompressor.h
+++ b/src/librawspeed/decompressors/PhaseOneDecompressor.h
@@ -39,7 +39,7 @@ struct PhaseOneStrip {
 };
 
 class PhaseOneDecompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   std::vector<PhaseOneStrip> strips;
 
@@ -50,7 +50,7 @@ class PhaseOneDecompressor final : public AbstractDecompressor {
   void prepareStrips();
 
 public:
-  PhaseOneDecompressor(const RawImage& img,
+  PhaseOneDecompressor(RawImageData* img,
                        std::vector<PhaseOneStrip>&& strips_);
 
   void decompress() const;

--- a/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
@@ -91,7 +91,7 @@ void SamsungV0Decompressor::decompress() const {
     decompressStrip(row, stripes[row]);
 
   // Swap red and blue pixels to get the final CFA pattern
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   for (int row = 0; row < out.height - 1; row += 2) {
@@ -108,7 +108,7 @@ int32_t SamsungV0Decompressor::calcAdj(BitPumpMSB32& bits, int nbits) {
 
 void SamsungV0Decompressor::decompressStrip(int row,
                                             const ByteStream& bs) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
@@ -37,7 +37,7 @@
 
 namespace rawspeed {
 
-SamsungV0Decompressor::SamsungV0Decompressor(const RawImage& image,
+SamsungV0Decompressor::SamsungV0Decompressor(RawImageData *image,
                                              const ByteStream& bso,
                                              const ByteStream& bsr)
     : AbstractSamsungDecompressor(image) {

--- a/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV0Decompressor.cpp
@@ -91,7 +91,9 @@ void SamsungV0Decompressor::decompress() const {
     decompressStrip(row, stripes[row]);
 
   // Swap red and blue pixels to get the final CFA pattern
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   for (int row = 0; row < out.height - 1; row += 2) {
     for (int col = 0; col < out.width - 1; col += 2)
       std::swap(out(row, col + 1), out(row + 1, col));
@@ -106,7 +108,9 @@ int32_t SamsungV0Decompressor::calcAdj(BitPumpMSB32& bits, int nbits) {
 
 void SamsungV0Decompressor::decompressStrip(int row,
                                             const ByteStream& bs) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
 
   BitPumpMSB32 bits(bs);

--- a/src/librawspeed/decompressors/SamsungV0Decompressor.h
+++ b/src/librawspeed/decompressors/SamsungV0Decompressor.h
@@ -28,7 +28,6 @@
 
 namespace rawspeed {
 
-class RawImage;
 
 // Decoder for compressed srw files (NX300 and later)
 class SamsungV0Decompressor final : public AbstractSamsungDecompressor {
@@ -41,7 +40,7 @@ class SamsungV0Decompressor final : public AbstractSamsungDecompressor {
   static int32_t calcAdj(BitPumpMSB32& bits, int b);
 
 public:
-  SamsungV0Decompressor(const RawImage& image, const ByteStream& bso,
+  SamsungV0Decompressor(RawImageData *image, const ByteStream& bso,
                         const ByteStream& bsr);
 
   void decompress() const;

--- a/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
@@ -115,7 +115,9 @@ void SamsungV1Decompressor::decompress() const {
     }
   }
 
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width % 32 == 0 && "Should have even count of pixels per row.");
   assert(out.height % 2 == 0 && "Should have even row count.");
   BitPumpMSB pump(bs);

--- a/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
@@ -40,7 +40,7 @@ struct SamsungV1Decompressor::encTableItem {
   uint8_t diffLen;
 };
 
-SamsungV1Decompressor::SamsungV1Decompressor(const RawImage& image,
+SamsungV1Decompressor::SamsungV1Decompressor(RawImageData *image,
                                              const ByteStream& bs_, int bit)
     : AbstractSamsungDecompressor(image), bs(bs_) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||

--- a/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV1Decompressor.cpp
@@ -115,7 +115,7 @@ void SamsungV1Decompressor::decompress() const {
     }
   }
 
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width % 32 == 0 && "Should have even count of pixels per row.");

--- a/src/librawspeed/decompressors/SamsungV1Decompressor.h
+++ b/src/librawspeed/decompressors/SamsungV1Decompressor.h
@@ -28,7 +28,6 @@
 namespace rawspeed {
 
 class ByteStream;
-class RawImage;
 
 // Decoder for compressed srw files (NX3000 and later)
 class SamsungV1Decompressor final : public AbstractSamsungDecompressor {
@@ -41,7 +40,7 @@ class SamsungV1Decompressor final : public AbstractSamsungDecompressor {
   static constexpr int bits = 12;
 
 public:
-  SamsungV1Decompressor(const RawImage& image, const ByteStream& bs_, int bit);
+  SamsungV1Decompressor(RawImageData* image, const ByteStream& bs_, int bit);
 
   void decompress() const;
 };

--- a/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
@@ -149,7 +149,7 @@ SamsungV2Decompressor::SamsungV2Decompressor(RawImageData *image,
 inline __attribute__((always_inline)) std::array<uint16_t, 16>
 SamsungV2Decompressor::prepareBaselineValues(BitPumpMSB32& pump, int row,
                                              int col) {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -312,7 +312,7 @@ SamsungV2Decompressor::decodeDifferences(BitPumpMSB32& pump, int row) {
 
 inline __attribute__((always_inline)) void
 SamsungV2Decompressor::processBlock(BitPumpMSB32& pump, int row, int col) {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
@@ -78,7 +78,7 @@ SamsungV2Decompressor::getDiff(BitPumpMSB32& pump, uint32_t len) {
   return signExtend(pump.getBits(len), len);
 }
 
-SamsungV2Decompressor::SamsungV2Decompressor(const RawImage& image,
+SamsungV2Decompressor::SamsungV2Decompressor(RawImageData *image,
                                              const ByteStream& bs,
                                              unsigned bits)
     : AbstractSamsungDecompressor(image) {

--- a/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SamsungV2Decompressor.cpp
@@ -149,7 +149,9 @@ SamsungV2Decompressor::SamsungV2Decompressor(RawImageData *image,
 inline __attribute__((always_inline)) std::array<uint16_t, 16>
 SamsungV2Decompressor::prepareBaselineValues(BitPumpMSB32& pump, int row,
                                              int col) {
-  const Array2DRef<uint16_t> img(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> img(rawU16->getU16DataAsUncroppedArray2DRef());
 
   std::array<uint16_t, 16> baseline;
 
@@ -310,7 +312,9 @@ SamsungV2Decompressor::decodeDifferences(BitPumpMSB32& pump, int row) {
 
 inline __attribute__((always_inline)) void
 SamsungV2Decompressor::processBlock(BitPumpMSB32& pump, int row, int col) {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   const std::array<uint16_t, 16> baseline =
       prepareBaselineValues(pump, row, col);

--- a/src/librawspeed/decompressors/SamsungV2Decompressor.h
+++ b/src/librawspeed/decompressors/SamsungV2Decompressor.h
@@ -28,7 +28,6 @@
 
 namespace rawspeed {
 
-class RawImage;
 
 // Decoder for third generation compressed SRW files (NX1)
 class SamsungV2Decompressor final : public AbstractSamsungDecompressor {
@@ -66,7 +65,7 @@ private:
   void decompressRow(int row);
 
 public:
-  SamsungV2Decompressor(const RawImage& image, const ByteStream& bs,
+  SamsungV2Decompressor(RawImageData* image, const ByteStream& bs,
                         unsigned bit);
 
   void decompress();

--- a/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
@@ -52,7 +52,7 @@ inline int SonyArw1Decompressor::getDiff(BitPumpMSB& bs, uint32_t len) {
 }
 
 void SonyArw1Decompressor::decompress(const ByteStream& input) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
@@ -32,7 +32,7 @@
 
 namespace rawspeed {
 
-SonyArw1Decompressor::SonyArw1Decompressor(const RawImage& img) : mRaw(img) {
+SonyArw1Decompressor::SonyArw1Decompressor(RawImageData *img) : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))
     ThrowRDE("Unexpected component count / data type");

--- a/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw1Decompressor.cpp
@@ -52,7 +52,9 @@ inline int SonyArw1Decompressor::getDiff(BitPumpMSB& bs, uint32_t len) {
 }
 
 void SonyArw1Decompressor::decompress(const ByteStream& input) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
   assert(out.height > 0);
   assert(out.height % 2 == 0);

--- a/src/librawspeed/decompressors/SonyArw1Decompressor.h
+++ b/src/librawspeed/decompressors/SonyArw1Decompressor.h
@@ -30,12 +30,12 @@ namespace rawspeed {
 class ByteStream;
 
 class SonyArw1Decompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   inline static int getDiff(BitPumpMSB& bs, uint32_t len);
 
 public:
-  explicit SonyArw1Decompressor(const RawImage& img);
+  explicit SonyArw1Decompressor(RawImageData* img);
   void decompress(const ByteStream& input) const;
 };
 

--- a/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
@@ -52,7 +52,7 @@ SonyArw2Decompressor::SonyArw2Decompressor(RawImageData *img,
 }
 
 void SonyArw2Decompressor::decompressRow(int row) const {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);

--- a/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
@@ -35,7 +35,7 @@
 
 namespace rawspeed {
 
-SonyArw2Decompressor::SonyArw2Decompressor(const RawImage& img,
+SonyArw2Decompressor::SonyArw2Decompressor(RawImageData *img,
                                            const ByteStream& input_)
     : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||

--- a/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
+++ b/src/librawspeed/decompressors/SonyArw2Decompressor.cpp
@@ -52,7 +52,9 @@ SonyArw2Decompressor::SonyArw2Decompressor(RawImageData *img,
 }
 
 void SonyArw2Decompressor::decompressRow(int row) const {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
   assert(out.width % 32 == 0);
 

--- a/src/librawspeed/decompressors/SonyArw2Decompressor.h
+++ b/src/librawspeed/decompressors/SonyArw2Decompressor.h
@@ -30,11 +30,11 @@ class SonyArw2Decompressor final : public AbstractDecompressor {
   void decompressRow(int row) const;
   void decompressThread() const noexcept;
 
-  RawImage mRaw;
+  RawImageData* mRaw;
   ByteStream input;
 
 public:
-  SonyArw2Decompressor(const RawImage& img, const ByteStream& input);
+  SonyArw2Decompressor(RawImageData* img, const ByteStream& input);
   void decompress() const;
 };
 

--- a/src/librawspeed/decompressors/UncompressedDecompressor.h
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.h
@@ -36,7 +36,7 @@ class iPoint2D;
 
 class UncompressedDecompressor final : public AbstractDecompressor {
   ByteStream input;
-  RawImage mRaw;
+  RawImageData* mRaw;
 
   // check buffer size, throw, or compute minimal height that can be decoded
   void sanityCheck(const uint32_t* h, int bytesPerLine) const;
@@ -56,7 +56,7 @@ class UncompressedDecompressor final : public AbstractDecompressor {
                      uint32_t skipBytes, uint32_t h, uint64_t y) const;
 
 public:
-  UncompressedDecompressor(ByteStream input_, const RawImage& img)
+  UncompressedDecompressor(ByteStream input_, RawImageData* img)
       : input(std::move(input_)), mRaw(img) {}
 
   /* Helper function for decoders, that will unpack uncompressed image data */

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -806,7 +806,9 @@ void VC5Decompressor::decode(unsigned int offsetX, unsigned int offsetY,
 }
 
 void VC5Decompressor::combineFinalLowpassBands() const noexcept {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   const int width = out.width / 2;
   const int height = out.height / 2;

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -806,7 +806,7 @@ void VC5Decompressor::decode(unsigned int offsetX, unsigned int offsetY,
 }
 
 void VC5Decompressor::combineFinalLowpassBands() const noexcept {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -372,7 +372,7 @@ void VC5Decompressor::Wavelet::ReconstructableBand::createDecodingTasks(
   createLowHighPassCombiningTask(exceptionThrow);
 }
 
-VC5Decompressor::VC5Decompressor(ByteStream bs, const RawImage& img)
+VC5Decompressor::VC5Decompressor(ByteStream bs, RawImageData* img)
     : mRaw(img), mBs(std::move(bs)) {
   if (!mRaw->dim.hasPositiveArea())
     ThrowRDE("Bad image dimensions.");

--- a/src/librawspeed/decompressors/VC5Decompressor.h
+++ b/src/librawspeed/decompressors/VC5Decompressor.h
@@ -87,7 +87,7 @@ inline VC5Tag operator-(VC5Tag tag) {
 }
 
 class VC5Decompressor final : public AbstractDecompressor {
-  RawImage mRaw;
+  RawImageData* mRaw;
   ByteStream mBs;
 
   static constexpr auto VC5_LOG_TABLE_BITWIDTH = 12;
@@ -217,7 +217,7 @@ class VC5Decompressor final : public AbstractDecompressor {
   void parseVC5();
 
 public:
-  VC5Decompressor(ByteStream bs, const RawImage& img);
+  VC5Decompressor(ByteStream bs, RawImageData *img);
 
   void decode(unsigned int offsetX, unsigned int offsetY, unsigned int width,
               unsigned int height);

--- a/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
+++ b/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
@@ -93,7 +93,9 @@ struct Cr2sRawInterpolator::YCbCr final {
 };
 
 template <int version> void Cr2sRawInterpolator::interpolate_422_row(int row) {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   constexpr int InputComponentsPerMCU = 4;
   constexpr int PixelsPerMCU = 2;
@@ -176,7 +178,9 @@ template <int version> void Cr2sRawInterpolator::interpolate_422_row(int row) {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_422() {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
   assert(out.height > 0);
 
@@ -187,7 +191,9 @@ template <int version> void Cr2sRawInterpolator::interpolate_422() {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_420_row(int row) {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   constexpr int X_S_F = 2;
   constexpr int Y_S_F = 2;
@@ -339,7 +345,9 @@ template <int version> void Cr2sRawInterpolator::interpolate_420_row(int row) {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_420() {
-  const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
+  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  assert(rawU16);
+  const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
   constexpr int X_S_F = 2;
   constexpr int Y_S_F = 2;

--- a/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
+++ b/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
@@ -93,7 +93,7 @@ struct Cr2sRawInterpolator::YCbCr final {
 };
 
 template <int version> void Cr2sRawInterpolator::interpolate_422_row(int row) {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -178,7 +178,7 @@ template <int version> void Cr2sRawInterpolator::interpolate_422_row(int row) {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_422() {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
   assert(out.width > 0);
@@ -191,7 +191,7 @@ template <int version> void Cr2sRawInterpolator::interpolate_422() {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_420_row(int row) {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 
@@ -345,7 +345,7 @@ template <int version> void Cr2sRawInterpolator::interpolate_420_row(int row) {
 }
 
 template <int version> void Cr2sRawInterpolator::interpolate_420() {
-  auto rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
+  auto *rawU16 = dynamic_cast<RawImageDataU16*>(mRaw);
   assert(rawU16);
   const Array2DRef<uint16_t> out(rawU16->getU16DataAsUncroppedArray2DRef());
 

--- a/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
+++ b/src/librawspeed/interpolators/Cr2sRawInterpolator.cpp
@@ -508,7 +508,7 @@ inline void Cr2sRawInterpolator::YUV_TO_RGB<2>(const YCbCr& p, uint16_t* X) {
 void Cr2sRawInterpolator::interpolate(int version) {
   assert(version >= 0 && version <= 2);
 
-  const auto& subSampling = mRaw->metadata.subsampling;
+  const auto& subSampling = mRaw->subsampling;
   if (subSampling.y == 1 && subSampling.x == 2) {
     switch (version) {
     case 0:

--- a/src/librawspeed/interpolators/Cr2sRawInterpolator.h
+++ b/src/librawspeed/interpolators/Cr2sRawInterpolator.h
@@ -26,10 +26,10 @@
 
 namespace rawspeed {
 
-class RawImage;
+class RawImageData;
 
 class Cr2sRawInterpolator final {
-  const RawImage& mRaw;
+  RawImageData* mRaw;
 
   const Array2DRef<const uint16_t> input;
   std::array<int, 3> sraw_coeffs;
@@ -38,7 +38,7 @@ class Cr2sRawInterpolator final {
   struct YCbCr;
 
 public:
-  Cr2sRawInterpolator(const RawImage& mRaw_, Array2DRef<const uint16_t> input_,
+  Cr2sRawInterpolator(RawImageData* mRaw_, Array2DRef<const uint16_t> input_,
                       std::array<int, 3> sraw_coeffs_, int hue_)
       : mRaw(mRaw_), input(input_), sraw_coeffs(sraw_coeffs_), hue(hue_) {}
 

--- a/src/librawspeed/tiff/CiffEntry.cpp
+++ b/src/librawspeed/tiff/CiffEntry.cpp
@@ -56,8 +56,6 @@ CiffEntry::CiffEntry(NORangesSet<Buffer>* valueDatas,
       ThrowCPE("Two valueData's overlap. Raw corrupt!");
     break;
   case 0x4000:
-    // Data is stored directly in entry
-    data_offset = dirEntry.getPosition();
     // Maximum of 8 bytes of data (the size and offset fields)
     bytesize = 8;
     data = dirEntry.getStream(bytesize);

--- a/src/librawspeed/tiff/TiffEntry.cpp
+++ b/src/librawspeed/tiff/TiffEntry.cpp
@@ -54,14 +54,12 @@ TiffEntry::TiffEntry(TiffIFD* parent_, ByteStream& bs)
     ThrowTPE("integer overflow in size calculation.");
 
   uint32_t byte_size = count << datashifts[numType];
-  uint32_t data_offset = UINT32_MAX;
 
   if (byte_size <= 4) {
-    data_offset = bs.getPosition();
     data = bs.getSubStream(bs.getPosition(), byte_size);
     bs.skipBytes(4);
   } else {
-    data_offset = bs.getU32();
+    uint32_t data_offset = bs.getU32();
     if (type == TiffDataType::OFFSET ||
         isIn(tag, {TiffTag::DNGPRIVATEDATA, TiffTag::MAKERNOTE,
                    TiffTag::MAKERNOTE_ALT, TiffTag::FUJI_RAW_IFD,

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -244,7 +244,7 @@ int main(int argc, char* argv[]) { // NOLINT
 
       double sum = 0.0F;
 #ifdef HAVE_OPENMP
-#pragma omp parallel for default(none) firstprivate(dimUncropped, raw, bpp) schedule(static) reduction(+ : sum)
+#pragma omp parallel for default(none) firstprivate(dimUncropped, frame, bpp) schedule(static) reduction(+ : sum)
 #endif
       for (int y = 0; y < dimUncropped.y; ++y) {
         const uint8_t* const data = frame->getDataUncropped(0, y);
@@ -260,7 +260,7 @@ int main(int argc, char* argv[]) { // NOLINT
         sum = 0.0F;
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for default(none) firstprivate(dimUncropped, raw, cpp) schedule(static) reduction(+ : sum)
+#pragma omp parallel for default(none) firstprivate(dimUncropped, frame, cpp) schedule(static) reduction(+ : sum)
 #endif
         for (int y = 0; y < dimUncropped.y; ++y) {
           const auto* const data =
@@ -277,7 +277,7 @@ int main(int argc, char* argv[]) { // NOLINT
         sum = 0.0F;
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for default(none) firstprivate(dimUncropped, raw, cpp) schedule(static) reduction(+ : sum)
+#pragma omp parallel for default(none) firstprivate(dimUncropped, frame, cpp) schedule(static) reduction(+ : sum)
 #endif
         for (int y = 0; y < dimUncropped.y; ++y) {
           const auto* const data =

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -178,7 +178,7 @@ int main(int argc, char* argv[]) { // NOLINT
 
     d->applyCrop = false;
     d->failOnUnknown = true;
-    auto raw = d->mRaw;
+    auto raw = d->mRaw.get(0);
 
     d->decodeMetaData(meta.get());
 
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) { // NOLINT
     d->checkSupport(meta.get());
     d->decodeRaw();
     d->decodeMetaData(meta.get());
-    raw = d->mRaw;
+    raw = d->mRaw.get(0);
 
     const auto errors = raw->getErrors();
     for (const auto& error : errors)

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -177,112 +177,120 @@ int main(int argc, char* argv[]) { // NOLINT
     }
 
     d->applyCrop = false;
-    d->failOnUnknown = true;
-    auto raw = d->mRaw.get(0);
-
+    d->failOnUnknown = true;    
     d->decodeMetaData(meta.get());
 
-    fprintf(stdout, "make: %s\n", raw->metadata.make.c_str());
-    fprintf(stdout, "model: %s\n", raw->metadata.model.c_str());
+    fprintf(stdout, "make: %s\n", d->mRaw.metadata.make.c_str());
+    fprintf(stdout, "model: %s\n", d->mRaw.metadata.model.c_str());
 
-    fprintf(stdout, "canonical_make: %s\n", raw->metadata.canonical_make.c_str());
+    fprintf(stdout, "canonical_make: %s\n",
+            d->mRaw.metadata.canonical_make.c_str());
     fprintf(stdout, "canonical_model: %s\n",
-            raw->metadata.canonical_model.c_str());
+            d->mRaw.metadata.canonical_model.c_str());
     fprintf(stdout, "canonical_alias: %s\n",
-            raw->metadata.canonical_alias.c_str());
+            d->mRaw.metadata.canonical_alias.c_str());
 
     d->checkSupport(meta.get());
     d->decodeRaw();
     d->decodeMetaData(meta.get());
-    raw = d->mRaw.get(0);
 
-    const auto errors = raw->getErrors();
-    for (const auto& error : errors)
-      fprintf(stderr, "WARNING: [rawspeed] %s\n", error.c_str());
+    fprintf(stdout, "wbCoeffs: %f %f %f %f\n", d->mRaw.metadata.wbCoeffs[0],
+            d->mRaw.metadata.wbCoeffs[1], d->mRaw.metadata.wbCoeffs[2],
+            d->mRaw.metadata.wbCoeffs[3]);
 
-    fprintf(stdout, "blackLevel: %d\n", raw->blackLevel);
-    fprintf(stdout, "whitePoint: %d\n", raw->whitePoint);
+    fprintf(stdout, "fuji_rotation_pos: %d\n",
+            d->mRaw.metadata.fujiRotationPos);
+    fprintf(stdout, "pixel_aspect_ratio: %f\n",
+            d->mRaw.metadata.pixelAspectRatio);
 
-    fprintf(stdout, "blackLevelSeparate: %d %d %d %d\n",
-            raw->blackLevelSeparate[0], raw->blackLevelSeparate[1],
-            raw->blackLevelSeparate[2], raw->blackLevelSeparate[3]);
+    fprintf(stdout, "total frames: %lu\n", d->mRaw.size());
 
-    fprintf(stdout, "wbCoeffs: %f %f %f %f\n", raw->metadata.wbCoeffs[0],
-            raw->metadata.wbCoeffs[1], raw->metadata.wbCoeffs[2],
-            raw->metadata.wbCoeffs[3]);
+    for (rawspeed::RawImage::storage_t::size_type i = 0; i < d->mRaw.size();
+         ++i) {
+      fprintf(stdout, "\nframe %lu:\n", i);
+      auto frame = d->mRaw.get(i);
+      const auto errors = frame->getErrors();
+      for (const auto& error : errors)
+        fprintf(stderr, "WARNING: [rawspeed] %s\n", error.c_str());
 
-    fprintf(stdout, "isCFA: %d\n", raw->isCFA);
-    uint32_t filters = raw->cfa.getDcrawFilter();
-    fprintf(stdout, "filters: %d (0x%x)\n", filters, filters);
-    const uint32_t bpp = raw->getBpp();
-    fprintf(stdout, "bpp: %d\n", bpp);
-    const uint32_t cpp = raw->getCpp();
-    fprintf(stdout, "cpp: %d\n", cpp);
-    fprintf(stdout, "dataType: %u\n", static_cast<unsigned>(raw->getDataType()));
+      fprintf(stdout, "blackLevel: %d\n", frame->blackLevel);
+      fprintf(stdout, "whitePoint: %d\n", frame->whitePoint);
 
-    // dimensions of uncropped image
-    const iPoint2D dimUncropped = raw->getUncroppedDim();
-    fprintf(stdout, "dimUncropped: %dx%d\n", dimUncropped.x, dimUncropped.y);
+      fprintf(stdout, "blackLevelSeparate: %d %d %d %d\n",
+              frame->blackLevelSeparate[0], frame->blackLevelSeparate[1],
+              frame->blackLevelSeparate[2], frame->blackLevelSeparate[3]);
 
-    // dimensions of cropped image
-    iPoint2D dimCropped = raw->dim;
-    fprintf(stdout, "dimCropped: %dx%d\n", dimCropped.x, dimCropped.y);
+      fprintf(stdout, "isCFA: %d\n", frame->isCFA);
+      uint32_t filters = frame->cfa.getDcrawFilter();
+      fprintf(stdout, "filters: %d (0x%x)\n", filters, filters);
+      const uint32_t bpp = frame->getBpp();
+      fprintf(stdout, "bpp: %d\n", bpp);
+      const uint32_t cpp = frame->getCpp();
+      fprintf(stdout, "cpp: %d\n", cpp);
+      fprintf(stdout, "dataType: %u\n",
+              static_cast<unsigned>(frame->getDataType()));
 
-    // crop - Top,Left corner
-    iPoint2D cropTL = raw->getCropOffset();
-    fprintf(stdout, "cropOffset: %dx%d\n", cropTL.x, cropTL.y);
+      // dimensions of uncropped image
+      const iPoint2D dimUncropped = frame->getUncroppedDim();
+      fprintf(stdout, "dimUncropped: %dx%d\n", dimUncropped.x, dimUncropped.y);
 
-    fprintf(stdout, "fuji_rotation_pos: %d\n", raw->metadata.fujiRotationPos);
-    fprintf(stdout, "pixel_aspect_ratio: %f\n", raw->metadata.pixelAspectRatio);
+      // dimensions of cropped image
+      iPoint2D dimCropped = frame->dim;
+      fprintf(stdout, "dimCropped: %dx%d\n", dimCropped.x, dimCropped.y);
 
-    double sum = 0.0F;
+      // crop - Top,Left corner
+      iPoint2D cropTL = frame->getCropOffset();
+      fprintf(stdout, "cropOffset: %dx%d\n", cropTL.x, cropTL.y);
+
+      double sum = 0.0F;
 #ifdef HAVE_OPENMP
 #pragma omp parallel for default(none) firstprivate(dimUncropped, raw, bpp) schedule(static) reduction(+ : sum)
 #endif
-    for (int y = 0; y < dimUncropped.y; ++y) {
-      const uint8_t* const data = raw->getDataUncropped(0, y);
+      for (int y = 0; y < dimUncropped.y; ++y) {
+        const uint8_t* const data = frame->getDataUncropped(0, y);
 
-      for (unsigned x = 0; x < bpp * dimUncropped.x; ++x)
-        sum += static_cast<double>(data[x]);
-    }
-    fprintf(stdout, "Image byte sum: %lf\n", sum);
-    fprintf(stdout, "Image byte avg: %lf\n",
-            sum / static_cast<double>(dimUncropped.y * dimUncropped.x * bpp));
+        for (unsigned x = 0; x < bpp * dimUncropped.x; ++x)
+          sum += static_cast<double>(data[x]);
+      }
+      fprintf(stdout, "Image byte sum: %lf\n", sum);
+      fprintf(stdout, "Image byte avg: %lf\n",
+              sum / static_cast<double>(dimUncropped.y * dimUncropped.x * bpp));
 
-    if (raw->getDataType() == rawspeed::RawImageType::F32) {
-      sum = 0.0F;
+      if (frame->getDataType() == rawspeed::RawImageType::F32) {
+        sum = 0.0F;
 
 #ifdef HAVE_OPENMP
 #pragma omp parallel for default(none) firstprivate(dimUncropped, raw, cpp) schedule(static) reduction(+ : sum)
 #endif
-      for (int y = 0; y < dimUncropped.y; ++y) {
-        const auto* const data =
-            reinterpret_cast<float*>(raw->getDataUncropped(0, y));
+        for (int y = 0; y < dimUncropped.y; ++y) {
+          const auto* const data =
+              reinterpret_cast<float*>(frame->getDataUncropped(0, y));
 
-        for (unsigned x = 0; x < cpp * dimUncropped.x; ++x)
-          sum += static_cast<double>(data[x]);
-      }
+          for (unsigned x = 0; x < cpp * dimUncropped.x; ++x)
+            sum += static_cast<double>(data[x]);
+        }
 
-      fprintf(stdout, "Image float sum: %lf\n", sum);
-      fprintf(stdout, "Image float avg: %lf\n",
-              sum / static_cast<double>(dimUncropped.y * dimUncropped.x));
-    } else if (raw->getDataType() == rawspeed::RawImageType::UINT16) {
-      sum = 0.0F;
+        fprintf(stdout, "Image float sum: %lf\n", sum);
+        fprintf(stdout, "Image float avg: %lf\n",
+                sum / static_cast<double>(dimUncropped.y * dimUncropped.x));
+      } else if (frame->getDataType() == rawspeed::RawImageType::UINT16) {
+        sum = 0.0F;
 
 #ifdef HAVE_OPENMP
 #pragma omp parallel for default(none) firstprivate(dimUncropped, raw, cpp) schedule(static) reduction(+ : sum)
 #endif
-      for (int y = 0; y < dimUncropped.y; ++y) {
-        const auto* const data =
-            reinterpret_cast<uint16_t*>(raw->getDataUncropped(0, y));
+        for (int y = 0; y < dimUncropped.y; ++y) {
+          const auto* const data =
+              reinterpret_cast<uint16_t*>(frame->getDataUncropped(0, y));
 
-        for (unsigned x = 0; x < cpp * dimUncropped.x; ++x)
-          sum += static_cast<double>(data[x]);
+          for (unsigned x = 0; x < cpp * dimUncropped.x; ++x)
+            sum += static_cast<double>(data[x]);
+        }
+
+        fprintf(stdout, "Image uint16_t sum: %lf\n", sum);
+        fprintf(stdout, "Image uint16_t avg: %lf\n",
+                sum / static_cast<double>(dimUncropped.y * dimUncropped.x));
       }
-
-      fprintf(stdout, "Image uint16_t sum: %lf\n", sum);
-      fprintf(stdout, "Image uint16_t avg: %lf\n",
-              sum / static_cast<double>(dimUncropped.y * dimUncropped.x));
     }
   } catch (const RawspeedException& e) {
     fprintf(stderr, "ERROR: [rawspeed] %s\n", e.what());

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -165,7 +165,7 @@ std::string img_hash(const RawImage& r, bool noSamples) {
   APPEND(&oss, "canonical_alias: %s\n", r.metadata.canonical_alias.c_str());
   APPEND(&oss, "canonical_id: %s\n", r.metadata.canonical_id.c_str());
 
-  for (auto frame : r) {
+  for (const auto &frame : r) {
 
     APPEND(&oss, "isoSpeed: %d\n", r.metadata.isoSpeed);
     APPEND(&oss, "blackLevel: %d\n", frame->blackLevel);
@@ -385,13 +385,14 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
     // write the hash. if force is set, then we are potentially overwriting here
     ofstream f(hashfile);
     f << img_hash(decoder->mRaw, noSamples);
-    if (o.dump)
+    if (o.dump){
       for (rawspeed::RawImage::storage_t::size_type i = 0;
            i < decoder->mRaw.size(); ++i) {
         std::stringstream s;
         s << filename << "." << i;
         writeImage(decoder->mRaw.get(i).get(), s.str());
       }
+    }
   } else {
     // do generate the hash string regardless.
     std::string h = img_hash(decoder->mRaw, noSamples);
@@ -406,13 +407,14 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
     if (h!= truth) {
       ofstream f(filename + ".hash.failed");
       f << h;
-      if (o.dump)
+      if (o.dump){
         for (rawspeed::RawImage::storage_t::size_type i = 0;
              i < decoder->mRaw.size(); ++i) {
           std::stringstream s;
           s << filename << "." << i << ".failed";
           writeImage(decoder->mRaw.get(i).get(), s.str());
         }
+      }
       throw RstestHashMismatch("hash/metadata mismatch", time);
     }
   }

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -386,8 +386,12 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
     ofstream f(hashfile);
     f << img_hash(decoder->mRaw, noSamples);
     if (o.dump)
-      /// TODO modify to handle multiframe images
-      writeImage(decoder->mRaw.get(0).get(), filename);
+      for (rawspeed::RawImage::storage_t::size_type i = 0;
+           i < decoder->mRaw.size(); ++i) {
+        std::stringstream s;
+        s << filename << "." << i;
+        writeImage(decoder->mRaw.get(i).get(), s.str());
+      }
   } else {
     // do generate the hash string regardless.
     std::string h = img_hash(decoder->mRaw, noSamples);
@@ -403,8 +407,12 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
       ofstream f(filename + ".hash.failed");
       f << h;
       if (o.dump)
-        /// TODO modify to handle multiframe images
-        writeImage(decoder->mRaw.get(0).get(), filename + ".failed");
+        for (rawspeed::RawImage::storage_t::size_type i = 0;
+             i < decoder->mRaw.size(); ++i) {
+          std::stringstream s;
+          s << filename << "." << i << ".failed";
+          writeImage(decoder->mRaw.get(i).get(), s.str());
+        }
       throw RstestHashMismatch("hash/metadata mismatch", time);
     }
   }

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -368,7 +368,7 @@ size_t process(const std::string& filename, const CameraMetaData* metadata,
 
   decoder->decodeRaw();
   decoder->decodeMetaData(metadata);
-  auto raw = decoder->mRaw.get();
+  auto raw = decoder->mRaw.get(0).get();
   // RawImage raw = decoder->decode();
 
   auto time = t();

--- a/test/librawspeed/metadata/CameraSensorInfoTest.cpp
+++ b/test/librawspeed/metadata/CameraSensorInfoTest.cpp
@@ -269,7 +269,7 @@ protected:
             std::rand(), // NOLINT do not need crypto-level randomness
             std::rand()  // NOLINT do not need crypto-level randomness
         }) {}
-  virtual void SetUp() override { data = GetParam(); }
+  void SetUp() override { data = GetParam(); }
 
   IsoExpectationsT data;
 

--- a/test/librawspeed/metadata/CameraTest.cpp
+++ b/test/librawspeed/metadata/CameraTest.cpp
@@ -139,7 +139,7 @@ TEST(BoolHintTest, HintsBoolTrue) {
 
 class BoolHintTest : public ::testing::TestWithParam<std::tuple<string>> {
 protected:
-  virtual void SetUp() override { notTrue = std::get<0>(GetParam()); }
+  void SetUp() override { notTrue = std::get<0>(GetParam()); }
   string notTrue;
 };
 INSTANTIATE_TEST_CASE_P(NotTrue, BoolHintTest,

--- a/test/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/test/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -140,7 +140,7 @@ TEST(ColorFilterArrayTestBasic, HandlesOutOfBounds) {
 class ColorFilterArrayTest : public ::testing::TestWithParam<Bayer2x2> {
 protected:
   ColorFilterArrayTest() = default;
-  virtual void SetUp() { param = GetParam(); }
+  void SetUp() override { param = GetParam(); }
 
   Bayer2x2 param;
 };
@@ -234,7 +234,7 @@ class ColorFilterArrayShiftTest
           std::tuple<CFAColor, CFAColor, CFAColor, CFAColor, int, int>> {
 protected:
   ColorFilterArrayShiftTest() = default;
-  virtual void SetUp() {
+  void SetUp() override {
     auto param = GetParam();
     mat = std::make_tuple(std::get<0>(param), std::get<1>(param),
                           std::get<2>(param), std::get<3>(param));


### PR DESCRIPTION
Hi I implemented support for multiframe DNGs. Teste with penatx PixelShift DNG.

warning: this breaks external API, merging must be coordinated with changes in darktable.

my plan is to change darktable pipeline to support multiple frames, and merge them in demosaic module.

work done:
-refactored RawImage and RawImageData classes to store multiple frames.
-modified internal api
-modified DngDecoder to decode all frames

todo:
-speed optimizations
-cleanup?

possible future:
-modify all decoders to support multiple frames