### PR TITLE
Panasonic DC-S5M2 and DC-S5M2X support (data only)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -10955,8 +10955,29 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DC-S5M2X" supported="no">
+	<Camera make="Panasonic" model="DC-S5M2X">
 		<ID make="Panasonic" model="DC-S5M2X">Panasonic DC-S5M2X</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">10308 -4206 -783</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4088 12102 2229</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-125 1051 5912</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-S5M2X" mode="3:2">
+		<ID make="Panasonic" model="DC-S5M2X">Panasonic DC-S5M2X</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">10308 -4206 -783</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4088 12102 2229</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-125 1051 5912</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-S1R">
 		<ID make="Panasonic" model="DC-S1R">Panasonic DC-S1R</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -10931,8 +10931,29 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DC-S5M2" supported="no">
+	<Camera make="Panasonic" model="DC-S5M2">
 		<ID make="Panasonic" model="DC-S5M2">Panasonic DC-S5M2</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">10308 -4206 -783</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4088 12102 2229</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-125 1051 5912</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-S5M2" mode="3:2">
+		<ID make="Panasonic" model="DC-S5M2">Panasonic DC-S5M2</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">10308 -4206 -783</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4088 12102 2229</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-125 1051 5912</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-S5M2X" supported="no">
 		<ID make="Panasonic" model="DC-S5M2X">Panasonic DC-S5M2X</ID>


### PR DESCRIPTION
Partly addresses https://github.com/darktable-org/darktable/issues/13511 and https://github.com/darktable-org/darktable/issues/15446

Used ADC 15.2. Crop is unverified.

This depends on [v8 decoder](https://github.com/darktable-org/rawspeed/issues/367) working.