### PR TITLE
CI: when running RPU integration tests, only use a single thread

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -333,6 +333,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
           TARGET: test_integration
+          OMP_NUM_THREADS: 1
         run: |
           set -xe
           "${SRC_DIR}/.ci/ci-script.sh"


### PR DESCRIPTION
*Maybe* helps with the run time?