### PR TITLE
canon EOS M6 White Level for stopped down lens

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1685,10 +1685,10 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2048" white="16000"/>
-		<Sensor black="512" white="16000" iso_list="100 125 200 250"/>
-		<Sensor black="512" white="13200" iso_list="160"/>
-		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000"/>
+		<Sensor black="2048" white="15600"/>
+		<Sensor black="512" white="15600" iso_list="100 125 200 250"/>
+		<Sensor black="512" white="12600" iso_list="160"/>
+		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000 "/>
 		<BlackAreas>
 			<Vertical x="4" width="260"/>
 			<Horizontal y="4" height="30"/>


### PR DESCRIPTION
found former settings are fine with open aperture (ef-m 22 f2.0), stopped down needs a different set (ef-m f5.6) did some investigations with a clipping flashlight with both f stops and all ISO values and checked that with real life images

so general question: which usecase should be covered by default?