### PR TITLE
Panasonic v6 12 bit support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11310,30 +11310,6 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DC-GH5M2" mode="16:9">
-		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
-		<Crop x="0" y="0" width="-56" height="0"/>
-		<Sensor black="129" white="4088"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
-	<Camera make="Panasonic" model="DC-GH5M2" mode="1:1">
-		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
-		<Crop x="0" y="0" width="-56" height="0"/>
-		<Sensor black="129" white="4088"/>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
-	</Camera>
 	<Camera make="Panasonic" model="DC-G9">
 		<ID make="Panasonic" model="DC-G9">Panasonic DC-G9</ID>
 		<Crop x="0" y="0" width="-58" height="0"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11286,6 +11286,54 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="Panasonic" model="DC-GH5M2">
+		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
+		<Crop x="0" y="0" width="-56" height="0"/>
+		<Sensor black="129" white="4088"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-GH5M2" mode="4:3">
+		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
+		<Crop x="0" y="0" width="-56" height="0"/>
+		<Sensor black="129" white="4088"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-GH5M2" mode="16:9">
+		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
+		<Crop x="0" y="0" width="-56" height="0"/>
+		<Sensor black="129" white="4088"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-GH5M2" mode="1:1">
+		<ID make="Panasonic" model="DC-GH5M2">Panasonic DC-GH5M2</ID>
+		<Crop x="0" y="0" width="-56" height="0"/>
+		<Sensor black="129" white="4088"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9300 -3659 -755</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-2981 10988 2287</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-190 1077 5016</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="Panasonic" model="DC-G9">
 		<ID make="Panasonic" model="DC-G9">Panasonic DC-G9</ID>
 		<Crop x="0" y="0" width="-58" height="0"/>

--- a/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -42,10 +42,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     rawspeed::RawImage mRaw(CreateRawImage(bs));
 
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
+    const auto bps = bs.get<uint32_t>();
 
-    rawspeed::PanasonicV6Decompressor<14> p(mRaw, rawData);
-    mRaw->createData();
-    p.decompress();
+    if (bps == 12) {
+      rawspeed::PanasonicV6Decompressor<12> d(mRaw, rawData);
+      mRaw->createData();
+      d.decompress();
+    } else {
+      rawspeed::PanasonicV6Decompressor<14> p(mRaw, rawData);
+      mRaw->createData();
+      p.decompress();
+    }
 
     mRaw->checkMemIsInitialized();
   } catch (const rawspeed::RawspeedException&) {

--- a/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -43,7 +43,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
 
     rawspeed::ByteStream rawData = bs.getStream(bs.getRemainSize());
 
-    rawspeed::PanasonicV6Decompressor p(mRaw, rawData);
+    rawspeed::PanasonicV6Decompressor<14> p(mRaw, rawData);
     mRaw->createData();
     p.decompress();
 

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -144,12 +144,19 @@ RawImage Rw2Decoder::decodeRawInternal() {
       return mRaw;
     }
     case 6: {
-      if (bitsPerSample != 14)
+      if (bitsPerSample != 14 && bitsPerSample != 12)
         ThrowRDE("Version %i: unexpected bits per sample: %i", version,
                  bitsPerSample);
-      PanasonicV6Decompressor v6(mRaw, bs);
-      mRaw->createData();
-      v6.decompress();
+
+      if(bitsPerSample == 14) {
+        PanasonicV6Decompressor<14> v6(mRaw, bs);
+        mRaw->createData();
+        v6.decompress();
+      } else {
+        PanasonicV6Decompressor<12> v6(mRaw, bs);
+        mRaw->createData();
+        v6.decompress();
+      }
       return mRaw;
     }
     case 7: {

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -26,7 +26,6 @@
 #include "common/Common.h"                // for rawspeed_get_number_of_pro...
 #include "common/RawImage.h"              // for RawImage, RawImageData
 #include "decoders/RawDecoderException.h" // for ThrowException, ThrowRDE
-#include "io/Buffer.h"
 #include <array>                          // for array
 #include <cassert>                        // for assert
 #include <cstdint>                        // for uint16_t
@@ -34,18 +33,15 @@
 namespace rawspeed {
 
 namespace {
-template <const int B>
-struct pana_cs6_page_decoder {
+template <const int B> struct pana_cs6_page_decoder {
   static_assert(B == 14 | B == 12, "only 12/14 bits are valid!");
-  static constexpr int BufferSize = B == 14 ? 14 : 18; 
+  static constexpr int BufferSize = B == 14 ? 14 : 18;
   std::array<uint16_t, BufferSize> pixelbuffer;
   unsigned char current = 0;
 
   void fillBuffer(const ByteStream& bs) noexcept;
 
-  explicit pana_cs6_page_decoder(const ByteStream& bs) {
-    fillBuffer(bs);
-  }
+  explicit pana_cs6_page_decoder(const ByteStream& bs) { fillBuffer(bs); }
 
   uint16_t nextpixel() {
     uint16_t currPixel = pixelbuffer[current];
@@ -54,95 +50,95 @@ struct pana_cs6_page_decoder {
   }
 };
 
-  template <>
-  inline void __attribute__((always_inline))
-  pana_cs6_page_decoder<12>::fillBuffer(const ByteStream& bs) noexcept {
-    // 12 bit: 8/0 + 4 upper bits of /1
-    pixelbuffer[0] = (bs.peekByte(15) << 4) | (bs.peekByte(14) >> 4);  
-    // 12 bit: 4l/1 + 8/2            
-    pixelbuffer[1] = (((bs.peekByte(14) & 0xf) << 8) | (bs.peekByte(13))) & 0xfff; 
-    
-    // 2; 2u/3, 6 low bits remains in bs.peekByte(12) 
-    pixelbuffer[2] = (bs.peekByte(12) >> 6) & 0x3;           
-    // 8; 6l/3 + 2u/4; 6 low bits remains in bs.peekByte(11)            
-    pixelbuffer[3] = ((bs.peekByte(12) & 0x3f) << 2) | (bs.peekByte(11) >> 6);   
-    // 8: 6l/4 + 2u/5; 6 low bits remains in bs.peekByte(10)  
-    pixelbuffer[4] = ((bs.peekByte(11) & 0x3f) << 2) | (bs.peekByte(10) >> 6);     
-    // 8: 6l/5 + 2u/6, 6 low bits remains in bs.peekByte(9)
-    pixelbuffer[5] = ((bs.peekByte(10) & 0x3f) << 2) | (bs.peekByte(9) >> 6);     
+template <>
+inline void __attribute__((always_inline))
+pana_cs6_page_decoder<12>::fillBuffer(const ByteStream& bs) noexcept {
+  // 12 bit: 8/0 + 4 upper bits of /1
+  pixelbuffer[0] = (bs.peekByte(15) << 4) | (bs.peekByte(14) >> 4);
+  // 12 bit: 4l/1 + 8/2
+  pixelbuffer[1] = (((bs.peekByte(14) & 0xf) << 8) | (bs.peekByte(13))) & 0xfff;
 
-    // 2, 4 low bits remains in bs.peekByte(9)
-    pixelbuffer[6] = (bs.peekByte(9) >> 4) & 0x3;               
-    // 8: 4 low bits from bs.peekByte(9), 4 upper bits from bs.peekByte(8)       
-    pixelbuffer[7] = ((bs.peekByte(9) & 0xf) << 4) | (bs.peekByte(8) >> 4);    
-    // 8: 4 low bits from bs.peekByte(8), 4 upper bits from bs.peekByte(7)  
-    pixelbuffer[8] = ((bs.peekByte(8) & 0xf) << 4) | (bs.peekByte(7) >> 4);  
-    // 8: 4 low bits from bs.peekByte(7), 4 upper bits from bs.peekByte(6)    
-    pixelbuffer[9] = ((bs.peekByte(7) & 0xf) << 4) | (bs.peekByte(6) >> 4);     
+  // 2; 2u/3, 6 low bits remains in bs.peekByte(12)
+  pixelbuffer[2] = (bs.peekByte(12) >> 6) & 0x3;
+  // 8; 6l/3 + 2u/4; 6 low bits remains in bs.peekByte(11)
+  pixelbuffer[3] = ((bs.peekByte(12) & 0x3f) << 2) | (bs.peekByte(11) >> 6);
+  // 8: 6l/4 + 2u/5; 6 low bits remains in bs.peekByte(10)
+  pixelbuffer[4] = ((bs.peekByte(11) & 0x3f) << 2) | (bs.peekByte(10) >> 6);
+  // 8: 6l/5 + 2u/6, 6 low bits remains in bs.peekByte(9)
+  pixelbuffer[5] = ((bs.peekByte(10) & 0x3f) << 2) | (bs.peekByte(9) >> 6);
 
-    // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)
-    pixelbuffer[10] = (bs.peekByte(6) >> 2) & 0x3;     
-    // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)                
-    pixelbuffer[11] = ((bs.peekByte(6) & 0x3) << 6) | (bs.peekByte(5) >> 2);  
-    // 8: 2 bits from bs.peekByte(5), 6 bits from bs.peekByte(4)  
-    pixelbuffer[12] = ((bs.peekByte(5) & 0x3) << 6) | (bs.peekByte(4) >> 2);  
-    // 8: 2 bits from bs.peekByte(4), 6 bits from bs.peekByte(3) 
-    pixelbuffer[13] = ((bs.peekByte(4) & 0x3) << 6) | (bs.peekByte(3) >> 2);   
+  // 2, 4 low bits remains in bs.peekByte(9)
+  pixelbuffer[6] = (bs.peekByte(9) >> 4) & 0x3;
+  // 8: 4 low bits from bs.peekByte(9), 4 upper bits from bs.peekByte(8)
+  pixelbuffer[7] = ((bs.peekByte(9) & 0xf) << 4) | (bs.peekByte(8) >> 4);
+  // 8: 4 low bits from bs.peekByte(8), 4 upper bits from bs.peekByte(7)
+  pixelbuffer[8] = ((bs.peekByte(8) & 0xf) << 4) | (bs.peekByte(7) >> 4);
+  // 8: 4 low bits from bs.peekByte(7), 4 upper bits from bs.peekByte(6)
+  pixelbuffer[9] = ((bs.peekByte(7) & 0xf) << 4) | (bs.peekByte(6) >> 4);
 
-    // 2: low bits from bs.peekByte(3)
-    pixelbuffer[14] = bs.peekByte(3) & 0x3;                           
-    pixelbuffer[15] = bs.peekByte(2);
-    pixelbuffer[16] = bs.peekByte(1);
-    pixelbuffer[17] = bs.peekByte(0);
-  }
+  // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)
+  pixelbuffer[10] = (bs.peekByte(6) >> 2) & 0x3;
+  // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)
+  pixelbuffer[11] = ((bs.peekByte(6) & 0x3) << 6) | (bs.peekByte(5) >> 2);
+  // 8: 2 bits from bs.peekByte(5), 6 bits from bs.peekByte(4)
+  pixelbuffer[12] = ((bs.peekByte(5) & 0x3) << 6) | (bs.peekByte(4) >> 2);
+  // 8: 2 bits from bs.peekByte(4), 6 bits from bs.peekByte(3)
+  pixelbuffer[13] = ((bs.peekByte(4) & 0x3) << 6) | (bs.peekByte(3) >> 2);
 
-  template <>
-  inline void __attribute__((always_inline))
-  pana_cs6_page_decoder<14>::fillBuffer(const ByteStream& bs) noexcept {
-    // The bit packing scheme here is actually just 128-bit little-endian int,
-    // that we consume from the high bits to low bits, with no padding.
-    // It is really tempting to refactor this using proper BitPump, but so far
-    // that results in disappointing performance.
+  // 2: low bits from bs.peekByte(3)
+  pixelbuffer[14] = bs.peekByte(3) & 0x3;
+  pixelbuffer[15] = bs.peekByte(2);
+  pixelbuffer[16] = bs.peekByte(1);
+  pixelbuffer[17] = bs.peekByte(0);
+}
 
-    // 14 bits
-    pixelbuffer[0] = (bs.peekByte(15) << 6) | (bs.peekByte(14) >> 2);
-    // 14 bits
-    pixelbuffer[1] = (((bs.peekByte(14) & 0x3) << 12) | (bs.peekByte(13) << 4) |
-                      (bs.peekByte(12) >> 4)) &
-                     0x3fff;
-    // 2 bits
-    pixelbuffer[2] = (bs.peekByte(12) >> 2) & 0x3;
-    // 10 bits
-    pixelbuffer[3] = ((bs.peekByte(12) & 0x3) << 8) | bs.peekByte(11);
-    // 10 bits
-    pixelbuffer[4] = (bs.peekByte(10) << 2) | (bs.peekByte(9) >> 6);
-    // 10 bits
-    pixelbuffer[5] = ((bs.peekByte(9) & 0x3f) << 4) | (bs.peekByte(8) >> 4);
-    // 2 bits
-    pixelbuffer[6] = (bs.peekByte(8) >> 2) & 0x3;
-    // 10 bits
-    pixelbuffer[7] = ((bs.peekByte(8) & 0x3) << 8) | bs.peekByte(7);
-    // 10 bits
-    pixelbuffer[8] = ((bs.peekByte(6) << 2) & 0x3fc) | (bs.peekByte(5) >> 6);
-    // 10 bits
-    pixelbuffer[9] = ((bs.peekByte(5) << 4) | (bs.peekByte(4) >> 4)) & 0x3ff;
-    // 2 bits
-    pixelbuffer[10] = (bs.peekByte(4) >> 2) & 0x3;
-    // 10 bits
-    pixelbuffer[11] = ((bs.peekByte(4) & 0x3) << 8) | bs.peekByte(3);
-    // 10 bits
-    pixelbuffer[12] =
-        (((bs.peekByte(2) << 2) & 0x3fc) | bs.peekByte(1) >> 6) & 0x3ff;
-    // 10 bits
-    pixelbuffer[13] = ((bs.peekByte(1) << 4) | (bs.peekByte(0) >> 4)) & 0x3ff;
-    // 4 padding bits
-  }
+template <>
+inline void __attribute__((always_inline))
+pana_cs6_page_decoder<14>::fillBuffer(const ByteStream& bs) noexcept {
+  // The bit packing scheme here is actually just 128-bit little-endian int,
+  // that we consume from the high bits to low bits, with no padding.
+  // It is really tempting to refactor this using proper BitPump, but so far
+  // that results in disappointing performance.
+
+  // 14 bits
+  pixelbuffer[0] = (bs.peekByte(15) << 6) | (bs.peekByte(14) >> 2);
+  // 14 bits
+  pixelbuffer[1] = (((bs.peekByte(14) & 0x3) << 12) | (bs.peekByte(13) << 4) |
+                    (bs.peekByte(12) >> 4)) &
+                   0x3fff;
+  // 2 bits
+  pixelbuffer[2] = (bs.peekByte(12) >> 2) & 0x3;
+  // 10 bits
+  pixelbuffer[3] = ((bs.peekByte(12) & 0x3) << 8) | bs.peekByte(11);
+  // 10 bits
+  pixelbuffer[4] = (bs.peekByte(10) << 2) | (bs.peekByte(9) >> 6);
+  // 10 bits
+  pixelbuffer[5] = ((bs.peekByte(9) & 0x3f) << 4) | (bs.peekByte(8) >> 4);
+  // 2 bits
+  pixelbuffer[6] = (bs.peekByte(8) >> 2) & 0x3;
+  // 10 bits
+  pixelbuffer[7] = ((bs.peekByte(8) & 0x3) << 8) | bs.peekByte(7);
+  // 10 bits
+  pixelbuffer[8] = ((bs.peekByte(6) << 2) & 0x3fc) | (bs.peekByte(5) >> 6);
+  // 10 bits
+  pixelbuffer[9] = ((bs.peekByte(5) << 4) | (bs.peekByte(4) >> 4)) & 0x3ff;
+  // 2 bits
+  pixelbuffer[10] = (bs.peekByte(4) >> 2) & 0x3;
+  // 10 bits
+  pixelbuffer[11] = ((bs.peekByte(4) & 0x3) << 8) | bs.peekByte(3);
+  // 10 bits
+  pixelbuffer[12] =
+      (((bs.peekByte(2) << 2) & 0x3fc) | bs.peekByte(1) >> 6) & 0x3ff;
+  // 10 bits
+  pixelbuffer[13] = ((bs.peekByte(1) << 4) | (bs.peekByte(0) >> 4)) & 0x3ff;
+  // 4 padding bits
+}
 
 } // namespace
 
 template <int B>
 PanasonicV6Decompressor<B>::PanasonicV6Decompressor(const RawImage& img,
-                                                 const ByteStream& input_)
+                                                    const ByteStream& input_)
     : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))
@@ -171,7 +167,7 @@ template <int B>
 inline void __attribute__((always_inline))
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
 PanasonicV6Decompressor<B>::decompressBlock(ByteStream& rowInput, int row,
-                                         int col) const noexcept {
+                                            int col) const noexcept {
   const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
 
   pana_cs6_page_decoder<B> page(
@@ -193,7 +189,8 @@ PanasonicV6Decompressor<B>::decompressBlock(ByteStream& rowInput, int row,
     uint16_t epixel = page.nextpixel();
     if (oddeven[pix % 2]) {
       epixel *= pmul;
-      if (pixel_base < PanasonicV6Decompressor::PixelbaseCompare && nonzero[pix % 2] > pixel_base)
+      if (pixel_base < PanasonicV6Decompressor::PixelbaseCompare &&
+          nonzero[pix % 2] > pixel_base)
         epixel += nonzero[pix % 2] - pixel_base;
       nonzero[pix % 2] = epixel;
     } else {
@@ -215,7 +212,6 @@ PanasonicV6Decompressor<B>::decompressBlock(ByteStream& rowInput, int row,
   }
 }
 
-
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
 template <int B>
 void PanasonicV6Decompressor<B>::decompressRow(int row) const noexcept {
@@ -230,8 +226,7 @@ void PanasonicV6Decompressor<B>::decompressRow(int row) const noexcept {
     decompressBlock(rowInput, row, col);
 }
 
-template <int B>
-void PanasonicV6Decompressor<B>::decompress() const {
+template <int B> void PanasonicV6Decompressor<B>::decompress() const {
 #ifdef HAVE_OPENMP
 #pragma omp parallel for num_threads(rawspeed_get_number_of_processor_cores()) \
     schedule(static) default(none)

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -26,6 +26,7 @@
 #include "common/Common.h"                // for rawspeed_get_number_of_pro...
 #include "common/RawImage.h"              // for RawImage, RawImageData
 #include "decoders/RawDecoderException.h" // for ThrowException, ThrowRDE
+#include "io/Buffer.h"
 #include <array>                          // for array
 #include <cassert>                        // for assert
 #include <cstdint>                        // for uint16_t
@@ -33,11 +34,71 @@
 namespace rawspeed {
 
 namespace {
+template <const int B>
 struct pana_cs6_page_decoder {
-  std::array<uint16_t, 14> pixelbuffer;
+  static_assert(B == 14 | B == 12, "only 12/14 bits are valid!");
+  static constexpr int BufferSize = B == 14 ? 14 : 18; 
+  std::array<uint16_t, BufferSize> pixelbuffer;
   unsigned char current = 0;
 
+  void fillBuffer(const ByteStream& bs) noexcept;
+
   explicit pana_cs6_page_decoder(const ByteStream& bs) {
+    fillBuffer(bs);
+  }
+
+  uint16_t nextpixel() {
+    uint16_t currPixel = pixelbuffer[current];
+    ++current;
+    return currPixel;
+  }
+};
+
+  template <>
+  inline void __attribute__((always_inline))
+  pana_cs6_page_decoder<12>::fillBuffer(const ByteStream& bs) noexcept {
+    // 12 bit: 8/0 + 4 upper bits of /1
+    pixelbuffer[0] = (bs.peekByte(15) << 4) | (bs.peekByte(14) >> 4);  
+    // 12 bit: 4l/1 + 8/2            
+    pixelbuffer[1] = (((bs.peekByte(14) & 0xf) << 8) | (bs.peekByte(13))) & 0xfff; 
+    
+    // 2; 2u/3, 6 low bits remains in bs.peekByte(12) 
+    pixelbuffer[2] = (bs.peekByte(12) >> 6) & 0x3;           
+    // 8; 6l/3 + 2u/4; 6 low bits remains in bs.peekByte(11)            
+    pixelbuffer[3] = ((bs.peekByte(12) & 0x3f) << 2) | (bs.peekByte(11) >> 6);   
+    // 8: 6l/4 + 2u/5; 6 low bits remains in bs.peekByte(10)  
+    pixelbuffer[4] = ((bs.peekByte(11) & 0x3f) << 2) | (bs.peekByte(10) >> 6);     
+    // 8: 6l/5 + 2u/6, 6 low bits remains in bs.peekByte(9)
+    pixelbuffer[5] = ((bs.peekByte(10) & 0x3f) << 2) | (bs.peekByte(9) >> 6);     
+
+    // 2, 4 low bits remains in bs.peekByte(9)
+    pixelbuffer[6] = (bs.peekByte(9) >> 4) & 0x3;               
+    // 8: 4 low bits from bs.peekByte(9), 4 upper bits from bs.peekByte(8)       
+    pixelbuffer[7] = ((bs.peekByte(9) & 0xf) << 4) | (bs.peekByte(8) >> 4);    
+    // 8: 4 low bits from bs.peekByte(8), 4 upper bits from bs.peekByte(7)  
+    pixelbuffer[8] = ((bs.peekByte(8) & 0xf) << 4) | (bs.peekByte(7) >> 4);  
+    // 8: 4 low bits from bs.peekByte(7), 4 upper bits from bs.peekByte(6)    
+    pixelbuffer[9] = ((bs.peekByte(7) & 0xf) << 4) | (bs.peekByte(6) >> 4);     
+
+    // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)
+    pixelbuffer[10] = (bs.peekByte(6) >> 2) & 0x3;     
+    // 2: bits 2-3 from bs.peekByte(6), two low bits remain in bs.peekByte(6)                
+    pixelbuffer[11] = ((bs.peekByte(6) & 0x3) << 6) | (bs.peekByte(5) >> 2);  
+    // 8: 2 bits from bs.peekByte(5), 6 bits from bs.peekByte(4)  
+    pixelbuffer[12] = ((bs.peekByte(5) & 0x3) << 6) | (bs.peekByte(4) >> 2);  
+    // 8: 2 bits from bs.peekByte(4), 6 bits from bs.peekByte(3) 
+    pixelbuffer[13] = ((bs.peekByte(4) & 0x3) << 6) | (bs.peekByte(3) >> 2);   
+
+    // 2: low bits from bs.peekByte(3)
+    pixelbuffer[14] = bs.peekByte(3) & 0x3;                           
+    pixelbuffer[15] = bs.peekByte(2);
+    pixelbuffer[16] = bs.peekByte(1);
+    pixelbuffer[17] = bs.peekByte(0);
+  }
+
+  template <>
+  inline void __attribute__((always_inline))
+  pana_cs6_page_decoder<14>::fillBuffer(const ByteStream& bs) noexcept {
     // The bit packing scheme here is actually just 128-bit little-endian int,
     // that we consume from the high bits to low bits, with no padding.
     // It is really tempting to refactor this using proper BitPump, but so far
@@ -77,15 +138,10 @@ struct pana_cs6_page_decoder {
     // 4 padding bits
   }
 
-  uint16_t nextpixel() {
-    uint16_t currPixel = pixelbuffer[current];
-    ++current;
-    return currPixel;
-  }
-};
 } // namespace
 
-PanasonicV6Decompressor::PanasonicV6Decompressor(const RawImage& img,
+template <int B>
+PanasonicV6Decompressor<B>::PanasonicV6Decompressor(const RawImage& img,
                                                  const ByteStream& input_)
     : mRaw(img) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
@@ -111,13 +167,14 @@ PanasonicV6Decompressor::PanasonicV6Decompressor(const RawImage& img,
   input = input_.peekStream(numBlocks, BytesPerBlock);
 }
 
+template <int B>
 inline void __attribute__((always_inline))
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
-PanasonicV6Decompressor::decompressBlock(ByteStream& rowInput, int row,
+PanasonicV6Decompressor<B>::decompressBlock(ByteStream& rowInput, int row,
                                          int col) const noexcept {
   const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
 
-  pana_cs6_page_decoder page(
+  pana_cs6_page_decoder<B> page(
       rowInput.getStream(PanasonicV6Decompressor::BytesPerBlock));
 
   std::array<unsigned, 2> oddeven = {0, 0};
@@ -130,13 +187,13 @@ PanasonicV6Decompressor::decompressBlock(ByteStream& rowInput, int row,
       uint16_t base = page.nextpixel();
       if (base == 3)
         base = 4;
-      pixel_base = 0x200 << base;
+      pixel_base = PanasonicV6Decompressor::PixelbaseZero << base;
       pmul = 1 << base;
     }
     uint16_t epixel = page.nextpixel();
     if (oddeven[pix % 2]) {
       epixel *= pmul;
-      if (pixel_base < 0x2000 && nonzero[pix % 2] > pixel_base)
+      if (pixel_base < PanasonicV6Decompressor::PixelbaseCompare && nonzero[pix % 2] > pixel_base)
         epixel += nonzero[pix % 2] - pixel_base;
       nonzero[pix % 2] = epixel;
     } else {
@@ -147,19 +204,21 @@ PanasonicV6Decompressor::decompressBlock(ByteStream& rowInput, int row,
         epixel = nonzero[pix % 2];
     }
     auto spix = static_cast<unsigned>(static_cast<int>(epixel) - 0xf);
-    if (spix <= 0xffff)
-      out(row, col) = spix & 0xffff;
+    if (spix <= PanasonicV6Decompressor::SpixCompare)
+      out(row, col) = spix & PanasonicV6Decompressor::SpixCompare;
     else {
       // FIXME: this is a convoluted way to compute zero.
       // What was this code trying to do, actually?
       epixel = static_cast<int>(epixel + 0x7ffffff1) >> 0x1f;
-      out(row, col) = epixel & 0x3fff;
+      out(row, col) = epixel & PanasonicV6Decompressor::PixelMask;
     }
   }
 }
 
+
 // NOLINTNEXTLINE(bugprone-exception-escape): no exceptions will be thrown.
-void PanasonicV6Decompressor::decompressRow(int row) const noexcept {
+template <int B>
+void PanasonicV6Decompressor<B>::decompressRow(int row) const noexcept {
   assert(mRaw->dim.x % PanasonicV6Decompressor::PixelsPerBlock == 0);
   const int blocksperrow =
       mRaw->dim.x / PanasonicV6Decompressor::PixelsPerBlock;
@@ -171,7 +230,8 @@ void PanasonicV6Decompressor::decompressRow(int row) const noexcept {
     decompressBlock(rowInput, row, col);
 }
 
-void PanasonicV6Decompressor::decompress() const {
+template <int B>
+void PanasonicV6Decompressor<B>::decompress() const {
 #ifdef HAVE_OPENMP
 #pragma omp parallel for num_threads(rawspeed_get_number_of_processor_cores()) \
     schedule(static) default(none)
@@ -182,5 +242,9 @@ void PanasonicV6Decompressor::decompress() const {
     decompressRow(row);
   }
 }
+
+// forward refs.
+template class PanasonicV6Decompressor<14>;
+template class PanasonicV6Decompressor<12>;
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.cpp
@@ -34,7 +34,7 @@ namespace rawspeed {
 
 namespace {
 template <const int B> struct pana_cs6_page_decoder {
-  static_assert(B == 14 | B == 12, "only 12/14 bits are valid!");
+  static_assert((B == 14 || B == 12), "only 12/14 bits are valid!");
   static constexpr int BufferSize = B == 14 ? 14 : 18;
   std::array<uint16_t, BufferSize> pixelbuffer;
   unsigned char current = 0;

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.h
@@ -26,12 +26,21 @@
 
 namespace rawspeed {
 
+template <int B>
 class PanasonicV6Decompressor final : public AbstractDecompressor {
   RawImage mRaw;
 
   ByteStream input;
 
-  static constexpr int PixelsPerBlock = 11;
+  static constexpr int BitsPerSample = B;
+  static_assert(BitsPerSample == 14 || BitsPerSample == 12, "invalid bits per sample; only use 12/14 bits.");
+  static constexpr bool is14Bit = BitsPerSample == 14;
+
+  static constexpr int PixelsPerBlock = is14Bit ? 11 : 14;
+  static constexpr unsigned int PixelbaseZero = is14Bit ? 0x200 : 0x80;
+  static constexpr unsigned int PixelbaseCompare = is14Bit ? 0x2000 : 0x800;
+  static constexpr unsigned int SpixCompare = is14Bit ? 0xffff : 0x3fff;
+  static constexpr unsigned int PixelMask = is14Bit ? 0x3fff : 0xfff;
   static constexpr int BytesPerBlock = 16;
 
   inline void __attribute__((always_inline))

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.h
@@ -57,4 +57,8 @@ public:
   void decompress() const;
 };
 
+// forward ref for tests
+extern template class PanasonicV6Decompressor<14>;
+extern template class PanasonicV6Decompressor<12>;
+
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.h
@@ -33,7 +33,7 @@ class PanasonicV6Decompressor final : public AbstractDecompressor {
   ByteStream input;
 
   static constexpr int BitsPerSample = B;
-  static_assert(BitsPerSample == 14 || BitsPerSample == 12,
+  static_assert((BitsPerSample == 14 || BitsPerSample == 12),
                 "invalid bits per sample; only use 12/14 bits.");
   static constexpr bool is14Bit = BitsPerSample == 14;
 

--- a/src/librawspeed/decompressors/PanasonicV6Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV6Decompressor.h
@@ -33,7 +33,8 @@ class PanasonicV6Decompressor final : public AbstractDecompressor {
   ByteStream input;
 
   static constexpr int BitsPerSample = B;
-  static_assert(BitsPerSample == 14 || BitsPerSample == 12, "invalid bits per sample; only use 12/14 bits.");
+  static_assert(BitsPerSample == 14 || BitsPerSample == 12,
+                "invalid bits per sample; only use 12/14 bits.");
   static constexpr bool is14Bit = BitsPerSample == 14;
 
   static constexpr int PixelsPerBlock = is14Bit ? 11 : 14;


### PR DESCRIPTION
This adds support for the GH5M2, darktable-org/darktable#9370, which uses v6 12 bit format. I manually verified a few images from the RPU. I don't own this camera. I only had one dng to check for the color matrix from when I was fixing a previous issue with black point. I'm not sure how to determine the crop section in camera.xml. I based them off the GH5.

Also just a FYI to @pgassmann since you asked about this in my other PR.