### PR TITLE
Align Phase One sensor levels

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -16565,7 +16565,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="42" y="8" width="-20" height="-54"/>
-		<Sensor black="0" white="65535"/>
+		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">8035 435 -962</ColorMatrixRow>
@@ -16583,7 +16583,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="42" y="16" width="-20" height="-50"/>
-		<Sensor black="257" white="16383"/>
+		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6294 686 -712</ColorMatrixRow>
@@ -16601,7 +16601,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="92" y="108" width="0" height="0"/>
-		<Sensor black="1024" white="65535"/>
+		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">3984 0 0</ColorMatrixRow>

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -212,6 +212,7 @@ RawImage IiqDecoder::decodeRawInternal() {
       block_offsets = bs.getSubStream(data, len);
       break;
     case 0x21d:
+      // 16-bit black level adapted to 14-bit raw data (IIQFormat::IIQ_L)
       black_level = data >> 2;
       break;
     case 0x222:


### PR DESCRIPTION
1. Set all sensor levels for Phase One backs in cameras.xml to 0 for black and 16383 for white. This affects the entries for IQ140, IQ180 and IQ250.<br/>
The **black level** for all supported Phase One backs is read from metadata. The value in cameras.xml is ignored, therefore it should be set to zero.<br/>
All currently supported Phase One backs use the 14-bit IIQ_L format. A real 16-bit raw data option (IIQ_L16) is only provided by unsupported IQ3 and IQ4 backs. Based on the unshifted 14-bit raw data the **white level** should be 16383. For verification I used the samples from RPU (for IQ140) and other sources (for IQ250).<br/>

2. Add an explanatory comment to IiqDecoder::decodeRawInternal() at the line where the black level is read from metadata. The level read is related to 16-bit data, and because rawspeed provides unshifted 14-bit raw data the level is shifted accordingly. Once IIQ_L16 is supported this shift has to be made conditional.