### PR TITLE
Add Canon EOS Kiss F alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1433,6 +1433,7 @@
 		</BlackAreas>
 		<Aliases>
 			<Alias id="EOS Rebel T3">Canon EOS REBEL T3</Alias>
+			<Alias id="EOS Kiss X50">Canon EOS Kiss X50</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -1516,6 +1517,7 @@
 		<Aliases>
 			<Alias id="EOS Rebel T7">Canon EOS Rebel T7</Alias>
 			<Alias id="EOS 1500D">Canon EOS 1500D</Alias>
+			<Alias id="EOS Kiss X90">Canon EOS Kiss X90</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1407,6 +1407,7 @@
 		<Aliases>
 			<Alias id="EOS Digital Rebel XS">Canon EOS DIGITAL REBEL XS</Alias>
 			<Alias id="EOS Kiss Digital F">Canon EOS Kiss Digital F</Alias>
+			<Alias id="EOS Kiss F">Canon EOS Kiss F</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/15299

The "Canon EOS Kiss Digital F" was probably wrong to begin with, but probably doesn't hurt to keep it...

Edit: Added a few more while at it, mainly from random sampling https://global.canon/en/c-museum/camera.html