### PR TITLE
Samsung EK-GN120: re-introduce support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12742,12 +12742,12 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3" supported="no-samples">
+	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3">
 		<ID make="Samsung" model="EK-GN120">Samsung EK-GN120</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="45" y="25" width="-11" height="-29"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12743,7 +12743,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3">
-		<ID make="Samsung" model="EK-GN120">Samsung EK-GN120</ID>
+		<ID make="Samsung" model="EK-GN120">Samsung Galaxy NX</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>


### PR DESCRIPTION
I've uploaded a sample to RPU (but can't see it now on the website?!), but also took the occasion to just fix the cameras.xml - the EK-GN120 is using the same sensor as the NX300, and now the entries are identical.

SRW from the Galaxy NX (EK-GN120) look good in darktable now as well.