### PR TITLE
Remove some unsupported Samsung DNG model flags

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17521,16 +17521,16 @@
 	<Camera make="SAMSUNG DIGITAL IMA" model="SAMSUNG GX20" mode="dng" supported="no-samples">
 		<ID make="Samsung" model="GX20">Samsung GX20</ID>
 	</Camera>
-	<Camera make="samsung" model="SM-G920F" supported="no-samples">
+	<Camera make="samsung" model="SM-G920F" mode="dng">
 		<ID make="Samsung" model="G920F">Samsung G920F</ID>
 	</Camera>
-	<Camera make="samsung" model="SM-G935F" supported="no-samples">
+	<Camera make="samsung" model="SM-G935F" mode="dng">
 		<ID make="Samsung" model="G935F">Samsung G935F</ID>
 	</Camera>
-	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX10" supported="no-samples">
+	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX10" mode="dng">
 		<ID make="Samsung" model="GX10">Samsung GX10</ID>
 	</Camera>
-	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX20" supported="no-samples">
+	<Camera make="SAMSUNG TECHWIN Co." model="SAMSUNG GX20" mode="dng">
 		<ID make="Samsung" model="GX20">Samsung GX20</ID>
 	</Camera>
 	<Camera make="Nokia" model="Lumia 1020" mode="dng">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/12160, https://github.com/darktable-org/darktable/issues/14094 and https://github.com/darktable-org/darktable/issues/14219

CC0 samples are indeed present on RPU...