### PR TITLE
Add support for DNG DefaultScale tag

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -494,6 +494,14 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
   if (mRaw->dim.area() <= 0)
     ThrowRDE("No image left after crop");
 
+  // Adapt DNG DefaultScale to aspect-ratio
+  if (raw->hasEntry(TiffTag::DEFAULTSCALE)) {
+    const TiffEntry* default_scale = raw->getEntry(TiffTag::DEFAULTSCALE);
+    const auto scales = default_scale->getFloatArray(2);
+    // entry 1 is horizontal scale, entry 2 is vertical scale
+    mRaw->metadata.pixelAspectRatio = scales[0] / scales[1];
+  }
+
   // Apply stage 1 opcodes
   if (applyStage1DngOpcodes && raw->hasEntry(TiffTag::OPCODELIST1)) {
     try {


### PR DESCRIPTION
Some cameras like Nikon D1X has non-square pixels.
For the NEF file, this is controlled in cameras.xml with:

    <Hint name="pixel_aspect_ratio" value="0.5"/>

When NEF is converted to DNG, the required scale is encoded in DEFAULTSCALE tag. So we can derive the aspect ratio from
this tag.

Attached is a DNG file converted with AdobeDNG from D1X NEF. I've implemented it the same way in dnglab.


[NIKON D1X_ISO_200_12bits_Uncompressed.zip](https://github.com/darktable-org/rawspeed/files/8658630/NIKON.D1X_ISO_200_12bits_Uncompressed.zip)