### PR TITLE
ARW: Support new LJPEG compression on ILCE-7M4

### DIFF
--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -191,8 +191,8 @@ RawImage ArwDecoder::decodeRawInternal() {
     }
   }
 
-  if (width == 0 || height == 0 || height % 2 != 0 || width > 9600 ||
-      height > 6376)
+  if (width == 0 || height == 0 || height % 2 != 0 || width > 9728 ||
+      height > 6656)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   bool arw1 = uint64_t(counts->getU32()) * 8 != width * height * bitPerPixel;
@@ -250,7 +250,7 @@ void ArwDecoder::DecodeUncompressed(const TiffIFD* raw) const {
 
   mRaw->dim = iPoint2D(width, height);
 
-  if (width == 0 || height == 0 || width > 9600 || height > 6376)
+  if (width == 0 || height == 0 || width > 9728 || height > 6656)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   if (c2 == 0)
@@ -283,8 +283,8 @@ void ArwDecoder::DecodeLJpeg(const TiffIFD* raw) const {
     ThrowRDE("Unexpected bits per pixel: %u", bitPerPixel);
   }
 
-  if (width == 0 || height == 0 || height % 2 != 0 || width > 9600 ||
-      height > 6376)
+  if (width == 0 || height == 0 || height % 2 != 0 || width > 9728 ||
+      height > 6656)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   mRaw->dim = iPoint2D(width, height);

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -52,6 +52,7 @@ private:
   void DecodeARW2(const ByteStream& input, uint32_t w, uint32_t h,
                   uint32_t bpp);
   void DecodeUncompressed(const TiffIFD* raw) const;
+  void DecodeLJpeg(const TiffIFD* raw) const;
   static void SonyDecrypt(const uint32_t* ibuf, uint32_t* obuf, uint32_t len,
                           uint32_t key);
   void GetWB() const;

--- a/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecompressor.h
@@ -164,6 +164,7 @@ public:
 protected:
   bool fixDng16Bug = false;  // DNG v1.0.x compatibility
   bool fullDecodeHT = true;  // FullDecode Huffman
+  bool sonyArrange = false;  // Rows are interleaved
 
   void decode();
   void parseSOF(ByteStream data, SOFInfo* i);

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -47,7 +47,7 @@ public:
   LJpegDecompressor(const ByteStream& bs, const RawImage& img);
 
   void decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
-              uint32_t height, bool fixDng16Bug_);
+              uint32_t height, bool fixDng16Bug_, bool sonyArrange_ = false);
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -47,7 +47,7 @@ public:
   LJpegDecompressor(const ByteStream& bs, const RawImage& img);
 
   void decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
-              uint32_t height, bool fixDng16Bug_, bool sonyArrange_ = false);
+              uint32_t height, bool fixDng16Bug_, bool interleaveRows_ = false);
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
This is a rather hacky implementation of the LJPEG lossless RAW format on the Sony ILCE-7M4 and ILCE-1. I haven't been able to test with LJPEG DNGs which do not use the interleaved rows but it should work. This does not seem to break support for lossy or uncompressed ARWs in my tests