### PR TITLE
Sony ILCE-6700 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13675,6 +13675,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="SONY" model="ILCE-6700">
+		<ID make="Sony" model="ILCE-6700">Sony ILCE-6700</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-28" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">6972 -2408 -600</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4330 12101 2515</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-388 1277 5847</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="SONY" model="ILCE-1">
 		<ID make="Sony" model="ILCE-1">Sony ILCE-1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/rawspeed/issues/507

Confirmed w/ latest ADC 15.5 - crop and matrix are identical to FX30.