### PR TITLE
Assert on out of bounds access

### DIFF
--- a/src/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/src/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -117,6 +117,7 @@ HuffmanTable<> PentaxDecompressor::SetupHuffmanTable_Modern(ByteStream stream) {
         sm_val = v2[j];
       }
     }
+    assert(sm_num < 16);
     codeValues.push_back(sm_num);
     v2[sm_num] = 0xffffffff;
   }


### PR DESCRIPTION
From cppcheck 2.10:

[rawspeed/src/librawspeed/decompressors/PentaxDecompressor.cpp:121] (error,inconclusive) Out of bounds access in 'v2[sm_num]', if 'v2' size is 16 and 'sm_num' is 255 [containerOutOfBounds]
