### PR TITLE
`ColorFilterArray::shiftDcrawFilter()`: avoid out-of-bounds shifts

### DIFF
--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -153,9 +153,8 @@ uint32_t ColorFilterArray::shiftDcrawFilter(uint32_t filter, int x, int y) {
   // A shift in y direction means rotating the whole int by 4 bits.
   y *= 4;
   y = y >= 0 ? y % 32 : 32 - ((-y) % 32);
-  if (y != 0) {
+  if (y != 0)
     filter = (filter >> y) | (filter << (32 - y));
-  }
 
   return filter;
 }

--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -153,7 +153,9 @@ uint32_t ColorFilterArray::shiftDcrawFilter(uint32_t filter, int x, int y) {
   // A shift in y direction means rotating the whole int by 4 bits.
   y *= 4;
   y = y >= 0 ? y % 32 : 32 - ((-y) % 32);
-  filter = (filter >> y) | (filter << (32 - y));
+  if (y != 0) {
+    filter = (filter >> y) | (filter << (32 - y));
+  }
 
   return filter;
 }


### PR DESCRIPTION
when `y==0`, `(filter << (32 - y))` shifts by 32 is too large for 32-bit integer