### PR TITLE
Relax DNG black level parsing

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -767,9 +767,13 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
   iPoint2D blackdim(1, 1);
   if (raw->hasEntry(TiffTag::BLACKLEVELREPEATDIM)) {
     const TiffEntry* bleveldim = raw->getEntry(TiffTag::BLACKLEVELREPEATDIM);
-    if (bleveldim->count != 2)
+    if (bleveldim->count == 2)
+      blackdim = iPoint2D(bleveldim->getU32(0), bleveldim->getU32(1));
+    else if (bleveldim->count != 1 || 1 != bleveldim->getU32(0)) {
+      writeLog(DEBUG_PRIO::EXTRA,
+               "BLACKLEVELREPEATDIM entry is invalid, not allowed to guess");
       return false;
-    blackdim = iPoint2D(bleveldim->getU32(0), bleveldim->getU32(1));
+    }
   }
 
   if (!blackdim.hasPositiveArea())


### PR DESCRIPTION
Use the default BlackLevelRepeatDim (1,1) if the single entry value is 1

This e.g. allows the black level of Pentax K-3 Mark III Monochrome DNG from RPU to be parsed instead of being ignored:
```
Exif.SubImage1.BlackLevelRepeatDim           Short       1  1
Exif.SubImage1.BlackLevel                    Long        1  2048
```

~~Alternatively, could read the one value if count is 1, and copy it?~~