### PR TITLE
Hasselblad X1D support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17138,6 +17138,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="Hasselblad" model="Hasselblad X1D">
+		<ID make="Hasselblad" model="X1D">Hasselblad 50-15-Coated5</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="46" y="96" width="-60" height="0"/>
+		<Sensor black="1028" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">5002 -878 111</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4856 11929 3338</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-1183 2041 7022</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="Hasselblad" model="Hasselblad X1DM2-50c">
 		<ID make="Hasselblad" model="X1DM2-50c">Hasselblad 50-15-Coated5</ID>
 		<CFA width="2" height="2">
@@ -17146,7 +17164,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="48" y="104" width="-60" height="0"/>
+		<Crop x="46" y="96" width="-60" height="0"/>
 		<Sensor black="256" white="62914"/>
 		<Aliases>
 			<Alias id="X1D II 50C">Hasselblad X1D II 50C</Alias>


### PR DESCRIPTION
Color matrix is verified to be the same as Mk II via ADC 15.3 - as expected, as sensor is supposedly the same.

Black and white levels are from ADC, but doesn't really matter what they are as they're read from raw file metadata anyway.

The crop has been revisited and updated for Mk II as well.

Depends on https://github.com/darktable-org/rawspeed/pull/466 for OOC 3FR uncompressed support.