### PR TITLE
Fix OBS GCC14(?) build

### DIFF
--- a/src/librawspeed/io/FileReader.cpp
+++ b/src/librawspeed/io/FileReader.cpp
@@ -53,8 +53,9 @@ FileReader::readFile() {
   size_t fileSize = 0;
 
 #if defined(__unix__) || defined(__APPLE__)
-  using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
-  file_ptr file(fopen(fileName, "rb"), &fclose);
+  auto fclose = [](std::FILE* fp) { std::fclose(fp); };
+  using file_ptr = std::unique_ptr<FILE, decltype(fclose)>;
+  file_ptr file(fopen(fileName, "rb"), fclose);
 
   if (file == nullptr)
     ThrowFIE("Could not open file \"%s\".", fileName);

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -247,10 +247,11 @@ std::string img_hash(const RawImage& r, bool noSamples) {
   return oss.str();
 }
 
-using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
+auto fclose = [](std::FILE* fp) { std::fclose(fp); };
+using file_ptr = std::unique_ptr<FILE, decltype(fclose)>;
 
 void writePPM(const RawImage& raw, const std::string& fn) {
-  file_ptr f(fopen((fn + ".ppm").c_str(), "wb"), &fclose);
+  file_ptr f(fopen((fn + ".ppm").c_str(), "wb"), fclose);
 
   const iPoint2D dimUncropped = raw->getUncroppedDim();
   int width = dimUncropped.x;
@@ -274,7 +275,7 @@ void writePPM(const RawImage& raw, const std::string& fn) {
 }
 
 void writePFM(const RawImage& raw, const std::string& fn) {
-  file_ptr f(fopen((fn + ".pfm").c_str(), "wb"), &fclose);
+  file_ptr f(fopen((fn + ".pfm").c_str(), "wb"), fclose);
 
   const iPoint2D dimUncropped = raw->getUncroppedDim();
   int width = dimUncropped.x;


### PR DESCRIPTION
```
[   34s] /home/abuild/rpmbuild/BUILD/rawspeed-v3.5~git1290.8ffc638/src/librawspeed/io/FileReader.cpp:56:59: error: ignoring attributes on template argument 'int (*)(FILE*)' [-Werror=ignored-attributes]
[   34s]    56 |   using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
[   34s]       |                                                           ^

```