### PR TITLE
Add Panasonic DC-G95D and DC-G99D aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11287,7 +11287,9 @@
 		<Aliases>
 			<Alias>DC-G90</Alias>
 			<Alias>DC-G91</Alias>
+			<Alias>DC-G95D</Alias>
 			<Alias>DC-G99</Alias>
+			<Alias>DC-G99D</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -11304,7 +11306,9 @@
 		<Aliases>
 			<Alias>DC-G90</Alias>
 			<Alias>DC-G91</Alias>
+			<Alias>DC-G95D</Alias>
 			<Alias>DC-G99</Alias>
+			<Alias>DC-G99D</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
See

https://discuss.pixls.us/t/darktable-error-reading-panasonic-g95-raw-files/34852/5

https://www.digitalcameraworld.com/news/panasonic-is-back-with-another-new-camera-that-isnt-really-new