### PR TITLE
Revert "DngOpcodes: DeltaRowOrCol: fix `size_t` printf specifier on i…

### DIFF
--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -489,7 +489,7 @@ protected:
             S::select(getRoi().getWidth(), getRoi().getHeight()),
             S::select(getPitch().x, getPitch().y));
         expectedSize != deltaF_count) {
-      ThrowRDE("Got unexpected number of elements (%zu), expected %u.",
+      ThrowRDE("Got unexpected number of elements (%lu), expected %u.",
                expectedSize, deltaF_count);
     }
 


### PR DESCRIPTION
…586/amrv7l"

This reverts commit 111b3e9e134c53974ccf4f8219ad395504e7b265.