### PR TITLE
Add Hasselblad uncompressed 3FR support

### DIFF
--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -20,20 +20,21 @@
 */
 
 #include "decoders/ThreefrDecoder.h"
-#include "adt/Point.h"                            // for iPoint2D
-#include "decoders/RawDecoderException.h"         // for ThrowException
-#include "decompressors/HasselbladLJpegDecoder.h" // for HasselbladLJpegDec...
-#include "io/Buffer.h"                            // for Buffer, DataBuffer
-#include "io/ByteStream.h"                        // for ByteStream
-#include "io/Endianness.h"                        // for Endianness, Endian...
-#include "metadata/ColorFilterArray.h"            // for CFAColor, CFAColor...
-#include "tiff/TiffEntry.h"                       // for TiffEntry
-#include "tiff/TiffIFD.h"                         // for TiffRootIFD, TiffIFD
-#include "tiff/TiffTag.h"                         // for TiffTag, TiffTag::...
-#include <array>                                  // for array
-#include <cstdint>                                // for uint32_t
-#include <memory>                                 // for unique_ptr, allocator
-#include <string>                                 // for operator==, string
+#include "adt/Point.h"                              // for iPoint2D
+#include "decoders/RawDecoderException.h"           // for ThrowException
+#include "decompressors/HasselbladLJpegDecoder.h"   // for HasselbladLJpegDec...
+#include "decompressors/UncompressedDecompressor.h" // for UncompressedDeco...
+#include "io/Buffer.h"                              // for Buffer, DataBuffer
+#include "io/ByteStream.h"                          // for ByteStream
+#include "io/Endianness.h"                          // for Endianness, Endian...
+#include "metadata/ColorFilterArray.h"              // for CFAColor, CFAColor...
+#include "tiff/TiffEntry.h"                         // for TiffEntry
+#include "tiff/TiffIFD.h"                           // for TiffRootIFD, TiffIFD
+#include "tiff/TiffTag.h"                           // for TiffTag, TiffTag::...
+#include <array>                                    // for array
+#include <cstdint>                                  // for uint32_t
+#include <memory>                                   // for unique_ptr, allocator
+#include <string>                                   // for operator==, string
 
 namespace rawspeed {
 
@@ -53,12 +54,20 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   const auto* raw = mRootIFD->getIFDWithTag(TiffTag::STRIPOFFSETS, 1);
   uint32_t width = raw->getEntry(TiffTag::IMAGEWIDTH)->getU32();
   uint32_t height = raw->getEntry(TiffTag::IMAGELENGTH)->getU32();
-  uint32_t off = raw->getEntry(TiffTag::STRIPOFFSETS)->getU32();
-  // STRIPBYTECOUNTS is strange/invalid for the existing 3FR samples...
-
-  const ByteStream bs(DataBuffer(mFile.getSubView(off), Endianness::little));
+  uint32_t compression = raw->getEntry(TiffTag::COMPRESSION)->getU32();
 
   mRaw->dim = iPoint2D(width, height);
+
+  if (1 == compression) {
+    DecodeUncompressed(raw);
+    return mRaw;
+  }
+
+  uint32_t off = raw->getEntry(TiffTag::STRIPOFFSETS)->getU32();
+  // STRIPBYTECOUNTS is strange/invalid for the existing (compressed?) 3FR
+  // samples...
+
+  const ByteStream bs(DataBuffer(mFile.getSubView(off), Endianness::little));
 
   HasselbladLJpegDecoder l(bs, mRaw);
   mRaw->createData();
@@ -66,6 +75,33 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   l.decode();
 
   return mRaw;
+}
+
+void ThreefrDecoder::DecodeUncompressed(const TiffIFD* raw) const {
+  if (mRaw->getDataType() != RawImageType::UINT16)
+    ThrowRDE("Unexpected data type");
+
+  if (mRaw->getCpp() != 1 || mRaw->getBpp() != sizeof(uint16_t))
+    ThrowRDE("Unexpected cpp: %u", mRaw->getCpp());
+
+  // FIXME: could be wrong. max "active pixels" - "100 MP"
+  if (mRaw->dim.x == 0 || mRaw->dim.y == 0 || mRaw->dim.x % 2 != 0 ||
+      mRaw->dim.x > 12000 || mRaw->dim.y > 8842) {
+    ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
+             mRaw->dim.y);
+  }
+
+  uint32_t off = raw->getEntry(TiffTag::STRIPOFFSETS)->getU32();
+  // STRIPBYTECOUNTS looks valid for the existing uncompressed 3FR samples
+  uint32_t count = raw->getEntry(TiffTag::STRIPBYTECOUNTS)->getU32();
+
+  const ByteStream bs(
+      DataBuffer(mFile.getSubView(off, count), Endianness::little));
+
+  UncompressedDecompressor u(bs, mRaw, iRectangle2D({0, 0}, mRaw->dim),
+                             2 * mRaw->dim.x, 16, BitOrder::LSB);
+  mRaw->createData();
+  u.readUncompressedRaw();
 }
 
 void ThreefrDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {

--- a/src/librawspeed/decoders/ThreefrDecoder.h
+++ b/src/librawspeed/decoders/ThreefrDecoder.h
@@ -43,6 +43,7 @@ public:
 
 private:
   [[nodiscard]] int getDecoderVersion() const override { return 0; }
+  void DecodeUncompressed(const TiffIFD* raw) const;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -44,7 +44,7 @@ HasselbladDecompressor::HasselbladDecompressor(const RawImage& mRaw_,
 
   // FIXME: could be wrong. max "active pixels" - "100 MP"
   if (mRaw->dim.x == 0 || mRaw->dim.y == 0 || mRaw->dim.x % 2 != 0 ||
-      mRaw->dim.x > 12000 || mRaw->dim.y > 8816) {
+      mRaw->dim.x > 12000 || mRaw->dim.y > 8842) {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
              mRaw->dim.y);
   }

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
@@ -39,7 +39,7 @@ HasselbladLJpegDecoder::HasselbladLJpegDecoder(ByteStream bs,
 
   // FIXME: could be wrong. max "active pixels" - "100 MP"
   if (mRaw->dim.x == 0 || mRaw->dim.y == 0 || mRaw->dim.x % 2 != 0 ||
-      mRaw->dim.x > 12000 || mRaw->dim.y > 8816) {
+      mRaw->dim.x > 12000 || mRaw->dim.y > 8842) {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
              mRaw->dim.y);
   }


### PR DESCRIPTION
As found in X1D, X1D II 50C and X2D 100C (all available on RPU).

Split from https://github.com/darktable-org/rawspeed/pull/463

Also bumps size checks to 12000 x 8842 to support both H6D-100 and X2D 100C sensors.