### PR TITLE
Actually update to Google Test `1.13.0`

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -101,6 +101,9 @@ jobs:
                                     libxml2-utils \
                                     ninja-build \
                                     zlib1g-dev
+          if [ "${{ inputs.distro }}" = "ubuntu:jammy" ]; then
+            eatmydata apt-get purge googletest
+          fi
           if [ "$COMPILER_FAMILY" = "GNU" ]; then
             eatmydata apt-get install g++-${{ inputs.compiler-version }} \
                                       gcc \

--- a/cmake/Modules/GoogleTest.cmake
+++ b/cmake/Modules/GoogleTest.cmake
@@ -59,6 +59,10 @@ set_target_properties(gtest_main PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
 set_target_properties(gmock PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:gmock,INTERFACE_INCLUDE_DIRECTORIES>)
 set_target_properties(gmock_main PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:gmock_main,INTERFACE_INCLUDE_DIRECTORIES>)
 
+foreach(target gtest gtest_main gmock gmock_main)
+  target_compile_definitions(${target} PUBLIC -DGTEST_REMOVE_LEGACY_TEST_CASEAPI_)
+endforeach()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_SAVE}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_SAVE}")
 

--- a/cmake/Modules/GoogleTest.cmake.in
+++ b/cmake/Modules/GoogleTest.cmake.in
@@ -36,8 +36,8 @@ else()
     message(WARNING "Did not find Google Test sources! Fetching from web...")
     ExternalProject_Add(
       googletest
-      URL               https://github.com/google/googletest/archive/release-1.8.1.tar.gz
-      URL_HASH          SHA512=e6283c667558e1fd6e49fa96e52af0e415a3c8037afe1d28b7ff1ec4c2ef8f49beb70a9327b7fc77eb4052a58c4ccad8b5260ec90e4bceeac7a46ff59c4369d7
+      URL               https://github.com/google/googletest/archive/v1.13.0.tar.gz
+      URL_HASH          SHA512=70c0cfb1b4147bdecb467ecb22ae5b5529eec0abc085763213a796b7cdbd81d1761d12b342060539b936fa54f345d33f060601544874d6213fdde79111fa813e
       PREFIX            "${CMAKE_BINARY_DIR}"
       STAMP_DIR         "${CMAKE_BINARY_DIR}/stamp"
       DOWNLOAD_DIR      "${CMAKE_BINARY_DIR}/download"

--- a/src/utilities/rstest/MD5Test.cpp
+++ b/src/utilities/rstest/MD5Test.cpp
@@ -68,7 +68,7 @@ static const std::array<MD5Testcase, 7> testCases = {
              "678901234567890"),
 };
 
-INSTANTIATE_TEST_CASE_P(MD5Test, MD5Test, ::testing::ValuesIn(testCases));
+INSTANTIATE_TEST_SUITE_P(MD5Test, MD5Test, ::testing::ValuesIn(testCases));
 TEST_P(MD5Test, CheckTestCaseSet) {
   ASSERT_NO_THROW({
     rawspeed::md5::md5_state hash;

--- a/test/librawspeed/adt/NORangesSetTest.cpp
+++ b/test/librawspeed/adt/NORangesSetTest.cpp
@@ -98,7 +98,7 @@ protected:
   Range<int> r1;
   Range<int> r2;
 };
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Unsigned, ThreeRangesTest,
     testing::Combine(testing::Range(0, 3), testing::Range(0U, 3U),
                      testing::Range(0, 3), testing::Range(0U, 3U),

--- a/test/librawspeed/adt/PointTest.cpp
+++ b/test/librawspeed/adt/PointTest.cpp
@@ -275,7 +275,7 @@ static const Six valueSum[]{
     make_tuple(make_pair(5, 5), make_pair(5, 5), make_pair(10, 10)),
 };
 
-INSTANTIATE_TEST_CASE_P(SumTest, PointTest, ::testing::ValuesIn(valueSum));
+INSTANTIATE_TEST_SUITE_P(SumTest, PointTest, ::testing::ValuesIn(valueSum));
 TEST_P(PointTest, InPlaceAddTest1) {
   ASSERT_NO_THROW({
     a += b;
@@ -338,9 +338,9 @@ protected:
 
   iPoint2D p;
 };
-INSTANTIATE_TEST_CASE_P(HasPositiveAreaTest, HasPositiveAreaTest,
-                        ::testing::Combine(::testing::Range(-2, 3),
-                                           ::testing::Range(-2, 3)));
+INSTANTIATE_TEST_SUITE_P(HasPositiveAreaTest, HasPositiveAreaTest,
+                         ::testing::Combine(::testing::Range(-2, 3),
+                                            ::testing::Range(-2, 3)));
 static const iPoint2D PositiveAreaData[] = {
     {1, 1},
     {1, 2},
@@ -420,7 +420,7 @@ static const areaType valueArea[]{
     make_tuple(make_pair(maxVal, maxVal), maxAreaVal),
 
 };
-INSTANTIATE_TEST_CASE_P(AreaTest, AreaTest, ::testing::ValuesIn(valueArea));
+INSTANTIATE_TEST_SUITE_P(AreaTest, AreaTest, ::testing::ValuesIn(valueArea));
 TEST_P(AreaTest, AreaTest) {
   ASSERT_NO_THROW({ ASSERT_EQ(p.area(), a); });
 }
@@ -672,8 +672,8 @@ static const operatorsType operatorsValues[]{
     make_tuple(make_pair(1, 1), make_pair(1, 1), true, false, false, true,
                true)};
 
-INSTANTIATE_TEST_CASE_P(OperatorsTests, OperatorsTest,
-                        ::testing::ValuesIn(operatorsValues));
+INSTANTIATE_TEST_SUITE_P(OperatorsTests, OperatorsTest,
+                         ::testing::ValuesIn(operatorsValues));
 
 TEST_P(OperatorsTest, OperatorEQTest) {
   ASSERT_NO_THROW({ ASSERT_EQ(a == b, eq); });
@@ -809,8 +809,8 @@ static const Six smallestValues[]{
 
 class SmallestTest : public PointTest {};
 
-INSTANTIATE_TEST_CASE_P(GetSmallestTest, SmallestTest,
-                        ::testing::ValuesIn(smallestValues));
+INSTANTIATE_TEST_SUITE_P(GetSmallestTest, SmallestTest,
+                         ::testing::ValuesIn(smallestValues));
 TEST_P(SmallestTest, GetSmallestTest) {
   ASSERT_NO_THROW({
     ASSERT_EQ(a.getSmallest(b), c);

--- a/test/librawspeed/adt/RangeTest.h
+++ b/test/librawspeed/adt/RangeTest.h
@@ -111,11 +111,11 @@ protected:
   Range<int> r0;
   Range<int> r1;
 };
-INSTANTIATE_TEST_CASE_P(Unsigned, TwoRangesTest,
-                        testing::Combine(testing::Range(0, 3),
-                                         testing::Range(0U, 3U),
-                                         testing::Range(0, 3),
-                                         testing::Range(0U, 3U)));
+INSTANTIATE_TEST_SUITE_P(Unsigned, TwoRangesTest,
+                         testing::Combine(testing::Range(0, 3),
+                                          testing::Range(0U, 3U),
+                                          testing::Range(0, 3),
+                                          testing::Range(0U, 3U)));
 
 static const std::set<twoRangesType> AllOverlapped{
     std::make_tuple(0, 0, 0, 0), std::make_tuple(0, 0, 0, 1),

--- a/test/librawspeed/codes/HuffmanCodeTest.cpp
+++ b/test/librawspeed/codes/HuffmanCodeTest.cpp
@@ -120,8 +120,8 @@ static const CodeSymbolType CodeSymbolData[]{
     make_tuple(0b11, 2, false),
     // clang-format on
 };
-INSTANTIATE_TEST_CASE_P(CodeSymbolDeathTest, CodeSymbolDeathTest,
-                        ::testing::ValuesIn(CodeSymbolData));
+INSTANTIATE_TEST_SUITE_P(CodeSymbolDeathTest, CodeSymbolDeathTest,
+                         ::testing::ValuesIn(CodeSymbolData));
 TEST_P(CodeSymbolDeathTest, CodeSymbolDeathTest) {
   if (die) {
     ASSERT_DEATH({ HuffmanCode<BaselineCodeTag>::CodeSymbol(val, len); },
@@ -164,8 +164,8 @@ static const CodeSymbolPrintDataType CodeSymbolPrintData[]{
     make_tuple(0b11, 2, "0b11"),
     // clang-format on
 };
-INSTANTIATE_TEST_CASE_P(CodeSymbolPrintTest, CodeSymbolPrintTest,
-                        ::testing::ValuesIn(CodeSymbolPrintData));
+INSTANTIATE_TEST_SUITE_P(CodeSymbolPrintTest, CodeSymbolPrintTest,
+                         ::testing::ValuesIn(CodeSymbolPrintData));
 TEST_P(CodeSymbolPrintTest, CodeSymbolPrintTest) {
   ASSERT_EQ(::testing::PrintToString(
                 HuffmanCode<BaselineCodeTag>::CodeSymbol(val, len)),
@@ -205,7 +205,7 @@ GenerateAllPossibleCodeSymbols() {
   return allVariants;
 }
 static const auto allPossibleCodeSymbols = GenerateAllPossibleCodeSymbols();
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CodeSymbolHaveCommonPrefixTest, CodeSymbolHaveCommonPrefixTest,
     ::testing::Combine(::testing::ValuesIn(allPossibleCodeSymbols),
                        ::testing::ValuesIn(allPossibleCodeSymbols)));
@@ -538,8 +538,8 @@ static const SignExtendDataType signExtendData[]{
     make_tuple(0b11, 0b11, -0b100),
     // clang-format on
 };
-INSTANTIATE_TEST_CASE_P(SignExtendTest, SignExtendTest,
-                        ::testing::ValuesIn(signExtendData));
+INSTANTIATE_TEST_SUITE_P(SignExtendTest, SignExtendTest,
+                         ::testing::ValuesIn(signExtendData));
 TEST_P(SignExtendTest, SignExtendTest) {
   ASSERT_EQ(
       rawspeed::AbstractPrefixCodeDecoder<BaselineCodeTag>::extend(diff, len),
@@ -597,8 +597,8 @@ static const generateCodeSymbolsDataType generateCodeSymbolsData[]{
                }),
 
 };
-INSTANTIATE_TEST_CASE_P(generateCodeSymbolsTest, generateCodeSymbolsTest,
-                        ::testing::ValuesIn(generateCodeSymbolsData));
+INSTANTIATE_TEST_SUITE_P(generateCodeSymbolsTest, generateCodeSymbolsTest,
+                         ::testing::ValuesIn(generateCodeSymbolsData));
 TEST_P(generateCodeSymbolsTest, generateCodeSymbolsTest) {
   HuffmanCode<BaselineCodeTag> hc;
   Buffer bl(ncpl.data(), ncpl.size());

--- a/test/librawspeed/common/BayerPhaseTest.cpp
+++ b/test/librawspeed/common/BayerPhaseTest.cpp
@@ -103,7 +103,7 @@ protected:
   ColorFilterArray cfa;
 };
 
-INSTANTIATE_TEST_CASE_P(All2x2CFAs, BayerPhaseFromCFATest, AllPossible2x2CFAs);
+INSTANTIATE_TEST_SUITE_P(All2x2CFAs, BayerPhaseFromCFATest, AllPossible2x2CFAs);
 TEST_P(BayerPhaseFromCFATest, getAsBayerPhaseTest) {
   EXPECT_EQ(expected, rawspeed::getAsBayerPhase(cfa));
 }
@@ -126,8 +126,8 @@ protected:
   std::array<CFAColor, 4> expected;
 };
 
-INSTANTIATE_TEST_CASE_P(AllBayerPhases, BayerPhaseToCFATest,
-                        AllKnownBayerPhases);
+INSTANTIATE_TEST_SUITE_P(AllBayerPhases, BayerPhaseToCFATest,
+                         AllKnownBayerPhases);
 TEST_P(BayerPhaseToCFATest, getAsCFAColorsTest) {
   EXPECT_EQ(expected, rawspeed::getAsCFAColors(*in));
 }
@@ -144,8 +144,8 @@ protected:
   BayerPhase src;
   BayerPhase tgt;
 };
-INSTANTIATE_TEST_CASE_P(AllBayerPhaseShifts, BayerPhaseShifTest,
-                        AllPossibleBayerPhaseShifts);
+INSTANTIATE_TEST_SUITE_P(AllBayerPhaseShifts, BayerPhaseShifTest,
+                         AllPossibleBayerPhaseShifts);
 
 struct AbstractElement {};
 

--- a/test/librawspeed/common/CommonTest.cpp
+++ b/test/librawspeed/common/CommonTest.cpp
@@ -68,8 +68,8 @@ static const powerOfTwoType powerOfTwoValues[] = {
     make_tuple(9, false), make_tuple(10, false), make_tuple(11, false),
 
 };
-INSTANTIATE_TEST_CASE_P(PowerOfTwoTest, PowerOfTwoTest,
-                        ::testing::ValuesIn(powerOfTwoValues));
+INSTANTIATE_TEST_SUITE_P(PowerOfTwoTest, PowerOfTwoTest,
+                         ::testing::ValuesIn(powerOfTwoValues));
 TEST_P(PowerOfTwoTest, PowerOfTwoTest) {
   ASSERT_EQ(isPowerOfTwo(in), expected);
 }
@@ -96,8 +96,8 @@ static const RoundDownType RoundDownValues[] = {
     make_tuple(10, 9, 9),   make_tuple(10, 11, 0), make_tuple(10, 12, 0),
 
 };
-INSTANTIATE_TEST_CASE_P(RoundDownTest, RoundDownTest,
-                        ::testing::ValuesIn(RoundDownValues));
+INSTANTIATE_TEST_SUITE_P(RoundDownTest, RoundDownTest,
+                         ::testing::ValuesIn(RoundDownValues));
 TEST_P(RoundDownTest, RoundDownTest) {
   ASSERT_EQ(roundDown(in, multiple), expected);
 }
@@ -124,8 +124,8 @@ static const RoundUpType RoundUpValues[] = {
     make_tuple(10, 9, 18),  make_tuple(10, 11, 11), make_tuple(10, 12, 12),
 
 };
-INSTANTIATE_TEST_CASE_P(RoundUpTest, RoundUpTest,
-                        ::testing::ValuesIn(RoundUpValues));
+INSTANTIATE_TEST_SUITE_P(RoundUpTest, RoundUpTest,
+                         ::testing::ValuesIn(RoundUpValues));
 TEST_P(RoundUpTest, RoundUpTest) { ASSERT_EQ(roundUp(in, multiple), expected); }
 
 using RoundUpDivisionType = std::tuple<size_t, size_t, size_t>;
@@ -173,8 +173,8 @@ static const RoundUpDivisionType RoundUpDivisionValues[] = {
     make_tuple(numeric_limits<size_t>::max(), numeric_limits<size_t>::max(), 1),
 
 };
-INSTANTIATE_TEST_CASE_P(RoundUpDivisionTest, RoundUpDivisionTest,
-                        ::testing::ValuesIn(RoundUpDivisionValues));
+INSTANTIATE_TEST_SUITE_P(RoundUpDivisionTest, RoundUpDivisionTest,
+                         ::testing::ValuesIn(RoundUpDivisionValues));
 TEST_P(RoundUpDivisionTest, RoundUpDivisionTest) {
   ASSERT_EQ(roundUpDivision(in, divider), expected);
 }
@@ -191,9 +191,9 @@ protected:
   int value;
   int multiple;
 };
-INSTANTIATE_TEST_CASE_P(IsAlignedTest, IsAlignedTest,
-                        ::testing::Combine(::testing::Range(0, 32),
-                                           ::testing::Range(0, 32)));
+INSTANTIATE_TEST_SUITE_P(IsAlignedTest, IsAlignedTest,
+                         ::testing::Combine(::testing::Range(0, 32),
+                                            ::testing::Range(0, 32)));
 TEST_P(IsAlignedTest, IsAlignedAfterRoundUpTest) {
   ASSERT_TRUE(isAligned(roundUp(value, multiple), multiple));
 }
@@ -218,7 +218,7 @@ static const IsInType IsInValues[] = {
     make_tuple("baz-1", false), make_tuple("quz", false),
 
 };
-INSTANTIATE_TEST_CASE_P(IsInTest, IsInTest, ::testing::ValuesIn(IsInValues));
+INSTANTIATE_TEST_SUITE_P(IsInTest, IsInTest, ::testing::ValuesIn(IsInValues));
 TEST_P(IsInTest, IsInTest) {
   ASSERT_EQ(isIn(in, {"foo", "foo2", "bar", "baz"}), expected);
 }
@@ -267,8 +267,8 @@ static const ClampBitsType ClampBitsValues[] = {
     make_tuple(32, 0, 0),   make_tuple(32, 16, 32),
     make_tuple(32, 2, 3),   make_tuple(-32, 0, 0),
     make_tuple(-32, 16, 0), GENERATE()};
-INSTANTIATE_TEST_CASE_P(ClampBitsTest, ClampBitsTest,
-                        ::testing::ValuesIn(ClampBitsValues));
+INSTANTIATE_TEST_SUITE_P(ClampBitsTest, ClampBitsTest,
+                         ::testing::ValuesIn(ClampBitsValues));
 TEST_P(ClampBitsTest, ClampBitsTest) { ASSERT_EQ(clampBits(in, n), expected); }
 TEST(ClampBitsDeathTest, Only16Bit) {
 #ifndef NDEBUG
@@ -315,8 +315,8 @@ static const TrimSpacesType TrimSpacesValues[] = {
     make_tuple("\t  ", ""),
 #undef STR
 };
-INSTANTIATE_TEST_CASE_P(TrimSpacesTest, TrimSpacesTest,
-                        ::testing::ValuesIn(TrimSpacesValues));
+INSTANTIATE_TEST_SUITE_P(TrimSpacesTest, TrimSpacesTest,
+                         ::testing::ValuesIn(TrimSpacesValues));
 TEST_P(TrimSpacesTest, TrimSpacesTest) { ASSERT_EQ(trimSpaces(in), out); }
 
 using splitStringType = std::tuple<string, char, vector<string>>;
@@ -340,8 +340,8 @@ static const splitStringType splitStringValues[] = {
                vector<string>({" 412", " 542", "732 ", " "})),
 
 };
-INSTANTIATE_TEST_CASE_P(SplitStringTest, SplitStringTest,
-                        ::testing::ValuesIn(splitStringValues));
+INSTANTIATE_TEST_SUITE_P(SplitStringTest, SplitStringTest,
+                         ::testing::ValuesIn(splitStringValues));
 TEST_P(SplitStringTest, SplitStringTest) {
   auto split = splitString(in, sep);
   ASSERT_EQ(split.size(), out.size());
@@ -408,11 +408,11 @@ protected:
   int rowSize;
   int height;
 };
-INSTANTIATE_TEST_CASE_P(CopyPixelsTest, CopyPixelsTest,
-                        testing::Combine(testing::Range(0, 4, 1),
-                                         testing::Range(0, 4, 1),
-                                         testing::Range(0, 4, 1),
-                                         testing::Range(0, 4, 1)));
+INSTANTIATE_TEST_SUITE_P(CopyPixelsTest, CopyPixelsTest,
+                         testing::Combine(testing::Range(0, 4, 1),
+                                          testing::Range(0, 4, 1),
+                                          testing::Range(0, 4, 1),
+                                          testing::Range(0, 4, 1)));
 TEST_P(CopyPixelsTest, CopyPixelsTest) {
   generate();
   copy();

--- a/test/librawspeed/common/SplineTest.cpp
+++ b/test/librawspeed/common/SplineTest.cpp
@@ -219,8 +219,8 @@ static const identityType identityValues[] = {
         std::vector<std::array<double, 4>>{{{65535.0, -1.0, 0.0, 0.0}}})};
 
 using IntegerIdentityTest = IdentityTest<uint16_t>;
-INSTANTIATE_TEST_CASE_P(IntegerIdentityTest, IntegerIdentityTest,
-                        ::testing::ValuesIn(identityValues));
+INSTANTIATE_TEST_SUITE_P(IntegerIdentityTest, IntegerIdentityTest,
+                         ::testing::ValuesIn(identityValues));
 TEST_P(IntegerIdentityTest, ValuesAreLinearlyInterpolated) {
   for (auto x = edges.front().y; x < edges.back().y; ++x)
     ASSERT_EQ(interpolated[x], x);
@@ -228,8 +228,8 @@ TEST_P(IntegerIdentityTest, ValuesAreLinearlyInterpolated) {
 TEST_P(IntegerIdentityTest, SegmentCoeffients) { CheckSegments(); }
 
 using DoubleIdentityTest = IdentityTest<double>;
-INSTANTIATE_TEST_CASE_P(DoubleIdentityTest, DoubleIdentityTest,
-                        ::testing::ValuesIn(identityValues));
+INSTANTIATE_TEST_SUITE_P(DoubleIdentityTest, DoubleIdentityTest,
+                         ::testing::ValuesIn(identityValues));
 TEST_P(DoubleIdentityTest, ValuesAreLinearlyInterpolated) {
   for (auto x = edges.front().y; x < edges.back().y; ++x) {
     ASSERT_DOUBLE_EQ(interpolated[x], x);
@@ -280,8 +280,8 @@ protected:
   int extraSteps;
   std::vector<int> got;
 };
-INSTANTIATE_TEST_CASE_P(CalculateStepsEdgesTest, CalculateStepsEdgesTest,
-                        ::testing::Range(0, 254));
+INSTANTIATE_TEST_SUITE_P(CalculateStepsEdgesTest, CalculateStepsEdgesTest,
+                         ::testing::Range(0, 254));
 TEST_P(CalculateStepsEdgesTest, Count) {
   ASSERT_EQ(got.size(), 2 + extraSteps);
 }
@@ -323,8 +323,8 @@ static const calculateStepsType calculateStepsValues[] = {
 };
 
 using DoubleCalculateStepsTest = CalculateStepsTest<double>;
-INSTANTIATE_TEST_CASE_P(CalculateStepsTest, DoubleCalculateStepsTest,
-                        ::testing::ValuesIn(calculateStepsValues));
+INSTANTIATE_TEST_SUITE_P(CalculateStepsTest, DoubleCalculateStepsTest,
+                         ::testing::ValuesIn(calculateStepsValues));
 TEST_P(DoubleCalculateStepsTest, Count) {
   ASSERT_EQ(expected.size(), got.size());
   ASSERT_EQ(got.size(), 2 + extraSteps);
@@ -340,8 +340,8 @@ TEST_P(DoubleCalculateStepsTest, GotExpectedOutput) {
 }
 
 using IntegerCalculateStepsTest = CalculateStepsTest<int>;
-INSTANTIATE_TEST_CASE_P(CalculateStepsTest, IntegerCalculateStepsTest,
-                        ::testing::ValuesIn(calculateStepsValues));
+INSTANTIATE_TEST_SUITE_P(CalculateStepsTest, IntegerCalculateStepsTest,
+                         ::testing::ValuesIn(calculateStepsValues));
 TEST_P(IntegerCalculateStepsTest, Count) {
   ASSERT_EQ(expected.size(), got.size());
   ASSERT_EQ(got.size(), 2 + extraSteps);
@@ -408,8 +408,8 @@ static const auto constantValues =
                        ::testing::Range(0, 1 + NumExtraSteps));
 
 using IntegerConstantTest = ConstantTest<uint16_t>;
-INSTANTIATE_TEST_CASE_P(IntegerConstantTest, IntegerConstantTest,
-                        constantValues);
+INSTANTIATE_TEST_SUITE_P(IntegerConstantTest, IntegerConstantTest,
+                         constantValues);
 TEST_P(IntegerConstantTest, AllValuesAreEqual) {
   for (const auto value : interpolated)
     ASSERT_EQ(value, constant);
@@ -417,7 +417,8 @@ TEST_P(IntegerConstantTest, AllValuesAreEqual) {
 TEST_P(IntegerConstantTest, SegmentCoeffients) { CheckSegments(); }
 
 using DoubleConstantTest = ConstantTest<double>;
-INSTANTIATE_TEST_CASE_P(DoubleConstantTest, DoubleConstantTest, constantValues);
+INSTANTIATE_TEST_SUITE_P(DoubleConstantTest, DoubleConstantTest,
+                         constantValues);
 TEST_P(DoubleConstantTest, AllValuesAreEqual) {
   for (const auto value : interpolated) {
     ASSERT_DOUBLE_EQ(value, constant);
@@ -520,8 +521,8 @@ static const referenceType sin2PiRefValues[] = {
     make_tuple(14,   1.0E-04),
     // clang-format on
 };
-INSTANTIATE_TEST_CASE_P(Sin2Pi, Sin2PiRefTest,
-                        ::testing::ValuesIn(sin2PiRefValues));
+INSTANTIATE_TEST_SUITE_P(Sin2Pi, Sin2PiRefTest,
+                         ::testing::ValuesIn(sin2PiRefValues));
 TEST_P(Sin2PiRefTest, NearlyMatchesReference) { check(); }
 
 using SinPiRefTest = ReferenceTest<SinReferenceTest<1, 1>>;
@@ -542,8 +543,8 @@ static const referenceType sinPiRefValues[] = {
     make_tuple(12, 1.0E-05),
     // clang-format on
 };
-INSTANTIATE_TEST_CASE_P(SinPi, SinPiRefTest,
-                        ::testing::ValuesIn(sinPiRefValues));
+INSTANTIATE_TEST_SUITE_P(SinPi, SinPiRefTest,
+                         ::testing::ValuesIn(sinPiRefValues));
 TEST_P(SinPiRefTest, NearlyMatchesReference) { check(); }
 
 } // namespace rawspeed_test

--- a/test/librawspeed/io/BitPumpJPEGTest.cpp
+++ b/test/librawspeed/io/BitPumpJPEGTest.cpp
@@ -66,7 +66,7 @@ template <>
 const std::array<uint8_t, 8> Pattern<BitPumpJPEG, SaturatedTag>::Data{
     {uint8_t(~0U), 0, uint8_t(~0U), 0, uint8_t(~0U), 0, uint8_t(~0U), 0}};
 
-INSTANTIATE_TYPED_TEST_CASE_P(JPEG, BitPumpTest, Patterns<BitPumpJPEG>);
+INSTANTIATE_TYPED_TEST_SUITE_P(JPEG, BitPumpTest, Patterns<BitPumpJPEG>);
 
 TEST(BitPumpJPEGTest, 0xFF0x00Is0xFFTest) {
   // If 0xFF0x00 byte sequence is found, it is just 0xFF, i.e. 0x00 is ignored.

--- a/test/librawspeed/io/BitPumpLSBTest.cpp
+++ b/test/librawspeed/io/BitPumpLSBTest.cpp
@@ -23,7 +23,7 @@
 #include <array>            // for array
 #include <cstdint>          // for uint32_t, uint8_t
 #include <memory>           // for allocator
-#include <gtest/gtest.h>    // for INSTANTIATE_TYPED_TEST_CASE_P
+#include <gtest/gtest.h>    // for INSTANTIATE_TYPED_TEST_SUITE_P
 
 using rawspeed::BitPumpLSB;
 
@@ -50,6 +50,6 @@ template <> uint32_t Pattern<BitPumpLSB, InvOnesTag>::data(int index) {
   return set[index];
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(LSB, BitPumpTest, Patterns<BitPumpLSB>);
+INSTANTIATE_TYPED_TEST_SUITE_P(LSB, BitPumpTest, Patterns<BitPumpLSB>);
 
 } // namespace rawspeed_test

--- a/test/librawspeed/io/BitPumpMSB16Test.cpp
+++ b/test/librawspeed/io/BitPumpMSB16Test.cpp
@@ -23,7 +23,7 @@
 #include <array>             // for array
 #include <cstdint>           // for uint32_t, uint8_t
 #include <memory>            // for allocator
-#include <gtest/gtest.h>     // for INSTANTIATE_TYPED_TEST_CASE_P
+#include <gtest/gtest.h>     // for INSTANTIATE_TYPED_TEST_SUITE_P
 
 using rawspeed::BitPumpMSB16;
 
@@ -50,6 +50,6 @@ template <> uint32_t Pattern<BitPumpMSB16, InvOnesTag>::data(int index) {
   return set[index];
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(MSB16, BitPumpTest, Patterns<BitPumpMSB16>);
+INSTANTIATE_TYPED_TEST_SUITE_P(MSB16, BitPumpTest, Patterns<BitPumpMSB16>);
 
 } // namespace rawspeed_test

--- a/test/librawspeed/io/BitPumpMSB32Test.cpp
+++ b/test/librawspeed/io/BitPumpMSB32Test.cpp
@@ -23,7 +23,7 @@
 #include <array>             // for array
 #include <cstdint>           // for uint32_t, uint8_t
 #include <memory>            // for allocator
-#include <gtest/gtest.h>     // for INSTANTIATE_TYPED_TEST_CASE_P
+#include <gtest/gtest.h>     // for INSTANTIATE_TYPED_TEST_SUITE_P
 
 using rawspeed::BitPumpMSB32;
 
@@ -50,6 +50,6 @@ template <> uint32_t Pattern<BitPumpMSB32, InvOnesTag>::data(int index) {
   return set[index];
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(MSB32, BitPumpTest, Patterns<BitPumpMSB32>);
+INSTANTIATE_TYPED_TEST_SUITE_P(MSB32, BitPumpTest, Patterns<BitPumpMSB32>);
 
 } // namespace rawspeed_test

--- a/test/librawspeed/io/BitPumpMSBTest.cpp
+++ b/test/librawspeed/io/BitPumpMSBTest.cpp
@@ -23,7 +23,7 @@
 #include <array>            // for array
 #include <cstdint>          // for uint32_t, uint8_t
 #include <memory>           // for allocator
-#include <gtest/gtest.h>    // for INSTANTIATE_TYPED_TEST_CASE_P
+#include <gtest/gtest.h>    // for INSTANTIATE_TYPED_TEST_SUITE_P
 
 using rawspeed::BitPumpMSB;
 
@@ -50,6 +50,6 @@ template <> uint32_t Pattern<BitPumpMSB, InvOnesTag>::data(int index) {
   return set[index];
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(MSB, BitPumpTest, Patterns<BitPumpMSB>);
+INSTANTIATE_TYPED_TEST_SUITE_P(MSB, BitPumpTest, Patterns<BitPumpMSB>);
 
 } // namespace rawspeed_test

--- a/test/librawspeed/io/BitPumpTest.h
+++ b/test/librawspeed/io/BitPumpTest.h
@@ -170,9 +170,9 @@ TYPED_TEST_P(BitPumpTest, IncreasingPeekLengthNoFillTest) {
       TypeParam::PatternT::Data, TypeParam::PatternT::data);
 }
 
-REGISTER_TYPED_TEST_CASE_P(BitPumpTest, GetTest, GetNoFillTest, PeekTest,
-                           PeekNoFillTest, IncreasingPeekLengthTest,
-                           IncreasingPeekLengthNoFillTest);
+REGISTER_TYPED_TEST_SUITE_P(BitPumpTest, GetTest, GetNoFillTest, PeekTest,
+                            PeekNoFillTest, IncreasingPeekLengthTest,
+                            IncreasingPeekLengthNoFillTest);
 
 template <typename Pump, typename PatternTag> struct Pattern {};
 

--- a/test/librawspeed/io/BitPumpTest.h
+++ b/test/librawspeed/io/BitPumpTest.h
@@ -143,7 +143,7 @@ protected:
   }
 };
 
-TYPED_TEST_CASE_P(BitPumpTest);
+TYPED_TEST_SUITE_P(BitPumpTest);
 
 TYPED_TEST_P(BitPumpTest, GetTest) {
   this->template runTest<TestGetBitsTag>(TypeParam::PatternT::Data,

--- a/test/librawspeed/io/EndiannessTest.cpp
+++ b/test/librawspeed/io/EndiannessTest.cpp
@@ -135,9 +135,9 @@ B=2 # sizeof, bytes
 */
 class ushort16Test
     : public AbstractGetByteSwappedTest<ushort16TType, uint16_t> {};
-INSTANTIATE_TEST_CASE_P(ushort16Test, ushort16Test,
-                        ::testing::Combine(::testing::ValuesIn(ushort16Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(ushort16Test, ushort16Test,
+                         ::testing::Combine(::testing::ValuesIn(ushort16Values),
+                                            ::testing::Bool()));
 TEST_P(ushort16Test, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -179,9 +179,9 @@ TEST_P(ushort16Test, getU16NOP) {
 
 class short16Test : public AbstractGetByteSwappedTest<ushort16TType, int16_t> {
 };
-INSTANTIATE_TEST_CASE_P(short16Test, short16Test,
-                        ::testing::Combine(::testing::ValuesIn(ushort16Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(short16Test, short16Test,
+                         ::testing::Combine(::testing::ValuesIn(ushort16Values),
+                                            ::testing::Bool()));
 TEST_P(short16Test, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -210,9 +210,9 @@ TEST_P(short16Test, getNOP) {
 B=4 # sizeof, bytes
 */
 class uint32Test : public AbstractGetByteSwappedTest<uint32TType, uint32_t> {};
-INSTANTIATE_TEST_CASE_P(uint32Test, uint32Test,
-                        ::testing::Combine(::testing::ValuesIn(uint32Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(uint32Test, uint32Test,
+                         ::testing::Combine(::testing::ValuesIn(uint32Values),
+                                            ::testing::Bool()));
 TEST_P(uint32Test, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -253,9 +253,9 @@ TEST_P(uint32Test, getU32NOP) {
 }
 
 class int32Test : public AbstractGetByteSwappedTest<uint32TType, int32_t> {};
-INSTANTIATE_TEST_CASE_P(int32Test, int32Test,
-                        ::testing::Combine(::testing::ValuesIn(uint32Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(int32Test, int32Test,
+                         ::testing::Combine(::testing::ValuesIn(uint32Values),
+                                            ::testing::Bool()));
 TEST_P(int32Test, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -284,9 +284,9 @@ TEST_P(int32Test, getNOP) {
 B=8 # sizeof, bytes
 */
 class uint64Test : public AbstractGetByteSwappedTest<uint64TType, uint64_t> {};
-INSTANTIATE_TEST_CASE_P(uint64Test, uint64Test,
-                        ::testing::Combine(::testing::ValuesIn(uint64Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(uint64Test, uint64Test,
+                         ::testing::Combine(::testing::ValuesIn(uint64Values),
+                                            ::testing::Bool()));
 TEST_P(uint64Test, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -312,9 +312,9 @@ TEST_P(uint64Test, getNOP) {
 }
 
 class floatTest : public AbstractGetByteSwappedTest<uint32TType, float> {};
-INSTANTIATE_TEST_CASE_P(floatTest, floatTest,
-                        ::testing::Combine(::testing::ValuesIn(uint32Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(floatTest, floatTest,
+                         ::testing::Combine(::testing::ValuesIn(uint32Values),
+                                            ::testing::Bool()));
 TEST_P(floatTest, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }
@@ -340,9 +340,9 @@ TEST_P(floatTest, getNOP) {
 }
 
 class doubleTest : public AbstractGetByteSwappedTest<uint64TType, double> {};
-INSTANTIATE_TEST_CASE_P(doubleTest, doubleTest,
-                        ::testing::Combine(::testing::ValuesIn(uint64Values),
-                                           ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(doubleTest, doubleTest,
+                         ::testing::Combine(::testing::ValuesIn(uint64Values),
+                                            ::testing::Bool()));
 TEST_P(doubleTest, swap) {
   ASSERT_PRED_FORMAT2(HexEquals{}, getByteSwapped(in), expected);
 }

--- a/test/librawspeed/metadata/BlackAreaTest.cpp
+++ b/test/librawspeed/metadata/BlackAreaTest.cpp
@@ -57,11 +57,12 @@ protected:
   bool isVertical{false}; // Otherwise horizontal
 };
 
-INSTANTIATE_TEST_CASE_P(BlackAreas, BlackAreaTest,
-                        testing::Combine(testing::Range(0, 1000, 250), // offset
-                                         testing::Range(0, 1000, 250), // size
-                                         testing::Bool() // isVertical
-                                         ));
+INSTANTIATE_TEST_SUITE_P(BlackAreas, BlackAreaTest,
+                         testing::Combine(testing::Range(0, 1000,
+                                                         250), // offset
+                                          testing::Range(0, 1000, 250), // size
+                                          testing::Bool() // isVertical
+                                          ));
 
 TEST_P(BlackAreaTest, Constructor) {
   ASSERT_NO_THROW({ BlackArea Area(offset, size, isVertical); });

--- a/test/librawspeed/metadata/CameraSensorInfoTest.cpp
+++ b/test/librawspeed/metadata/CameraSensorInfoTest.cpp
@@ -78,10 +78,10 @@ protected:
   std::vector<int> mBlackLevelSeparate;
 };
 
-INSTANTIATE_TEST_CASE_P(MinMax, CameraSensorInfoTestDumb,
-                        testing::Combine(testing::ValuesIn(ISOList), // min iso
-                                         testing::ValuesIn(ISOList)  // max iso
-                                         ));
+INSTANTIATE_TEST_SUITE_P(MinMax, CameraSensorInfoTestDumb,
+                         testing::Combine(testing::ValuesIn(ISOList), // min iso
+                                          testing::ValuesIn(ISOList)  // max iso
+                                          ));
 
 TEST_P(CameraSensorInfoTestDumb, Constructor) {
   ASSERT_NO_THROW({
@@ -279,8 +279,8 @@ protected:
   std::vector<int> mBlackLevelSeparate;
 };
 
-INSTANTIATE_TEST_CASE_P(Expectations, CameraSensorInfoTest,
-                        testing::ValuesIn(CameraSensorIsoInfos));
+INSTANTIATE_TEST_SUITE_P(Expectations, CameraSensorInfoTest,
+                         testing::ValuesIn(CameraSensorIsoInfos));
 
 TEST_P(CameraSensorInfoTest, IsDefault) {
   CameraSensorInfo Info(mBlackLevel, mWhiteLevel, data.mMinIso, data.mMaxIso,

--- a/test/librawspeed/metadata/CameraTest.cpp
+++ b/test/librawspeed/metadata/CameraTest.cpp
@@ -142,8 +142,8 @@ protected:
   virtual void SetUp() override { notTrue = std::get<0>(GetParam()); }
   string notTrue;
 };
-INSTANTIATE_TEST_CASE_P(NotTrue, BoolHintTest,
-                        ::testing::Values("True", "false", "False", "", "_"));
+INSTANTIATE_TEST_SUITE_P(NotTrue, BoolHintTest,
+                         ::testing::Values("True", "false", "False", "", "_"));
 
 TEST_P(BoolHintTest, HintsBool) {
   Hints hints;

--- a/test/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/test/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -151,13 +151,13 @@ static const auto Bayer_RGB =
 static const auto Bayer_CYGM = ::testing::Values(
     CFAColor::CYAN, CFAColor::MAGENTA, CFAColor::YELLOW, CFAColor::FUJI_GREEN);
 
-INSTANTIATE_TEST_CASE_P(RGGB, ColorFilterArrayTest,
-                        testing::Combine(Bayer_RGB, Bayer_RGB, Bayer_RGB,
-                                         Bayer_RGB));
+INSTANTIATE_TEST_SUITE_P(RGGB, ColorFilterArrayTest,
+                         testing::Combine(Bayer_RGB, Bayer_RGB, Bayer_RGB,
+                                          Bayer_RGB));
 
-INSTANTIATE_TEST_CASE_P(CYGM, ColorFilterArrayTest,
-                        testing::Combine(Bayer_CYGM, Bayer_CYGM, Bayer_CYGM,
-                                         Bayer_CYGM));
+INSTANTIATE_TEST_SUITE_P(CYGM, ColorFilterArrayTest,
+                         testing::Combine(Bayer_CYGM, Bayer_CYGM, Bayer_CYGM,
+                                          Bayer_CYGM));
 
 static void setHelper(ColorFilterArray* cfa, Bayer2x2 param) {
   cfa->setCFA(square, std::get<0>(param), std::get<1>(param),
@@ -248,15 +248,15 @@ protected:
   int y;
 };
 
-INSTANTIATE_TEST_CASE_P(RGGB, ColorFilterArrayShiftTest,
-                        testing::Combine(Bayer_RGB, Bayer_RGB, Bayer_RGB,
-                                         Bayer_RGB, testing::Range(-2, 2),
-                                         testing::Range(-2, 2)));
+INSTANTIATE_TEST_SUITE_P(RGGB, ColorFilterArrayShiftTest,
+                         testing::Combine(Bayer_RGB, Bayer_RGB, Bayer_RGB,
+                                          Bayer_RGB, testing::Range(-2, 2),
+                                          testing::Range(-2, 2)));
 
-INSTANTIATE_TEST_CASE_P(CYGM, ColorFilterArrayShiftTest,
-                        testing::Combine(Bayer_CYGM, Bayer_CYGM, Bayer_CYGM,
-                                         Bayer_CYGM, testing::Range(-2, 2),
-                                         testing::Range(-2, 2)));
+INSTANTIATE_TEST_SUITE_P(CYGM, ColorFilterArrayShiftTest,
+                         testing::Combine(Bayer_CYGM, Bayer_CYGM, Bayer_CYGM,
+                                          Bayer_CYGM, testing::Range(-2, 2),
+                                          testing::Range(-2, 2)));
 
 TEST(ColorFilterArrayTestBasic, shiftDcrawFilter) {
   uint32_t bggr = 0x16161616;

--- a/test/librawspeed/test/ExceptionsTest.cpp
+++ b/test/librawspeed/test/ExceptionsTest.cpp
@@ -97,7 +97,7 @@ using Classes =
                    RawDecoderException, TiffParserException,
                    FiffParserException, RawParserException>;
 
-TYPED_TEST_CASE(ExceptionsTest, Classes);
+TYPED_TEST_SUITE(ExceptionsTest, Classes);
 
 TYPED_TEST(ExceptionsTest, Constructor) {
   ASSERT_NO_THROW({ TypeParam Exception(msg); });


### PR DESCRIPTION
I have no clue why deprecation warning is only seen on macOS CI
and not anywhere else.