### PR TITLE
Apply clang-tidy's `misc-include-cleaner` to headers too...

### DIFF
--- a/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
+++ b/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
@@ -20,11 +20,17 @@
 
 #pragma once
 
+#include "adt/Array1DRef.h"
+#include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
+#include "codes/PrefixCode.h"
 #include "common/RawspeedException.h"
 #include "io/ByteStream.h"
+#include <cassert>
+#include <cstdint>
 #include <optional>
 #include <type_traits>
+#include <vector>
 
 template <typename CodeTag>
 auto getCodeValues(rawspeed::ByteStream& bs, unsigned numEntries) {

--- a/src/librawspeed/adt/AlignedAllocator.h
+++ b/src/librawspeed/adt/AlignedAllocator.h
@@ -25,9 +25,12 @@
 #include "adt/Invariant.h"
 #include "common/Common.h"
 #include "common/RawspeedException.h"
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
+#include <type_traits>
 
 namespace rawspeed {
 

--- a/src/librawspeed/adt/Array1DRef.h
+++ b/src/librawspeed/adt/Array1DRef.h
@@ -23,7 +23,6 @@
 #include "rawspeedconfig.h"
 #include "adt/Invariant.h"
 #include <type_traits>
-#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/adt/BitIterator.h
+++ b/src/librawspeed/adt/BitIterator.h
@@ -22,8 +22,9 @@
 
 #include "adt/Invariant.h"
 #include "common/Common.h"
+#include <cstddef>
 #include <iterator>
-#include <utility>
+#include <type_traits>
 
 namespace rawspeed {
 

--- a/src/librawspeed/adt/CroppedArray1DRef.h
+++ b/src/librawspeed/adt/CroppedArray1DRef.h
@@ -24,7 +24,6 @@
 #include "adt/Array1DRef.h"
 #include "adt/Invariant.h"
 #include <type_traits>
-#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/adt/CroppedArray2DRef.h
+++ b/src/librawspeed/adt/CroppedArray2DRef.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/CroppedArray1DRef.h"
 #include "adt/Invariant.h"

--- a/src/librawspeed/adt/DefaultInitAllocatorAdaptor.h
+++ b/src/librawspeed/adt/DefaultInitAllocatorAdaptor.h
@@ -22,7 +22,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <new>
 #include <type_traits>
 
 namespace rawspeed {

--- a/src/librawspeed/adt/NORangesSet.h
+++ b/src/librawspeed/adt/NORangesSet.h
@@ -26,7 +26,6 @@
 #include <cstddef>
 #include <iterator>
 #include <set> // IWYU pragma: export
-#include <utility>
 
 namespace rawspeed {
 

--- a/src/librawspeed/codes/AbstractPrefixCode.h
+++ b/src/librawspeed/codes/AbstractPrefixCode.h
@@ -20,12 +20,15 @@
 
 #pragma once
 
+#include "rawspeedconfig.h"
 #include "adt/BitIterator.h"
 #include "adt/iterator_range.h"
 #include "common/Common.h"
 #include "decoders/RawDecoderException.h"
+#include <cassert>
 #include <cstdint>
 #include <type_traits>
+#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/codes/AbstractPrefixCodeDecoder.h
+++ b/src/librawspeed/codes/AbstractPrefixCodeDecoder.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "rawspeedconfig.h"
 #include "adt/Invariant.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/PrefixCode.h"
@@ -29,11 +30,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <iterator>
-#include <numeric>
-#include <type_traits>
-#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/codes/BinaryPrefixTree.h
+++ b/src/librawspeed/codes/BinaryPrefixTree.h
@@ -22,6 +22,7 @@
 
 #include "adt/Invariant.h"
 #include "codes/AbstractPrefixCode.h"
+#include <array>
 #include <cassert>
 #include <functional>
 #include <initializer_list> // IWYU pragma: keep

--- a/src/librawspeed/codes/DummyPrefixCodeDecoder.h
+++ b/src/librawspeed/codes/DummyPrefixCodeDecoder.h
@@ -20,15 +20,11 @@
 
 #pragma once
 
+#include "adt/Invariant.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
 #include "codes/PrefixCode.h"
 #include "io/BitStream.h"
-#include <cassert>
-#include <cstdint>
-#include <tuple>
-#include <utility>
-#include <vector>
 
 namespace rawspeed {
 class Buffer;

--- a/src/librawspeed/codes/HuffmanCode.h
+++ b/src/librawspeed/codes/HuffmanCode.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "rawspeedconfig.h"
 #include "adt/Array1DRef.h"
 #include "adt/Invariant.h"
 #include "codes/AbstractPrefixCode.h"
@@ -31,10 +32,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <iterator>
 #include <numeric>
-#include <type_traits>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/codes/PrefixCode.h
+++ b/src/librawspeed/codes/PrefixCode.h
@@ -24,12 +24,7 @@
 #include "decoders/RawDecoderException.h"
 #include <algorithm>
 #include <cassert>
-#include <cstddef>
-#include <cstdint>
 #include <functional>
-#include <iterator>
-#include <numeric>
-#include <type_traits>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/codes/PrefixCodeDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeDecoder.h
@@ -22,7 +22,9 @@
 
 // IWYU pragma: begin_exports
 
+#include "codes/AbstractPrefixCode.h"
 #include "codes/PrefixCodeLUTDecoder.h"
+#include "codes/PrefixCodeLookupDecoder.h"
 // #include "codes/PrefixCodeLookupDecoder.h"
 // #include "codes/PrefixCodeTreeDecoder.h"
 // #include "codes/PrefixCodeVectorDecoder.h"

--- a/src/librawspeed/codes/PrefixCodeLUTDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeLUTDecoder.h
@@ -21,15 +21,15 @@
 
 #pragma once
 
-#include "codes/PrefixCodeLookupDecoder.h"
+#include "adt/Invariant.h"
 #include "common/Common.h"
 #include "decoders/RawDecoderException.h"
 #include "io/BitStream.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 /*

--- a/src/librawspeed/codes/PrefixCodeLookupDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeLookupDecoder.h
@@ -21,13 +21,15 @@
 
 #pragma once
 
+#include "adt/Invariant.h"
 #include "codes/AbstractPrefixCodeDecoder.h"
 #include "codes/HuffmanCode.h"
+#include "codes/PrefixCode.h"
 #include "decoders/RawDecoderException.h"
 #include "io/BitStream.h"
 #include <cassert>
 #include <cstdint>
-#include <memory>
+#include <limits>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/src/librawspeed/codes/PrefixCodeTreeDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeTreeDecoder.h
@@ -21,19 +21,15 @@
 
 #pragma once
 
+#include "adt/Invariant.h"
 #include "codes/AbstractPrefixCodeDecoder.h"
 #include "codes/BinaryPrefixTree.h"
 #include "decoders/RawDecoderException.h"
 #include "io/BitStream.h"
-#include <algorithm>
 #include <cassert>
-#include <initializer_list>
-#include <iterator>
-#include <memory>
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/codes/PrefixCodeVectorDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeVectorDecoder.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
+#include "adt/Invariant.h"
 #include "codes/AbstractPrefixCodeDecoder.h"
 #include "decoders/RawDecoderException.h"
 #include "io/BitStream.h"
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <tuple>

--- a/src/librawspeed/common/DngOpcodes.h
+++ b/src/librawspeed/common/DngOpcodes.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
 #include <utility>

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -41,6 +41,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/common/Spline.h
+++ b/src/librawspeed/common/Spline.h
@@ -25,11 +25,13 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <functional>
 #include <limits>
-#include <memory>
 #include <type_traits>
 #include <vector>
+
+#ifndef NDEBUG
+#include <functional>
+#endif
 
 namespace rawspeed {
 class iPoint2D;

--- a/src/librawspeed/common/XTransPhase.h
+++ b/src/librawspeed/common/XTransPhase.h
@@ -23,14 +23,11 @@
 #include "adt/Array2DRef.h"
 #include "adt/Point.h"
 #include "metadata/ColorFilterArray.h"
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
-#include <iterator>
 #include <optional>
-#include <utility>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decoders/NakedDecoder.h
+++ b/src/librawspeed/decoders/NakedDecoder.h
@@ -25,9 +25,6 @@
 #include "common/RawImage.h"
 #include "decoders/RawDecoder.h"
 #include <cstdint>
-#include <functional>
-#include <map>
-#include <string>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "io/Buffer.h"

--- a/src/librawspeed/decoders/RawDecoderException.h
+++ b/src/librawspeed/decoders/RawDecoderException.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 // IWYU pragma: end_exports

--- a/src/librawspeed/decoders/Rw2Decoder.h
+++ b/src/librawspeed/decoders/Rw2Decoder.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "adt/Point.h"
 #include "common/RawImage.h"
 #include "decoders/AbstractTiffDecoder.h"
 #include "io/Buffer.h"

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
+#include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
-#include "common/RawspeedException.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/AbstractDecompressor.h"
 #include "io/ByteStream.h"

--- a/src/librawspeed/decompressors/Cr2Decompressor.h
+++ b/src/librawspeed/decompressors/Cr2Decompressor.h
@@ -24,14 +24,11 @@
 #include "adt/Invariant.h"
 #include "adt/Point.h"
 #include "adt/iterator_range.h"
-#include "codes/DummyPrefixCodeDecoder.h"
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
-#include "common/RawspeedException.h"
 #include "decoders/RawDecoderException.h"
 #include "io/ByteStream.h"
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/src/librawspeed/decompressors/Cr2DecompressorImpl.h
+++ b/src/librawspeed/decompressors/Cr2DecompressorImpl.h
@@ -20,11 +20,11 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+#include "rawspeedconfig.h"
 #include "adt/Array2DRef.h"
+#include "adt/Invariant.h"
 #include "adt/Point.h"
 #include "adt/iterator_range.h"
-#include "codes/DummyPrefixCodeDecoder.h"
-#include "codes/PrefixCodeLUTDecoder.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/Cr2Decompressor.h"
@@ -36,7 +36,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <initializer_list>
+#include <iterator>
 #include <optional>
 #include <tuple>
 #include <utility>

--- a/src/librawspeed/decompressors/Cr2LJpegDecoder.h
+++ b/src/librawspeed/decompressors/Cr2LJpegDecoder.h
@@ -23,8 +23,6 @@
 
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "decompressors/Cr2Decompressor.h"
-#include <cassert>
-#include <cstdint>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decompressors/DeflateDecompressor.h
+++ b/src/librawspeed/decompressors/DeflateDecompressor.h
@@ -28,7 +28,6 @@
 #include "decompressors/AbstractDecompressor.h"
 #include "io/Buffer.h"
 #include <memory>
-#include <utility>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decompressors/FujiDecompressor.h
+++ b/src/librawspeed/decompressors/FujiDecompressor.h
@@ -22,17 +22,11 @@
 #pragma once
 
 #include "rawspeedconfig.h"
-#include "adt/Array2DRef.h"
 #include "adt/Point.h"
 #include "common/RawImage.h"
 #include "decompressors/AbstractDecompressor.h"
-#include "io/BitPumpMSB.h"
 #include "io/ByteStream.h"
-#include "metadata/ColorFilterArray.h"
-#include <array>
-#include <cassert>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/decompressors/HasselbladDecompressor.h
+++ b/src/librawspeed/decompressors/HasselbladDecompressor.h
@@ -22,24 +22,12 @@
 
 #pragma once
 
-#include "adt/Point.h"
-#include "adt/iterator_range.h"
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
-#include "common/RawspeedException.h"
-#include "decoders/RawDecoderException.h"
 #include "io/BitPumpMSB32.h"
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
-#include <array>
-#include <cassert>
-#include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <iterator>
-#include <tuple>
-#include <utility>
-#include <vector>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "decompressors/AbstractLJpegDecoder.h"
-#include "io/BitPumpMSB32.h"
 
 namespace rawspeed {
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -29,7 +29,7 @@
 #include <cstdint>
 #include <functional>
 #include <stddef.h>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/decompressors/PanasonicV4Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV4Decompressor.h
@@ -25,7 +25,6 @@
 #include "decompressors/AbstractDecompressor.h"
 #include "io/ByteStream.h"
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.h
@@ -28,7 +28,6 @@
 #include "io/ByteStream.h"
 #include <cstddef>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/decompressors/PanasonicV7Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV7Decompressor.h
@@ -25,7 +25,6 @@
 #include "io/ByteStream.h"
 #include <climits>
 #include <cstdint>
-#include <functional>
 
 namespace rawspeed {
 template <class T> class CroppedArray1DRef;

--- a/src/librawspeed/decompressors/PentaxDecompressor.h
+++ b/src/librawspeed/decompressors/PentaxDecompressor.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "codes/AbstractPrefixCode.h"
+#include "codes/HuffmanCode.h"
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
 #include "decompressors/AbstractDecompressor.h"

--- a/src/librawspeed/decompressors/PhaseOneDecompressor.h
+++ b/src/librawspeed/decompressors/PhaseOneDecompressor.h
@@ -25,7 +25,6 @@
 #include "common/RawImage.h"
 #include "decompressors/AbstractDecompressor.h"
 #include "io/ByteStream.h"
-#include <utility>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/decompressors/UncompressedDecompressor.h
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.h
@@ -29,7 +29,6 @@
 #include "io/ByteStream.h"
 #include "io/Endianness.h"
 #include <cstdint>
-#include <utility>
 
 namespace rawspeed {
 

--- a/src/librawspeed/decompressors/VC5Decompressor.h
+++ b/src/librawspeed/decompressors/VC5Decompressor.h
@@ -23,6 +23,7 @@
 
 #include "adt/Array2DRef.h"
 #include "adt/DefaultInitAllocatorAdaptor.h"
+#include "codes/AbstractPrefixCode.h"
 #include "codes/PrefixCodeLUTDecoder.h"
 #include "codes/PrefixCodeVectorDecoder.h"
 #include "common/BayerPhase.h"

--- a/src/librawspeed/io/BitPumpJPEG.h
+++ b/src/librawspeed/io/BitPumpJPEG.h
@@ -20,9 +20,7 @@
 
 #pragma once
 
-#include "common/Common.h"
 #include "io/BitStream.h"
-#include "io/Buffer.h"
 #include "io/Endianness.h"
 #include <algorithm>
 #include <array>

--- a/src/librawspeed/io/BitPumpLSB.h
+++ b/src/librawspeed/io/BitPumpLSB.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "io/BitStream.h"
-#include "io/Buffer.h"
 #include "io/Endianness.h"
 #include <cstdint>
 

--- a/src/librawspeed/io/BitPumpMSB.h
+++ b/src/librawspeed/io/BitPumpMSB.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "io/BitStream.h"
-#include "io/Buffer.h"
 #include "io/Endianness.h"
 #include <cstdint>
 

--- a/src/librawspeed/io/BitPumpMSB16.h
+++ b/src/librawspeed/io/BitPumpMSB16.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "io/BitStream.h"
-#include "io/Buffer.h"
 #include "io/Endianness.h"
 #include <cstdint>
 

--- a/src/librawspeed/io/BitPumpMSB32.h
+++ b/src/librawspeed/io/BitPumpMSB32.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "io/BitStream.h"
-#include "io/Buffer.h"
 #include "io/Endianness.h"
 #include <cstdint>
 

--- a/src/librawspeed/io/BitStream.h
+++ b/src/librawspeed/io/BitStream.h
@@ -27,7 +27,6 @@
 #include "common/Common.h"
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
-#include "io/Endianness.h"
 #include "io/IOException.h"
 #include <algorithm>
 #include <array>

--- a/src/librawspeed/io/Buffer.h
+++ b/src/librawspeed/io/Buffer.h
@@ -21,15 +21,17 @@
 
 #pragma once
 
-#include "AddressSanitizer.h"
+#include "rawspeedconfig.h"
 #include "adt/Invariant.h"
-#include "common/Common.h"
 #include "io/Endianness.h"
 #include "io/IOException.h"
 #include <cassert>
 #include <cstdint>
-#include <memory>
 #include <utility>
+
+#ifndef NDEBUG
+#include "AddressSanitizer.h"
+#endif
 
 namespace rawspeed {
 

--- a/src/librawspeed/io/ByteStream.h
+++ b/src/librawspeed/io/ByteStream.h
@@ -21,15 +21,21 @@
 
 #pragma once
 
-#include "AddressSanitizer.h"
+#include "rawspeedconfig.h"
 #include "adt/Invariant.h"
-#include "common/Common.h"
 #include "io/Buffer.h"
 #include "io/IOException.h"
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <limits>
+#include <string_view>
+
+#ifndef NDEBUG
+#include "AddressSanitizer.h"
+#endif
 
 namespace rawspeed {
 

--- a/src/librawspeed/io/FileIOException.h
+++ b/src/librawspeed/io/FileIOException.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/io/IOException.h
+++ b/src/librawspeed/io/IOException.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 // IWYU pragma: end_exports

--- a/src/librawspeed/metadata/Camera.h
+++ b/src/librawspeed/metadata/Camera.h
@@ -26,7 +26,6 @@
 #include "metadata/BlackArea.h"
 #include "metadata/CameraSensorInfo.h"
 #include "metadata/ColorFilterArray.h"
-#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <map>

--- a/src/librawspeed/metadata/CameraMetadataException.h
+++ b/src/librawspeed/metadata/CameraMetadataException.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 // IWYU pragma: end_exports

--- a/src/librawspeed/metadata/CameraSensorInfo.h
+++ b/src/librawspeed/metadata/CameraSensorInfo.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "rawspeedconfig.h"
-#include <algorithm>
 #include <vector>
 
 namespace rawspeed {

--- a/src/librawspeed/metadata/ColorFilterArray.h
+++ b/src/librawspeed/metadata/ColorFilterArray.h
@@ -22,9 +22,7 @@
 
 #include "rawspeedconfig.h"
 #include "adt/Point.h"
-#include <algorithm>
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
 

--- a/src/librawspeed/parsers/CiffParserException.h
+++ b/src/librawspeed/parsers/CiffParserException.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 #include "parsers/RawParserException.h"

--- a/src/librawspeed/parsers/FiffParserException.h
+++ b/src/librawspeed/parsers/FiffParserException.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 #include "parsers/RawParserException.h"

--- a/src/librawspeed/parsers/RawParserException.h
+++ b/src/librawspeed/parsers/RawParserException.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 // IWYU pragma: end_exports

--- a/src/librawspeed/parsers/TiffParserException.h
+++ b/src/librawspeed/parsers/TiffParserException.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "rawspeedconfig.h"
-
 // IWYU pragma: begin_exports
 #include "common/RawspeedException.h"
 #include "parsers/RawParserException.h"

--- a/src/librawspeed/tiff/TiffEntry.h
+++ b/src/librawspeed/tiff/TiffEntry.h
@@ -26,7 +26,6 @@
 #include "adt/NotARational.h"
 #include "io/ByteStream.h"
 #include "tiff/TiffTag.h"
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <string>

--- a/src/librawspeed/tiff/TiffIFD.h
+++ b/src/librawspeed/tiff/TiffIFD.h
@@ -24,7 +24,6 @@
 
 #include "rawspeedconfig.h"
 #include "adt/NORangesSet.h"
-#include "common/RawspeedException.h"
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include "io/Endianness.h"

--- a/test/librawspeed/adt/RangeTest.h
+++ b/test/librawspeed/adt/RangeTest.h
@@ -22,7 +22,6 @@
 #include <ostream>
 #include <set>
 #include <tuple>
-#include <utility>
 #include <gtest/gtest.h>
 
 using rawspeed::Range;

--- a/test/librawspeed/io/BitPumpTest.h
+++ b/test/librawspeed/io/BitPumpTest.h
@@ -18,15 +18,12 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include "common/Common.h"
-#include "io/BitStream.h"
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include "io/Endianness.h"
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <initializer_list>
 #include <gtest/gtest.h>
 
 using rawspeed::Buffer;


### PR DESCRIPTION
Ok, this is a bit of a PITA, has to be done manually.
```
$ find -iname *.h | xargs -L1 clang-tidy-17 -checks=-*,misc-include-cleaner -p build-Clang17-release/ -fix -fix-errors
```