### PR TITLE
Update cameras.xml with values for Canon EOS 550D

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -789,8 +789,8 @@
 			<Color x="0" y="1">RED</Color>
 		</CFA>
 		<Crop x="148" y="54" width="0" height="0"/>
-		<Sensor black="2048" white="13583" iso_min="0" iso_max="199"/>
-		<Sensor black="2048" white="15831"/>
+		<Sensor black="2054" white="15000"/>
+		<Sensor black="2048" white="13926" iso_list="100"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="44"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -789,6 +789,7 @@
 			<Color x="0" y="1">RED</Color>
 		</CFA>
 		<Crop x="148" y="54" width="0" height="0"/>
+		<Sensor black="2048" white="13583" iso_min="0" iso_max="199"/>
 		<Sensor black="2048" white="15831"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>


### PR DESCRIPTION
The white point value for the Canon EOS 550D/T2i/Kiss X4 when the image is below 200 ISO is missing, resulting in blown highlights.  A sample raw image shot on my 550D where this issue can be seen is [here](https://www.dropbox.com/scl/fi/x0tcx2ndsjyskjbn5k4rk/IMG_4790.CR2?rlkey=jncgok4v2zyln53gl1lfi4p8y&dl=0).

This PR sets the white point for this camera to 13583 when below 200 ISO.