### PR TITLE
CI: improved PR job cancelling

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ develop ]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   RPUU_DST: ${{ github.workspace }}/raw-camera-samples/raw.pixls.us-unique
 


### PR DESCRIPTION
This time, only works on pull_request events as per https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value