### PR TITLE
Support Samsung NX mini mirrorless camera from 2014

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12108,6 +12108,28 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="SAMSUNG" model="NX mini">
+		<ID make="Samsung" model="NX mini">Samsung NX mini</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="96" y="17" width="-24" height="-18"/>
+		<Sensor black="0" white="4000"/>
+		<BlackAreas>
+			<Vertical x="0" width="80"/>
+			<Horizontal y="0" height="17"/>
+		</BlackAreas>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">5222 -1196 -550</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-6540 14649 2009</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-1666 2819 5657</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="SAMSUNG" model="NX1">
 		<ID make="Samsung" model="NX1">Samsung NX1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
This is based on a conversion of an SRW (Samsung RAW file) to DNG and the output of `dngmeta.sh` in addition to manually inspecting the crop area and black areas.

The sensor range has been confirmed over all ISO settings from 160 to 12800.