### PR TITLE
Hasselblad X1D: adjust crop

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17146,7 +17146,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="48" y="104" width="-60" height="0"/>
+		<Crop x="56" y="104" width="-60" height="0"/>
 		<Sensor black="1028" white="65535"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Align w/ X1D II 50C (https://github.com/darktable-org/rawspeed/commit/b44f7d2c9e44761e1f08778c921ef9fa050c52c0) as sensor is identical.