### PR TITLE
Add missing Panasonic ZS200 aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11707,7 +11707,14 @@
 		<Sensor black="142" white="4095"/>
 		<Aliases>
 			<Alias>DC-TZ200</Alias>
+			<Alias>DC-TZ200D</Alias>
+			<Alias>DC-TZ202D</Alias>
+			<Alias>DC-TZ220</Alias>
+			<Alias>DC-TZ220D</Alias>
 			<Alias>DC-ZS200</Alias>
+			<Alias>DC-ZS200D</Alias>
+			<Alias>DC-ZS220</Alias>
+			<Alias>DC-ZS220D</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/15499

Turns out https://github.com/darktable-org/rawspeed/pull/509 was incomplete, aliases also needed to be added to the 3:2 mode...