### PR TITLE
[CI] Don't exclude benchmarking from the clang static analysis CI run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -181,8 +181,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
-          - { os: macos-11, family: XCode, version: 13.2.1, deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM12
+          - { os: macos-13, family: XCode, version: 14.3,   deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15, native
+          - { os: macos-11, family: XCode, version: 13.2.1, deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM12, native
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -198,8 +198,9 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM14, "backdeploy"
-          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 12.0, CC: cc, CXX: c++ } # LLVM13
+          - { os: macos-13, family: XCode, version: 14.3,   deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM15, "backdeploy"
+          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
+          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 12.0, CC: cc, CXX: c++ } # LLVM13, native
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -215,7 +216,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - compiler: { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14
+          - compiler: { os: macos-13, family: XCode, version: 14.3, deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15
             flavor: Coverage
     uses: ./.github/workflows/CI-macOS.yml
     with:


### PR DESCRIPTION
This used to fail with https://github.com/google/benchmark/issues/1513 Maybe it's gone now?