### PR TITLE
Update cameras.xml with values for Canon EOS 77D

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -733,10 +733,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2048" white="14338"/>
-		<Sensor black="511" white="11892" iso_list="100"/>
-		<Sensor black="511" white="14338" iso_list="200"/>
-		<Sensor black="2037" white="14338" iso_list="51200"/>
+                <Sensor black="2049" white="14338"/>
+                <Sensor black="511" white="11892" iso_list="100 125"/>
+                <Sensor black="511" white="10755" iso_list="160"/>
+                <Sensor black="511" white="14338" iso_list="200 250"/>
+                <Sensor black="2048" white="10755" iso_list="320 640 1250 2500 5000"/>
+                <Sensor black="2041" white="14338" iso_list="51200"/>		
 		<BlackAreas>
 			<Vertical x="0" width="260"/>
 			<Horizontal y="2" height="32"/>


### PR DESCRIPTION
Fixes: https://github.com/darktable-org/darktable/issues/15636

Took pictures at all ISOs (100, 125, 160, 200, 250, 320, 400, 500, 640, 800, 1000, 1250, 1600, 2000, 2500, 3200, 4000, 5000, 6400, 8000, 10000, 12800, 16000, 20000, 25600, 51200), converted them to DNG and processed them with dngmeta.rb to obtain updated values.