### PR TITLE
Fix Hasselblad X1D II 50C aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17138,8 +17138,8 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Hasselblad" model="Hasselblad X1DM2-50c">
-		<ID make="Hasselblad" model="X1DM2-50c">Hasselblad 50-15-Coated5</ID>
+	<Camera make="Hasselblad" model="X1D II 50C">
+		<ID make="Hasselblad" model="X1D II 50C">Hasselblad 50-15-Coated5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -17150,6 +17150,7 @@
 		<Sensor black="256" white="62914"/>
 		<Aliases>
 			<Alias id="X1D II 50C">Hasselblad X1D II 50C</Alias>
+			<Alias id="X1DM2-50c">Hasselblad X1DM2-50c</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Edit: Using OOC 3FR metadata as canonical. The "Hasselblad X1DM2-50c" and "Hasselblad X1D II 50C" models seem to have come from FFF files (i.e. downloaded or processed by Hasselblad Phocus, or other SW).

Depends on https://github.com/darktable-org/rawspeed/pull/466 for OOC 3FR uncompressed support.