### PR TITLE
Add Phase One P45 and IQ180 - white levels ?

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -16502,6 +16502,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="Phase One A/S" model="P45">
+		<ID make="Phase One" model="P45">Phase One P45</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="44" y="26" width="-24" height="-32"/>
+		<Sensor black="0" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">5053 -24 -117</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-5685 14077 1703</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-2619 4491 5850</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="Phase One A/S" model="P65+">
 		<ID make="Phase One" model="P65+">Phase One P65+</ID>
 		<CFA width="2" height="2">
@@ -16535,6 +16553,24 @@
 				<ColorMatrixRow plane="0">8035 435 -962</ColorMatrixRow>
 				<ColorMatrixRow plane="1">-6001 13872 2320</ColorMatrixRow>
 				<ColorMatrixRow plane="2">-1159 3065 5434</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Phase One A/S" model="IQ180">
+		<ID make="Phase One" model="IQ180">Phase One IQ180</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="36" y="8" width="-16" height="-48"/>
+		<Sensor black="257" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">6294 686 -712</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-5435 13417 2211</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-1006 2435 5042</ColorMatrixRow>
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>


### PR DESCRIPTION
I analyzed IIQ L raw files of two Phase One digital backs, P45 and IQ180, which I also converted to DNG format to extract Exif.SubImage1.BlackLevel, Exif.SubImage1.WhiteLevel and Exif.Image.ColorMatrix2 (for D65 illuminant). For the crop margins I compared exports from Capture One (original raw) and darktable (DNG file) to the uncropped versions and chose the narrowest borders maintaining clean data.

Surprisingly I had to set the white level to 16383 for both P45 and IQ180 raw files to get correct image preview, histogram and highlight reconstruction, while the corresponding DNG converted versions use a white level of 65535, in line with RawDigger by LibRaw. For consistency I also divided the DNG derived black levels by 4. I don't know the reason for this 14/16-bit discrepancy and hope it does not adversely affect the quadrant correction in IiqDecoder::CorrectQuadrantMultipliersCombined, the spline curve of which extends from 0 to 65535.

For both digital backs I uploaded a full set of sample images (IIQ L, IIQ S, Sensor+ for IQ180) to raw.pixls.us.