### PR TITLE
Explicitly specify `signed` modifier for `char` type

### DIFF
--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -103,7 +103,7 @@ FujiDecompressor::fuji_compressed_params::fuji_compressed_params(
   cur_val = -q_point[4];
   q_table.resize(2 * (1 << d.header.raw_bits));
 
-  for (char* qt = &q_table[0]; cur_val <= q_point[4]; ++qt, ++cur_val) {
+  for (int8_t* qt = &q_table[0]; cur_val <= q_point[4]; ++qt, ++cur_val) {
     if (cur_val <= -q_point[3]) {
       *qt = -4;
     } else if (cur_val <= -q_point[2]) {

--- a/src/librawspeed/decompressors/FujiDecompressor.h
+++ b/src/librawspeed/decompressors/FujiDecompressor.h
@@ -122,7 +122,7 @@ private:
 
     explicit fuji_compressed_params(const FujiDecompressor& d);
 
-    std::vector<char> q_table; /* quantization table */
+    std::vector<int8_t> q_table; /* quantization table */
     std::array<int, 5> q_point; /* quantization points */
     int max_bits;
     int min_value;


### PR DESCRIPTION
I am porting project `darktable` to RISC-V 64 in PR darktable-org/darktable#11797 and I noticed some tests failed in function `fuji_decode_sample` of this repo with logs like this:

```
RawSpeed:EXCEPTION: void rawspeed::FujiDecompressor::decompress() const, line 791: Too many errors encountered. Giving up. First Error:
void rawspeed::FujiDecompressor::fuji_decode_sample(T1&&, T2&&, fuji_compressed_block*, uint16_t*, int*, std::array<int_pair, 41>*) const [with T1 = rawspeed::FujiDecompressor::fuji_decode_sample_even(fuji_compressed_block*, uint16_t*, int*, std::array<int_pair, 41>*) const::<lambda(const uint16_t*, int*, int*, int*)>; T2 = rawspeed::FujiDecompressor::fuji_decode_sample_even(fuji_compressed_block*, uint16_t*, int*, std::array<int_pair, 41>*) const::<lambda(int, int, int)>; uint16_t = short unsigned int], line 305: fuji_decode_sample. code = '16384', total_values = '16384'
```

After some checking and testing, I found that it is caused by using `char` type in some places without specifying a modifier.

Reference to C++ standard ([cppref](https://en.cppreference.com/w/cpp/language/types#Character_types)):

> `char` - type for character representation which can be most efficiently processed on the target system (has the same representation and alignment as either `signed char` or `unsigned char`, but is always a distinct type). [Multibyte characters strings](https://en.cppreference.com/w/cpp/string/multibyte) use this type to represent code units. For every value of type `unsigned char` in range [0, 255], converting the value to `char` and then back to `unsigned char` produces the original value. (since C++11) **The signedness of `char` depends on the compiler and the target platform**: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.

Reference to [RISC-V Calling Convention Specification](https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf) [18.1] C Datatypes and Alignment:

> The C types char and unsigned char are 8-bit unsigned integers and are zero-extended when stored in a RISC-V integer register.

For RISC-V, the `char` type without a modifier is defined as `unsigned` by the implementation. Explicitly adding a `signed` modifier to them would fix these errors.
