### PR TITLE
rawspeed: Sony ILME-FX30 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14132,6 +14132,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="SONY" model="ILME-FX30">
+		<ID make="Sony" model="ILME-FX30">Sony ILME-FX30</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="512" white="16380"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">6972 -2408 -600</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4330 12101 2515</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-388 1277 5847</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng" supported="no-samples">
 		<ID make="Sinar" model="Hy6">Sinar Hy6</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14140,7 +14140,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="512" white="16380"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Add Sony ILME-FX30 Camera support. 
Resolving https://github.com/darktable-org/darktable/issues/14147