### PR TITLE
Pentax K-3 Mark III Monochrome support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12064,6 +12064,11 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-3 Mark III Monochrome">
+		<ID make="Pentax" model="K-3 Mark III Monochrome">PENTAX K-3 Mark III Monochrome</ID>
+		<Crop x="26" y="34" width="-28" height="-14"/>
+		<Sensor black="64" white="16315"/>
+	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-5" decoder_version="2">
 		<ID make="Pentax" model="K-5">PENTAX K-5</ID>
 		<CFA width="2" height="2">

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -65,6 +65,17 @@ RawImage PefDecoder::decodeRawInternal() {
   if (65535 != compression)
     ThrowRDE("Unsupported compression");
 
+  if (raw->hasEntry(TiffTag::PHOTOMETRICINTERPRETATION)) {
+    mRaw->isCFA =
+        (raw->getEntry(TiffTag::PHOTOMETRICINTERPRETATION)->getU16() != 34892);
+  }
+
+  if (mRaw->isCFA)
+    writeLog(DEBUG_PRIO::EXTRA, "This is a CFA image");
+  else {
+    writeLog(DEBUG_PRIO::EXTRA, "This is NOT a CFA image");
+  }
+
   const TiffEntry* offsets = raw->getEntry(TiffTag::STRIPOFFSETS);
   const TiffEntry* counts = raw->getEntry(TiffTag::STRIPBYTECOUNTS);
 


### PR DESCRIPTION
Could be incomplete though - the manual/specs mention PEF output as well, for which a sample on RPU is of course required...