### PR TITLE
Fuji" Fix 16 bit "lossless" support for GFX 100

### DIFF
--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -263,7 +263,7 @@ int __attribute__((const)) FujiDecompressor::bitDiff(int value1, int value2) {
   if (value2 >= value1)
     return decBits;
 
-  while (decBits <= 12) {
+  while (decBits <= 14) {
     ++decBits;
 
     if ((value2 << decBits) >= value1)


### PR DESCRIPTION
decBits limit must be 14 instead of 12 (still compatible with 14 bit images). See libraw bitDiff() function for reference.

fixes #228 