### PR TITLE
NefDecoder: refactor linearization curve detection

### DIFF
--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -115,7 +115,12 @@ RawImage NefDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
 
-  raw = mRootIFD->getIFDWithTag(static_cast<TiffTag>(0x8c));
+  auto ifds = mRootIFD->getIFDsWithTag(static_cast<TiffTag>(0x96));
+  if (ifds.empty()) {
+    raw = mRootIFD->getIFDWithTag(static_cast<TiffTag>(0x8c)); // Fall back
+  } else {
+    raw = ifds.front();
+  }
 
   const TiffEntry* meta;
   if (raw->hasEntry(static_cast<TiffTag>(0x96))) {

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -115,18 +115,13 @@ RawImage NefDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
 
-  auto ifds = mRootIFD->getIFDsWithTag(static_cast<TiffTag>(0x96));
-  if (ifds.empty()) {
-    raw = mRootIFD->getIFDWithTag(static_cast<TiffTag>(0x8c)); // Fall back
-  } else {
-    raw = ifds.front();
-  }
-
-  const TiffEntry* meta;
-  if (raw->hasEntry(static_cast<TiffTag>(0x96))) {
-    meta = raw->getEntry(static_cast<TiffTag>(0x96));
-  } else {
-    meta = raw->getEntry(static_cast<TiffTag>(0x8c)); // Fall back
+  const TiffEntry* meta =
+      mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x96));
+  if (!meta) {
+    meta = mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x8c)); // Fall back
+    if (!meta) {
+      ThrowRDE("Missing linearization table.");
+    }
   }
 
   ByteStream rawData(

--- a/src/librawspeed/tiff/TiffIFD.cpp
+++ b/src/librawspeed/tiff/TiffIFD.cpp
@@ -230,7 +230,7 @@ std::vector<const TiffIFD*> TiffIFD::getIFDsWithTag(TiffTag tag) const {
 const TiffIFD* TiffIFD::getIFDWithTag(TiffTag tag, uint32_t index) const {
   auto ifds = getIFDsWithTag(tag);
   if (index >= ifds.size())
-    ThrowTPE("failed to find %u ifs with tag 0x%04x", index + 1,
+    ThrowTPE("failed to find %u ifd with tag 0x%04x", index + 1,
              static_cast<unsigned>(tag));
   return ifds[index];
 }


### PR DESCRIPTION
Avoids throwing exception when only the tag 0x96 exists.

For an example see https://github.com/darktable-org/darktable/issues/15562#issuecomment-1824526754

This is again related to https://github.com/darktable-org/darktable/issues/5149