### PR TITLE
Remove SonarCloud cache and threads configuration as it is now by default

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -410,4 +410,4 @@ jobs:
         run: |
           set -xe
           cd "${SRC_DIR}"
-          sonar-scanner --define project.settings="${SRC_DIR}/.ci/sonar-project.properties" --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.projectKey="${{ secrets.SONAR_PROJECT_KEY }}" --define sonar.organization="${{ secrets.SONAR_ORGANIZATION }}" --define sonar.cfamily.compile-commands="${BUILD_DIR}/compile_commands.json" --define sonar.cfamily.threads="$(nproc --all)" --define sonar.cfamily.cache.enabled=false
+          sonar-scanner --define project.settings="${SRC_DIR}/.ci/sonar-project.properties" --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.projectKey="${{ secrets.SONAR_PROJECT_KEY }}" --define sonar.organization="${{ secrets.SONAR_ORGANIZATION }}" --define sonar.cfamily.compile-commands="${BUILD_DIR}/compile_commands.json"


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has automatic analysis caching and threads configuration. See: https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache