### PR TITLE
Add Olympus E-M10 Mark IIIs alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7050,6 +7050,9 @@
 		<ID make="Olympus" model="E-M10 Mark III">Olympus E-M10 Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="254" white="4000"/>
+		<Aliases>
+			<Alias id="E-M10 Mark IIIs">E-M10MarkIIIS</Alias>
+		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">8380 -2630 -639</ColorMatrixRow>


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/11803

Reviews also confirm these are identical wrt to sensor parameters, e.g. https://www.dpreview.com/news/0621457211/olympus-releases-the-lightly-updated-om-d-e-m10-mark-iiis

There is a sample on RPU and loads ok after this addition.