### PR TITLE
Add chroma and luma calibration for Phase One

### DIFF
--- a/src/librawspeed/decoders/IiqDecoder.h
+++ b/src/librawspeed/decoders/IiqDecoder.h
@@ -67,6 +67,8 @@ private:
                         uint32_t split_col);
   void CorrectQuadrantMultipliersCombined(ByteStream data, uint32_t split_row,
                                           uint32_t split_col) const;
+  enum class IiqCorr;
+  void PhaseOneFlatField(ByteStream data, IiqCorr corr) const;
   void correctSensorDefects(ByteStream data) const;
   void correctBadColumn(uint16_t col) const;
   void handleBadPixel(uint16_t col, uint16_t row) const;


### PR DESCRIPTION
With some of my IQ180 images I saw clear quarter paneling artefacts in darktable, which did not show up after Adobe DNG conversion, but also not using RawTherapee and of course C1. After comparing the correction meta data present in the various Phase One raw samples with the applied corrections in darktable, dcraw and LibRaw, I decided to adapt phase_one_flat_field() for rawspeed, following the LibRaw source. The corresponding tags are 0x40b for chroma calibration and 0x410 for luma calibration, both present in all supported backs. 

The result makes me happy, see the before/after images of my specially designed step gradient test print. I can upload the raw file if that is helpful. The code changes were tested using darktable release-4.2.1 (rawspeed @ 5f991a0).

The red highlights have nothing to do with darktable, they also appear in C1. The image is correctly ETTR exposed but apparently the CCD sensor has a non-linearity in the highlights at ISO speeds below 200 - here the green raw channels are highest, but not clipping, so the highlights turn magenta.

_Before_
![230307_9577_rel](https://user-images.githubusercontent.com/101976611/225898481-4e208bf0-2af0-476c-9edd-e6f1be677fe7.jpg)

_After_
![230307_9577_dev](https://user-images.githubusercontent.com/101976611/225898594-e377cc51-f4e0-4c81-873a-d14c3d2b21bd.jpg)
