### PR TITLE
Hasselblad X2D 100C compressed FFF support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17188,6 +17188,9 @@
 		</CFA>
 		<Crop x="136" y="106" width="-118" height="0"/>
 		<Sensor black="4267" white="65535"/>
+		<Aliases>
+			<Alias id="X2D 100C">Hasselblad X2D 100C</Alias>
+		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6468 -1899 -545</ColorMatrixRow>

--- a/src/librawspeed/decompressors/HasselbladDecompressor.cpp
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.cpp
@@ -44,7 +44,7 @@ HasselbladDecompressor::HasselbladDecompressor(const RawImage& mRaw_,
 
   // FIXME: could be wrong. max "active pixels" - "100 MP"
   if (mRaw->dim.x == 0 || mRaw->dim.y == 0 || mRaw->dim.x % 2 != 0 ||
-      mRaw->dim.x > 12000 || mRaw->dim.y > 8816) {
+      mRaw->dim.x > 12000 || mRaw->dim.y > 8842) {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
              mRaw->dim.y);
   }

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
@@ -39,7 +39,7 @@ HasselbladLJpegDecoder::HasselbladLJpegDecoder(ByteStream bs,
 
   // FIXME: could be wrong. max "active pixels" - "100 MP"
   if (mRaw->dim.x == 0 || mRaw->dim.y == 0 || mRaw->dim.x % 2 != 0 ||
-      mRaw->dim.x > 12000 || mRaw->dim.y > 8816) {
+      mRaw->dim.x > 12000 || mRaw->dim.y > 8842) {
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
              mRaw->dim.y);
   }


### PR DESCRIPTION
Should complete https://github.com/darktable-org/darktable/issues/14345 and https://github.com/darktable-org/rawspeed/pull/463

Waiting on CC0 RPU sample @kkempter-getswift

See https://www.imaging-resource.com/PRODS/hasselblad-x2d-100c/hasselblad-x2d-100cGALLERY.HTM