### PR TITLE
Panasonic DC-G9M2 support (data only)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11410,8 +11410,29 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Panasonic" model="DC-G9M2" supported="no">
+	<Camera make="Panasonic" model="DC-G9M2">
 		<ID make="Panasonic" model="DC-G9M2">Panasonic DC-G9M2</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="2048" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">8325 -3456 -623</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4330 12089 2528</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-860 2646 5984</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="Panasonic" model="DC-G9M2" mode="4:3">
+		<ID make="Panasonic" model="DC-G9M2">Panasonic DC-G9M2</ID>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="2048" white="65535"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">8325 -3456 -623</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4330 12089 2528</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-860 2646 5984</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-G95">
 		<ID make="Panasonic" model="DC-G95">Panasonic DC-G95</ID>


### PR DESCRIPTION
Partly addresses https://github.com/darktable-org/darktable/issues/15679

Used ADC 16.0. Crop is unverified.

This depends on https://github.com/darktable-org/rawspeed/issues/367