### PR TITLE
Sigma sd Quattro H (partial) support 

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17566,6 +17566,9 @@
 	<Camera make="SIGMA" model="sd Quattro" mode="dng">
 		<ID make="Sigma" model="sd Quattro">sd Quattro</ID>
 	</Camera>
+	<Camera make="SIGMA" model="sd Quattro H" mode="dng">
+		<ID make="Sigma" model="sd Quattro H">sd Quattro H</ID>
+	</Camera>
 	<Camera make="LGE" model="Nexus 5X" mode="dng">
 		<ID make="LG" model="Nexus 5X">LG Nexus 5X</ID>
 	</Camera>


### PR DESCRIPTION
DNG mode name normalization only

Partly addresses https://github.com/darktable-org/darktable/issues/2879