### PR TITLE
VC5: make use of our Prefix code decoders infra! (up to -15%)

### DIFF
--- a/src/librawspeed/decompressors/AbstractPrefixCode.h
+++ b/src/librawspeed/decompressors/AbstractPrefixCode.h
@@ -66,9 +66,9 @@ template <> struct CodeTraits<VC5CodeTag> final {
   static constexpr int MaxCodeLenghtBits = 26;
   static constexpr int MaxNumCodeValues = 264;
 
-  using CodeValueTy = uint16_t;
-  static constexpr int MaxCodeValueLenghtBits = 9;
-  static constexpr CodeValueTy MaxCodeValue = MaxNumCodeValues;
+  using CodeValueTy = uint32_t;
+  static constexpr int MaxCodeValueLenghtBits = 19;
+  static constexpr CodeValueTy MaxCodeValue = 524287;
 
   static constexpr int MaxDiffLengthBits = -1;     // unused
   static constexpr CodeValueTy MaxDiffLength = -1; // unused
@@ -99,18 +99,18 @@ template <typename CodeTag> struct CodeTraitsValidator final {
   static_assert(std::is_integral<typename Traits::CodeValueTy>::value);
   static_assert(std::is_unsigned<typename Traits::CodeValueTy>::value);
   static_assert(std::is_same<typename Traits::CodeValueTy, uint8_t>::value ||
-                std::is_same<typename Traits::CodeValueTy, uint16_t>::value);
+                std::is_same<typename Traits::CodeValueTy, uint32_t>::value);
 
   static_assert(Traits::MaxCodeValueLenghtBits > 0 &&
                 Traits::MaxCodeValueLenghtBits <=
                     bitwidth<typename Traits::CodeValueTy>());
   static_assert(Traits::MaxCodeValueLenghtBits == 8 ||
-                Traits::MaxCodeValueLenghtBits == 9);
+                Traits::MaxCodeValueLenghtBits == 19);
 
   static_assert(Traits::MaxCodeValue > 0 &&
                 Traits::MaxCodeValue <=
                     ((1ULL << Traits::MaxCodeValueLenghtBits) - 1ULL));
-  static_assert(Traits::MaxCodeValue == 255 || Traits::MaxCodeValue == 264);
+  static_assert(Traits::MaxCodeValue == 255 || Traits::MaxCodeValue == 524287);
 
   static_assert(
       std::is_same<decltype(Traits::SupportsFullDecode), const bool>::value);

--- a/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
+++ b/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
@@ -87,7 +87,7 @@ private:
   // The len field contains the number of bits, this lookup consumed.
   // A lookup value of 0 means the code was too big to fit into the table.
   // The optimal LookupDepth is also likely to depend on the CPU architecture.
-  static constexpr unsigned PayloadShift = 16;
+  static constexpr unsigned PayloadShift = 9;
   static constexpr unsigned FlagMask = 0x100;
   static constexpr unsigned LenMask = 0xff;
   static constexpr unsigned LookupDepth = 11;

--- a/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
+++ b/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
@@ -120,7 +120,7 @@ public:
       uint16_t ul = ll | ((1 << (LookupDepth - code_l)) - 1);
       static_assert(Traits::MaxCodeValueLenghtBits <=
                     bitwidth<LUTEntryTy>() - PayloadShift);
-      uint16_t diff_l = Base::code.codeValues[i];
+      LUTUnsignedEntryTy diff_l = Base::code.codeValues[i];
       for (uint16_t c = ll; c <= ul; c++) {
         if (!(c < decodeLookup.size()))
           ThrowRDE("Corrupt Huffman");

--- a/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
+++ b/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
@@ -91,7 +91,9 @@ private:
   static constexpr unsigned FlagMask = 0x100;
   static constexpr unsigned LenMask = 0xff;
   static constexpr unsigned LookupDepth = 11;
-  std::vector<int32_t> decodeLookup;
+  using LUTEntryTy = int32_t;
+  using LUTUnsignedEntryTy = std::make_unsigned_t<LUTEntryTy>;
+  std::vector<LUTEntryTy> decodeLookup;
 #else
   // lookup table containing 2 fields: payload:4|len:4
   // the payload is the length of the diff, len is the length of the code
@@ -139,15 +141,15 @@ public:
             decodeLookup[c] += diff_l;
 
           if (diff_l) {
-            uint32_t diff;
+            LUTUnsignedEntryTy diff;
             if (diff_l != 16) {
               diff = extractHighBits(c, code_l + diff_l,
                                      /*effectiveBitwidth=*/LookupDepth);
               diff &= ((1 << diff_l) - 1);
             } else
-              diff = uint32_t(-32768);
-            decodeLookup[c] |= static_cast<int32_t>(
-                static_cast<uint32_t>(Base::extend(diff, diff_l))
+              diff = LUTUnsignedEntryTy(-32768);
+            decodeLookup[c] |= static_cast<LUTEntryTy>(
+                static_cast<LUTUnsignedEntryTy>(Base::extend(diff, diff_l))
                 << PayloadShift);
           }
         }

--- a/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
+++ b/src/librawspeed/decompressors/PrefixCodeLUTDecoder.h
@@ -118,7 +118,8 @@ public:
 
       uint16_t ll = Base::code.symbols[i].code << (LookupDepth - code_l);
       uint16_t ul = ll | ((1 << (LookupDepth - code_l)) - 1);
-      static_assert(Traits::MaxCodeValueLenghtBits <= 16);
+      static_assert(Traits::MaxCodeValueLenghtBits <=
+                    bitwidth<LUTEntryTy>() - PayloadShift);
       uint16_t diff_l = Base::code.codeValues[i];
       for (uint16_t c = ll; c <= ul; c++) {
         if (!(c < decodeLookup.size()))


### PR DESCRIPTION
HURRAY! This took embarrassingly long time.

We manage to encode RLV entry into a 19-bit code value,
with decompanded RLV value occupying 10 bits,
and RLV run length taking 9 more (max being '320'),
which is less than max 23 bits than we can squeeze into the LUT.

I've looked at histograms for the actual RLV code distributions
in the RPU VC5 samples, and the common sense *seems* to exist,
in so that a low-code-len codes are, by far, most common,
so much like with LJpeg, LUT-based decoder appears worthwhile.

Performance-wise, VC5 decompressor is so fast, it's hard to tell.

For a single-thread case, there's a statistically-significant improvement:
```
raw.pixls.us-unique/GoPro/HERO6 Black$ OMP_NUM_THREADS=1 nice -n -19 /usr/src/googlebenchmark/tools/compare.py -a benchmarks ~/rawspeed/build-{old,new}/src/utilities/rsbench/rsbench --benchmark_counters_tabular=true --benchmark_min_time=0.5 --benchmark_min_warmup_time=1 --benchmark_repetitions=27 GOPR9172.GPR
RUNNING: /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench --benchmark_counters_tabular=true --benchmark_min_time=0.5 --benchmark_min_warmup_time=1 --benchmark_repetitions=27 GOPR9172.GPR --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpac2a6c43
2023-04-15T04:23:30+03:00
Running /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench
Run on (32 X 3925 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 2.17, 4.42, 3.14
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations  CPUTime,s CPUTime/WallTime     Pixels Pixels/CPUTime Pixels/WallTime Raws/CPUTime Raws/WallTime WallTime,s
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
GOPR9172.GPR/threads:1/process_time/real_time_mean         90.5 ms         90.4 ms           27  0.0904474         0.999951        12M       132.674M        132.667M      11.0562       11.0556  0.0904519
GOPR9172.GPR/threads:1/process_time/real_time_median       90.4 ms         90.4 ms           27  0.0904424          0.99995        12M       132.681M        132.676M      11.0568       11.0563  0.0904461
GOPR9172.GPR/threads:1/process_time/real_time_stddev      0.073 ms        0.073 ms           27   73.1364u         13.7739u          0       107.249k        106.848k     8.93742m      8.90399m   72.8702u
GOPR9172.GPR/threads:1/process_time/real_time_cv           0.08 %          0.08 %            27      0.08%            0.00%      0.00%          0.08%           0.08%        0.08%         0.08%      0.08%
RUNNING: /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench --benchmark_counters_tabular=true --benchmark_min_time=0.5 --benchmark_min_warmup_time=1 --benchmark_repetitions=27 GOPR9172.GPR --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpwgzw83rc
2023-04-15T04:23:52+03:00
Running /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench
Run on (32 X 3925 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 1.83, 4.19, 3.09
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations  CPUTime,s CPUTime/WallTime     Pixels Pixels/CPUTime Pixels/WallTime Raws/CPUTime Raws/WallTime WallTime,s
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
GOPR9172.GPR/threads:1/process_time/real_time_mean         77.4 ms         77.4 ms           27  0.0774076         0.999951        12M       155.024M        155.016M      12.9186        12.918  0.0774114
GOPR9172.GPR/threads:1/process_time/real_time_median       77.4 ms         77.4 ms           27  0.0773824         0.999954        12M       155.074M        155.068M      12.9228       12.9224  0.0773852
GOPR9172.GPR/threads:1/process_time/real_time_stddev      0.102 ms        0.102 ms           27   101.909u         22.5005u          0       203.964k        203.847k     0.016997     0.0169872   101.861u
GOPR9172.GPR/threads:1/process_time/real_time_cv           0.13 %          0.13 %            27      0.13%            0.00%      0.00%          0.13%           0.13%        0.13%         0.13%      0.13%
Comparing /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench to /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench
Benchmark                                                              Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------
GOPR9172.GPR/threads:1/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 27 vs 27
GOPR9172.GPR/threads:1/process_time/real_time_mean                  -0.1442         -0.1442            90            77            90            77
GOPR9172.GPR/threads:1/process_time/real_time_median                -0.1444         -0.1444            90            77            90            77
GOPR9172.GPR/threads:1/process_time/real_time_stddev                +0.3974         +0.3933             0             0             0             0
GOPR9172.GPR/threads:1/process_time/real_time_cv                    +0.6329         +0.6280             0             0             0             0
OVERALL_GEOMEAN                                                     -0.1442         -0.1442             0             0             0             0
```

... but for multi-thread case, the latency of decoding high-pass bands
is mostly hidden away and is normally not a limiting factor,
so it's harder to measure, but it does appear to help
by -2%..-5% of runtime improvement.
