### PR TITLE
Canon IXY 220F support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17716,6 +17716,13 @@
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="RICOH GR IIIx" mode="dng">
 		<ID make="Ricoh" model="GR IIIx">Ricoh GR IIIx</ID>
 	</Camera>
+	<Camera make="Canon" model="Canon IXY 220F" mode="dng">
+		<ID make="Canon" model="IXY 220F">Canon IXY 220F</ID>
+		<Aliases>
+			<Alias id="PowerShot ELPH 110 HS">Canon PowerShot ELPH 110 HS</Alias>
+			<Alias id="IXUS 125 HS">Canon IXUS 125 HS</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="Canon" model="Canon PowerShot A720 IS" mode="dng">
 		<ID make="Canon" model="PowerShot A720 IS">Canon PowerShot A720 IS</ID>
 		<ColorMatrices>
@@ -17996,6 +18003,26 @@
 			<Hint name="full_height" value="1036"/>
 			<Hint name="offset" value="1078"/>
 		</Hints>
+	</Camera>
+	<Camera make="Canon" model="IXY 220F" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="96" y="17" width="-8" height="-1"/>
+		<Sensor black="127" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="25230816"/>
+			<Hint name="full_width" value="4784"/>
+			<Hint name="full_height" value="3516"/>
+		</Hints>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">5307 -1727 -741</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-846 4464 142</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-22 786 1405</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="Canon" model="PowerShot SD300" mode="chdk" supported="no-samples">
 		<CFA2 width="2" height="2">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/15598

See https://global.canon/en/c-museum/product/dcc619.html for regional aliases.

Edit: went for the max crop for the CHDK mode, different/larger than the DNG.