### PR TITLE
Document and refresh compiler versions.cmake

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,12 +40,9 @@ jobs:
       matrix:
         os: [ linux ]
         compiler:
-          - { distro: "debian:unstable-slim", family: GNU,  version: 11, CC: gcc-11,   CXX: g++-11 }
-          - { distro: "debian:bullseye-slim", family: GNU,  version: 10, CC: gcc-10,   CXX: g++-10 }
           - { distro: "debian:unstable-slim", family: LLVM, version: 14, CC: clang-14, CXX: clang++-14 }
           - { distro: "debian:unstable-slim", family: LLVM, version: 13, CC: clang-13, CXX: clang++-13 }
           - { distro: "ubuntu:jammy",         family: LLVM, version: 12, CC: clang-12, CXX: clang++-12 }
-          - { distro: "debian:bullseye-slim", family: LLVM, version: 11, CC: clang-11, CXX: clang++-11 }
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-linux.yml
     with:
@@ -184,7 +181,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-12, family: XCode, version: 14.1, deployment_target: 14.1, CC: cc, CXX: c++ } # LLVM14
+          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14
+          - { os: macos-11, family: XCode, version: 13.2.1, deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM12
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -200,11 +198,9 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-12, family: XCode, version: 14.1,   deployment_target: 10.7,   CC: cc, CXX: c++ } # LLVM14
-          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 13.4.1, CC: cc, CXX: c++ } # LLVM13
-          - { os: macos-12, family: XCode, version: 13.2.1, deployment_target: 13.2.1, CC: cc, CXX: c++ } # LLVM12
-          - { os: macos-11, family: XCode, version: 12.5.1, deployment_target: 12.5.1, CC: cc, CXX: c++ } # LLVM11
-          - { os: macos-11, family: XCode, version: 12.4,   deployment_target: 12.4,   CC: cc, CXX: c++ } # LLVM10
+          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM14
+          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 12.0, CC: cc, CXX: c++ } # LLVM13
+          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM13
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -220,7 +216,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - compiler: { os: macos-12, family: XCode, version: 14.1, deployment_target: 14.1, CC: cc, CXX: c++ } # LLVM14
+          - compiler: { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14
             flavor: Coverage
     uses: ./.github/workflows/CI-macOS.yml
     with:

--- a/cmake/compiler-versions.cmake
+++ b/cmake/compiler-versions.cmake
@@ -1,25 +1,61 @@
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 10)
-  message(WARNING "GNU C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 10+ is required.")
+# We strive to keep the [darktable] software releases (but not necessarily
+# development versions!) buildable with the versions of the dependencies
+# provided out-of-the-box in the following distributions:
+# * debian stable
+# * latest(!) ubuntu LTS
+# * oldest(*) maintained macOS release (assuming current cadence of
+#   one major macOS release per year, and 3 (three) year shelf-life,
+#   so last three releases are to be supported)
+#
+# Compiler-wise, that means that we support three compiler families:
+# * GCC, with the required version being the newest one that is available
+#   in *both* the debian stable *and* the latest ubuntu LTS
+# * Xcode, with the required version being the newest one that is available
+#   for the oldest supported macOS release
+# * LLVM, with the required version being the oldest one between
+#    * the Xcode's underlying LLVM version
+#    * and the newest one that is available in *both* the
+#      debian stable *and* the latest ubuntu LTS
+#
+# As of the time of writing (2023-03-14), the next (spring) darktable release
+# will happen in 2023-06 ish. By that time:
+# * debian 12 (Bookworm) will have been released,
+#   coming with gcc-12 and LLVM15
+# * Ubuntu 22.04.1 LTS (Jammy Jellyfish) will be the newest LTS,
+#   coming with gcc-12 and LLVM15
+# * macOS 11 (Big Sur) be the oldest supported macOS version,
+#   with the newest supported Xcode version being 13.2 (LLVM12-based !)
+#
+# Therefore, we require GCC12, macOS 11 + Xcode 13.2, and LLVM12.
+#
+# The next+1 (fall) darktable release will happen 2023-12 ish,
+# and by that time, macOS 11 will have EOL'd on 2023-10 ish,
+# so after the spring release, macOS 12 will become required,
+# and that will allow us to require Xcode 14.2 (LLVM14-based),
+# and that will allow us to require LLVM14,
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+  message(WARNING "GNU C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
-  message(WARNING "GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 10+ is required.")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+  message(WARNING "GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
 
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 10)
-  message(WARNING "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 10+ is required.")
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+  message(WARNING "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
-  message(WARNING "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 10+ is required.")
-endif()
-
-# XCode 12.0 (apple clang 12.0.0) is based on LLVM10
-if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12.0.0)
-  message(WARNING "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. XCode version 12.0+ is required.")
-endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0.0)
-  message(WARNING "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. XCode version 12.0+ is required.")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+  message(WARNING "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
 
-if(CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.14)
-  message(WARNING "Targeting OSX version ${CMAKE_OSX_DEPLOYMENT_TARGET} older than 10.14 is unsupported.")
+# XCode 13.2 (apple clang 13.2.0) is based on LLVM12
+if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 13.2.0)
+  message(WARNING "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. XCode version 13.2+ is required.")
+endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.2.0)
+  message(WARNING "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. XCode version 13.2+ is required.")
+endif()
+
+if(CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 11.3)
+  message(WARNING "Targeting OSX version ${CMAKE_OSX_DEPLOYMENT_TARGET} older than 11.3 is unsupported.")
 endif()


### PR DESCRIPTION
As per disscussion in https://github.com/darktable-org/darktable/issues/13509.

We strive to keep the [darktable] software releases (but not necessarily
development versions!) buildable with the versions of the dependencies
provided out-of-the-box in the following distributions:
* debian stable
* latest(!) ubuntu LTS
* oldest(*) maintained macOS release (assuming current cadence of
  one major macOS release per year, and 3 (three) year shelf-life,
  so last three releases are to be supported)

Compiler-wise, that means that we support three compiler families:
* GCC, with the required version being the newest one that is available
  in *both* the debian stable *and* the latest ubuntu LTS
* Xcode, with the required version being the newest one that is available
  for the oldest supported macOS release
* LLVM, with the required version being the oldest one between
   * the Xcode's underlying LLVM version
   * and the newest one that is available in *both* the
     debian stable *and* the latest ubuntu LTS

As of the time of writing (2023-03-14), the next (spring) darktable release
will happen in 2023-06 ish. By that time:
* debian 12 (Bookworm) will have been released,
  coming with gcc-12 and LLVM15
* Ubuntu 22.04.1 LTS (Jammy Jellyfish) will be the newest LTS,
  coming with gcc-12 and LLVM15
* macOS 11 (Big Sur) be the oldest supported macOS version,
  with the newest supported Xcode version being 13.2 (LLVM12-based !)

Therefore, we require GCC12, macOS 11 + Xcode 13.2, and LLVM12.

The next+1 (fall) darktable release will happen 2023-12 ish,
and by that time, macOS 11 will have EOL'd on 2023-10 ish,
so after the spring release, macOS 12 will become required,
and that will allow us to require Xcode 14.2 (LLVM14-based),
and that will allow us to require LLVM14,
