### PR TITLE
Do not throw exception for large RowPerStrip values

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -334,7 +334,7 @@ DngDecoder::getTilingDescription(const TiffIFD* raw) const {
                            ? raw->getEntry(TiffTag::ROWSPERSTRIP)->getU32()
                            : mRaw->dim.y;
 
-  if (yPerSlice == 0 || yPerSlice > static_cast<uint32_t>(mRaw->dim.y) ||
+  if (yPerSlice == 0 ||
       roundUpDivision(mRaw->dim.y, yPerSlice) != counts->count) {
     ThrowRDE("Invalid y per slice %u or strip count %u (height = %u)",
              yPerSlice, counts->count, mRaw->dim.y);

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -222,7 +222,7 @@ void NefDecoder::DecodeUncompressed() const {
              counts->count, offsets->count);
   }
 
-  if (yPerSlice == 0 || yPerSlice > static_cast<uint32_t>(mRaw->dim.y) ||
+  if (yPerSlice == 0 ||
       roundUpDivision(mRaw->dim.y, yPerSlice) != counts->count) {
     ThrowRDE("Invalid y per slice %u or strip count %u (height = %u)",
              yPerSlice, counts->count, mRaw->dim.y);


### PR DESCRIPTION
TIFF spec says any value in [1,2^32-1 ] must be accepted, so throw only on 0
Align RawDecoder slice calculation to NefDecoder one