### PR TITLE
Sony ILCE-7RM5 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13702,6 +13702,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="SONY" model="ILCE-7RM5">
+		<ID make="Sony" model="ILCE-7RM5">Sony ILCE-7RM5</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-32" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">8200 -2976 -719</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4296 12053 2532</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-429 1282 5774</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="SONY" model="ILCE-7S">
 		<ID make="Sony" model="ILCE-7S">Sony ILCE-7S</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Using the just released ADC 15.1 for the color matrix.

Partially addresses https://github.com/darktable-org/darktable/issues/13035 (and https://github.com/darktable-org/darktable/issues/12985, and #409), i.e. no lossless mode support included yet.

As the RPU sample has uniform background, the crop might not be 100% correct and needs to be verified (currently copied from 7RM4).