### PR TITLE
Fix correction of ActiveArea for CFA in DNG decoder

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -206,8 +206,10 @@ void DngDecoder::parseCFA(const TiffIFD* raw) const {
       }))
     ThrowRDE("Error decoding active area");
 
-  mRaw->cfa.shiftRight(aa[1]);
-  mRaw->cfa.shiftDown(aa[0]);
+  // To reverse the ActiveArea modifictions done earlier, we need to
+  // use the negated ActiveArea x/y values.
+  mRaw->cfa.shiftRight(-aa[1]);
+  mRaw->cfa.shiftDown(-aa[0]);
 }
 
 DngTilingDescription


### PR DESCRIPTION
This supersedes #369 and fixes https://github.com/darktable-org/darktable/issues/11973.

For DNG files with CFA patterns larger than 2x2, the shifts for CFA are not correctly applied.
To undo the shift, we just need to use the negated values from ActiveArea.