### PR TITLE
Add missing schema ImBack camera maker

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -16270,7 +16270,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="ImBack" model="ImB35mm" mode="chdk">
-		<ID make="Imback" model="ImB35mm">ImBack</ID>
+		<ID make="ImBack" model="ImB35mm">ImBack</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -27,6 +27,7 @@
       <xs:enumeration value="GITUP"/>
       <xs:enumeration value="GoPro"/>
       <xs:enumeration value="Hasselblad"/>
+      <xs:enumeration value="ImBack"/>
       <xs:enumeration value="Kodak"/>
       <xs:enumeration value="LG"/>
       <xs:enumeration value="Leaf"/>
@@ -426,6 +427,7 @@
       <xs:enumeration value="Generic"/>
       <xs:enumeration value="GoPro"/>
       <xs:enumeration value="Hasselblad"/>
+      <xs:enumeration value="ImBack"/>
       <xs:enumeration value="KODAK"/>
       <xs:enumeration value="KONICA MINOLTA"/>
       <xs:enumeration value="Kodak"/>


### PR DESCRIPTION
Cf. recent commit https://github.com/darktable-org/rawspeed/commit/59cf9f95c4c770f7161b7bb54c7f52d4b6c91922

Should it be "ImBack" or "Imback"? We left GoPro, OnePlus, etc. alone AFAICT?