### PR TITLE
DngDecoder: improve ColorMatrix extraction

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -637,28 +637,41 @@ void DngDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     }
   }
 
-  if (mRootIFD->hasEntryRecursive(TiffTag::COLORMATRIX2) &&
-      mRootIFD->hasEntryRecursive(TiffTag::CALIBRATIONILLUMINANT2)) {
-    const TiffEntry* illuminant =
-        mRootIFD->getEntryRecursive(TiffTag::CALIBRATIONILLUMINANT2);
-    if (illuminant->getU16() == 21) { // D65
-      const TiffEntry* mat = mRootIFD->getEntryRecursive(TiffTag::COLORMATRIX2);
-      const auto srat_vals = mat->getSRationalArray(mat->count);
-      bool Success = true;
-      mRaw->metadata.colorMatrix.reserve(mat->count);
-      for (const auto& val : srat_vals) {
-        // FIXME: introduce proper rational type.
-        Success &= val.second != 0;
-        if (!Success)
-          break;
-        if (val.second == 10'000)
-            mRaw->metadata.colorMatrix.emplace_back(val.first);
-        else
-            mRaw->metadata.colorMatrix.emplace_back(static_cast<int>(roundf((10'000.0F * val.first) / val.second)));
-      }
-      if (!Success)
-        mRaw->metadata.colorMatrix.clear();
+  // Look for D65 calibrated color matrix
+  TiffEntry* illuminant;
+  TiffEntry* mat = nullptr;
+  if (mRootIFD->hasEntryRecursive(TiffTag::CALIBRATIONILLUMINANT1)) {
+    illuminant = mRootIFD->getEntryRecursive(TiffTag::CALIBRATIONILLUMINANT1);
+    if (illuminant->getU16() == 21 && // D65
+        mRootIFD->hasEntryRecursive(TiffTag::COLORMATRIX1)) {
+      mat = mRootIFD->getEntryRecursive(TiffTag::COLORMATRIX1);
     }
+  }
+  if (mat == nullptr &&
+      mRootIFD->hasEntryRecursive(TiffTag::CALIBRATIONILLUMINANT2)) {
+    illuminant = mRootIFD->getEntryRecursive(TiffTag::CALIBRATIONILLUMINANT2);
+    if (illuminant->getU16() == 21 && // D65
+        mRootIFD->hasEntryRecursive(TiffTag::COLORMATRIX2)) {
+      mat = mRootIFD->getEntryRecursive(TiffTag::COLORMATRIX2);
+    }
+  }
+  if (mat != nullptr) {
+    const auto srat_vals = mat->getSRationalArray(mat->count);
+    bool Success = true;
+    mRaw->metadata.colorMatrix.reserve(mat->count);
+    for (const auto& val : srat_vals) {
+      // FIXME: introduce proper rational type.
+      Success &= val.second != 0;
+      if (!Success)
+        break;
+      if (val.second == 10'000)
+        mRaw->metadata.colorMatrix.emplace_back(val.first);
+      else
+        mRaw->metadata.colorMatrix.emplace_back(
+            static_cast<int>(roundf((10'000.0F * val.first) / val.second)));
+    }
+    if (!Success)
+      mRaw->metadata.colorMatrix.clear();
   }
 }
 

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -648,10 +648,13 @@ void DngDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       mRaw->metadata.colorMatrix.reserve(mat->count);
       for (const auto& val : srat_vals) {
         // FIXME: introduce proper rational type.
-        Success &= val.second == 10'000;
+        Success &= val.second != 0;
         if (!Success)
           break;
-        mRaw->metadata.colorMatrix.emplace_back(val.first);
+        if (val.second == 10'000)
+            mRaw->metadata.colorMatrix.emplace_back(val.first);
+        else
+            mRaw->metadata.colorMatrix.emplace_back(static_cast<int>(roundf((10'000.0F * val.first) / val.second)));
       }
       if (!Success)
         mRaw->metadata.colorMatrix.clear();


### PR DESCRIPTION
See https://discuss.pixls.us/t/dng-hdr-created-in-dt-has-unsupported-input-profile/32528

Not really implementing "rationals support" throughout (I'll bring the comment back in), but should be an ok workaround (better than returning a zero matrix).