### PR TITLE
Bump minimal LLVM/XCode versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,8 +43,6 @@ jobs:
           - { distro: "debian:bookworm-slim", family: GNU,  version: 12, CC: gcc-12,   CXX: g++-12 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 15, CC: clang-15, CXX: clang++-15 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 14, CC: clang-14, CXX: clang++-14 }
-          - { distro: "debian:bookworm-slim", family: LLVM, version: 13, CC: clang-13, CXX: clang++-13 }
-          - { distro: "ubuntu:jammy",         family: LLVM, version: 12, CC: clang-12, CXX: clang++-12 }
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-linux.yml
     with:
@@ -182,8 +180,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-13, family: XCode, version: 14.3,   deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15, native
-          - { os: macos-11, family: XCode, version: 13.2.1, deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM12, native
+          - { os: macos-13, family: XCode, version: 14.3, deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15, native
+          - { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -199,9 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-13, family: XCode, version: 14.3,   deployment_target: 11.3, CC: cc, CXX: c++ } # LLVM15, "backdeploy"
-          - { os: macos-12, family: XCode, version: 14.2,   deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
-          - { os: macos-12, family: XCode, version: 13.4.1, deployment_target: 12.0, CC: cc, CXX: c++ } # LLVM13, native
+          - { os: macos-13, family: XCode, version: 14.3, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM15, "backdeploy"
         flavor: [ RelWithDebInfo, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:

--- a/cmake/compiler-versions.cmake
+++ b/cmake/compiler-versions.cmake
@@ -17,16 +17,16 @@
 #    * and the newest one that is available in *both* the
 #      debian stable *and* the latest ubuntu LTS
 #
-# As of the time of writing (2023-03-14), the next (spring) darktable release
-# will happen in 2023-06 ish. By that time:
+# As of the time of writing (2023-10-22), the next (winter) darktable release
+# will happen in 2023-12 ish. By that time:
 # * debian 12 (Bookworm) will have been released,
 #   coming with gcc-12 and LLVM15
 # * Ubuntu 22.04.1 LTS (Jammy Jellyfish) will be the newest LTS,
 #   coming with gcc-12 and LLVM15
-# * macOS 11 (Big Sur) be the oldest supported macOS version,
-#   with the newest supported Xcode version being 13.2 (LLVM12-based !)
+# * macOS 12 (Big Sur) be the oldest supported macOS version,
+#   with the newest supported Xcode version being 14.2 (LLVM14-based !)
 #
-# Therefore, we require GCC12, macOS 11 + Xcode 13.2, and LLVM12.
+# Therefore, we require GCC12, macOS 12 + Xcode 14.2, and LLVM14.
 #
 # The next+1 (fall) darktable release will happen 2023-12 ish,
 # and by that time, macOS 11 will have EOL'd on 2023-10 ish,
@@ -41,21 +41,21 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_L
   message(SEND_ERROR "GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
 
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
-  message(SEND_ERROR "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 14)
+  message(SEND_ERROR "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 14+ is required.")
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
-  message(SEND_ERROR "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
-endif()
-
-# XCode 13.2 (apple clang 1300.0.29.3) is based on LLVM12
-if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 13.0.0.13000029)
-  message(SEND_ERROR "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. XCode version 13.2+ is required.")
-endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0.13000029)
-  message(SEND_ERROR "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. XCode version 13.2+ is required.")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+  message(SEND_ERROR "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 14+ is required.")
 endif()
 
-if(CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 11.3)
-  message(SEND_ERROR "Targeting OSX version ${CMAKE_OSX_DEPLOYMENT_TARGET} older than 11.3 is unsupported.")
+# XCode 14.2 (apple clang 1400.0.29.202) is based on LLVM14
+if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 14.0.0.14000029)
+  message(SEND_ERROR "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. XCode version 14.2+ is required.")
+endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0.0.14000029)
+  message(SEND_ERROR "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. XCode version 14.2+ is required.")
+endif()
+
+if(CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 12.5)
+  message(SEND_ERROR "Targeting OSX version ${CMAKE_OSX_DEPLOYMENT_TARGET} older than 12.5 is unsupported.")
 endif()


### PR DESCRIPTION
While the guidelines say wait until macos 14 is available on github actions, as noted in
https://github.com/darktable-org/darktable/pull/15442 homebrew is already soft-killing macos 11,
so let's just do that now, thus requiring XCode 14.2.

This means LLVM12/LLVM13 are no longer supported, too.