### PR TITLE
LJpeg: "ban" point transform

### DIFF
--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
@@ -218,6 +218,8 @@ void AbstractLJpegDecoder::parseSOS(ByteStream sos) {
   Pt = sos.getByte(); // Point Transform
   if (Pt > 15)
     ThrowRDE("Invalid Point transform.");
+  if (Pt != 0)
+    ThrowRDE("Point transform not supported.");
 
   decodeScan();
 }


### PR DESCRIPTION
I was looking at the blac/white level reading for CR2, and that apparently requires scaling said levels with the frame precision, and then i have noticed the point transform,
and that we apparently never (as of RPU sample set at least) encounter the case where it's actually active.

Looking at the spec, the thing that gives me a pause is whether the change to the initial predictor all that is to it, or do we need to also scale the decoded data?

Until such case is hit, let's single it out.