### PR TITLE
Simplify CMakeLists by using policy to honor CXX standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 
 cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0025 NEW)
+cmake_policy(SET CMP0067 NEW)
 
 # Avoid source tree pollution
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,21 +1,4 @@
-include(CheckCXXCompilerFlag)
 include(CpuMarch)
-include(CheckCXXCompilerFlagAndEnableIt)
-
-# yes, need to keep both the CMAKE_CXX_FLAGS and CMAKE_CXX_STANDARD.
-# with just the CMAKE_CXX_STANDARD, try_compile() breaks:
-#   https://gitlab.kitware.com/cmake/cmake/issues/16456
-# with just the CMAKE_CXX_FLAGS, 'bundled' pugixml breaks tests
-#   https://github.com/darktable-org/rawspeed/issues/112#issuecomment-321517003
-
-message(STATUS "Checking for -std=c++17 support")
-CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
-if(NOT COMPILER_SUPPORTS_CXX17)
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-  message(STATUS "Checking for -std=c++17 support - works")
-endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/policy/CMP0067.html it is no longer required to set CXXFLAGS as well for try_compile().