### PR TITLE
Attempt to fix XSD validation w/ libxml2 2.12.0

### DIFF
--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -194,10 +194,7 @@
   </xs:simpleType>
   <xs:complexType name="CFA2Type">
     <xs:sequence>
-      <xs:choice>
-        <xs:element type="ColorRowType" name="ColorRow" minOccurs="2" maxOccurs="2"/>
-        <xs:element type="ColorRowType" name="ColorRow" minOccurs="6" maxOccurs="6"/>
-      </xs:choice>
+      <xs:element type="ColorRowType" name="ColorRow" minOccurs="2" maxOccurs="6"/>
     </xs:sequence>
     <xs:attribute type="CFA2TypeWidthType" name="width" use="required"/>
     <xs:attribute type="CFA2TypeHeightType" name="height" use="required"/>


### PR DESCRIPTION
Validation for `CFA2` variant of CFA encoding is rather partial anyways,
but it isn't even legal to try to match the same element as different XSD types...

Fixes #562.