### PR TITLE
Improve crop for Sony ILCE-7M4 and ILCE-7SM3

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13636,7 +13636,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-10" height="0"/>
+		<Crop x="0" y="0" width="-8" height="0"/>
 		<Sensor black="512" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -13804,7 +13804,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-28" height="0"/>
+		<Crop x="0" y="0" width="-24" height="0"/>
 		<Sensor black="512" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
This aligns the crops to the "active area" tag found in the corresponding lossless mode as mentioned in  https://github.com/darktable-org/rawspeed/pull/386#discussion_r1153110150

This should make future implementation of the lossless mode support more seamless.

ILCE-1 and ILCE-7RM5 are already well aligned.