### PR TITLE
Fix GFX100(S) 16-bit sensor levels

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14889,6 +14889,42 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="FUJIFILM" model="GFX 100" mode="16bit-uncompressed">
+		<ID make="Fujifilm" model="GFX 100">Fujifilm GFX 100</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="256" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX 100" mode="16bit-compressed">
+		<ID make="Fujifilm" model="GFX 100">Fujifilm GFX 100</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="256" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="FUJIFILM" model="GFX100S">
 		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
 		<CFA width="2" height="2">
@@ -14898,7 +14934,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="63" white="16383"/>
+		<Sensor black="62" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
@@ -14917,6 +14953,42 @@
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
 		<Sensor black="62" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX100S" mode="16bit-uncompressed">
+		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="255" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX100S" mode="16bit-compressed">
+		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="4" width="-146" height="-6"/>
+		<Sensor black="255" white="65535"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14862,7 +14862,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="63" white="16383"/>
+		<Sensor black="0" white="0"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
@@ -14880,43 +14880,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="62" white="16383"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
-	<Camera make="FUJIFILM" model="GFX 100" mode="16bit-uncompressed">
-		<ID make="Fujifilm" model="GFX 100">Fujifilm GFX 100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="256" white="65535"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
-	<Camera make="FUJIFILM" model="GFX 100" mode="16bit-compressed">
-		<ID make="Fujifilm" model="GFX 100">Fujifilm GFX 100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="256" white="65535"/>
+		<Sensor black="0" white="0"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
@@ -14934,7 +14898,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="62" white="16383"/>
+		<Sensor black="0" white="0"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
@@ -14952,43 +14916,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="62" white="16383"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
-	<Camera make="FUJIFILM" model="GFX100S" mode="16bit-uncompressed">
-		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="255" white="65535"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-4336 12583 1937</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-195 726 6199</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
-	<Camera make="FUJIFILM" model="GFX100S" mode="16bit-compressed">
-		<ID make="Fujifilm" model="GFX100S">Fujifilm GFX100S</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="4" width="-146" height="-6"/>
-		<Sensor black="255" white="65535"/>
+		<Sensor black="0" white="0"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">16212 -8423 -1583</ColorMatrixRow>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -495,8 +495,6 @@
       <xs:enumeration value="12bit-uncompressed"/>
       <xs:enumeration value="14bit-compressed"/>
       <xs:enumeration value="14bit-uncompressed"/>
-      <xs:enumeration value="16bit-compressed"/>
-      <xs:enumeration value="16bit-uncompressed"/>
       <xs:enumeration value="16:9"/>
       <xs:enumeration value="1:1"/>
       <xs:enumeration value="3:2"/>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -495,6 +495,8 @@
       <xs:enumeration value="12bit-uncompressed"/>
       <xs:enumeration value="14bit-compressed"/>
       <xs:enumeration value="14bit-uncompressed"/>
+      <xs:enumeration value="16bit-compressed"/>
+      <xs:enumeration value="16bit-uncompressed"/>
       <xs:enumeration value="16:9"/>
       <xs:enumeration value="1:1"/>
       <xs:enumeration value="3:2"/>


### PR DESCRIPTION
This branch corrects the black and white sensor levels for Fujifilm GFX100(S) cameras in 16-bit mode, fixing the following issues:

- [GFX 100S 16 bits white point #354](https://github.com/darktable-org/rawspeed/issues/354)
- [Fujifilm GFX 100 support issues #11071](https://github.com/darktable-org/darktable/issues/11071) (partly)

Currently, cameras.xml lists 62 or 63 for the black and 16383 for the white sensor level of these cameras, regardless of output bit depth. These numbers are correct for 14-bit output. For 16-bit they should be 255 (GFX100S) or 256 (GFX 100) for black and 65535 for white, as found in the exif tags _Exif.Fujifilm.BlackLevel_, _Exif.SubImage1.BlackLevel_ and _Exif.SubImage1.WhiteLevel_, the last two extracted from DNG converted files. Darktable uses these values per default which leads to apparently overexposed raws, unless you change the white level manually.

New modes '16bit-uncompressed' and '16bit-compressed' with adapted sensor levels are added to cameras.xml (and cameras.xsd) for Fujifilm GFX 100 and GFX100S cameras. The only code change is within _decodeMetaDataInternal_ of RafDecoder.cpp. I did not change _checkSupportInternal_ and _decodeRawInternal_, which should be fine as long as the standard modes '' and 'compressed' exist.

The change of black and white levels does not affect existing edits in darktable, but only new image imports and history resets.