### PR TITLE
CR2: read black/white levels from Makernotes

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -380,7 +380,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="22" y="18" width="4290" height="2856"/>
-		<Sensor black="1020" white="14500"/>
 		<Aliases>
 			<Alias id="Digital Rebel XSi">Canon EOS DIGITAL REBEL XSi</Alias>
 			<Alias id="Kiss Digital X2">Canon EOS Kiss Digital X2</Alias>
@@ -1395,8 +1394,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="42" y="18" width="3906" height="2602"/>
-		<Sensor black="255" white="3650" iso_min="0" iso_max="199"/>
-		<Sensor black="255" white="4036"/>
 		<BlackAreas>
 			<Vertical x="0" width="41"/>
 			<Horizontal y="2" height="14"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -402,7 +402,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="64" y="52" width="4752" height="3158"/>
-		<Sensor black="1020" white="13653"/>
 		<BlackAreas>
 			<Vertical x="0" width="60"/>
 			<Horizontal y="2" height="46"/>
@@ -418,7 +417,6 @@
 	<Camera make="Canon" model="Canon EOS 50D" mode="sRaw1">
 		<ID make="Canon" model="EOS 50D">Canon EOS 50D</ID>
 		<Crop x="0" y="0" width="3272" height="2178"/>
-		<Sensor black="0" white="13250"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">4920 616 -593</ColorMatrixRow>
@@ -430,7 +428,6 @@
 	<Camera make="Canon" model="Canon EOS 50D" mode="sRaw2">
 		<ID make="Canon" model="EOS 50D">Canon EOS 50D</ID>
 		<Crop x="0" y="0" width="2376" height="1584"/>
-		<Sensor black="0" white="13250"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">4920 616 -593</ColorMatrixRow>
@@ -885,8 +882,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="158" y="51" width="5634" height="3753"/>
-		<Sensor black="1024" white="12995" iso_list="160 320 640 1250"/>
-		<Sensor black="1024" white="15950"/>
 		<BlackAreas>
 			<Vertical x="0" width="156"/>
 			<Horizontal y="2" height="48"/>
@@ -902,8 +897,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark II" mode="sRaw1">
 		<ID make="Canon" model="EOS 5D Mark II">Canon EOS 5D Mark II</ID>
 		<Crop x="0" y="0" width="3872" height="2574"/>
-		<Sensor black="0" white="14300" iso_list="160 320 640 1250"/>
-		<Sensor black="0" white="16237"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">4716 603 -830</ColorMatrixRow>
@@ -915,8 +908,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark II" mode="sRaw2">
 		<ID make="Canon" model="EOS 5D Mark II">Canon EOS 5D Mark II</ID>
 		<Crop x="0" y="0" width="2808" height="1872"/>
-		<Sensor black="0" white="14300" iso_list="160 320 640 1250"/>
-		<Sensor black="0" white="16237"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">4716 603 -830</ColorMatrixRow>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1608,7 +1608,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="34" width="0" height="0"/>
-		<Sensor black="2048" white="16000"/>
 		<BlackAreas>
 			<Vertical x="2" width="68"/>
 			<Horizontal y="2" height="30"/>
@@ -1672,7 +1671,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="52" width="0" height="-2"/>
-		<Sensor black="2048" white="16000"/>
 		<BlackAreas>
 			<Vertical x="2" width="68"/>
 			<Horizontal y="2" height="40"/>
@@ -2199,7 +2197,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="17" width="0" height="0"/>
-		<Sensor black="2047" white="16000"/>
 		<BlackAreas>
 			<Vertical x="0" width="90"/>
 			<Horizontal y="0" height="16"/>
@@ -2243,7 +2240,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="17" width="0" height="0"/>
-		<Sensor black="2047" white="16000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">9602 -3823 -937</ColorMatrixRow>
@@ -2287,7 +2283,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="18" width="0" height="0"/>
-		<Sensor black="511" white="4000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">9602 -3823 -937</ColorMatrixRow>
@@ -2326,7 +2321,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="82" y="52" width="-14" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<BlackAreas>
 			<Vertical x="0" width="68"/>
 			<Horizontal y="0" height="46"/>
@@ -2348,7 +2342,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="82" y="52" width="-14" height="0"/>
-		<Sensor black="0" white="16000"/>
 		<BlackAreas>
 			<Vertical x="0" width="68"/>
 			<Horizontal y="0" height="46"/>
@@ -2387,7 +2380,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="54" y="14" width="-12" height="-18"/>
-		<Sensor black="120" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="50"/>
 			<Horizontal y="0" height="10"/>
@@ -2409,7 +2401,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="10" y="18" width="-56" height="-14"/>
-		<Sensor black="120" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="10"/>
 			<Vertical x="3696" width="48"/>
@@ -2433,7 +2424,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="12" y="13" width="4432" height="3323"/>
-		<Sensor black="128" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="10"/>
 			<Horizontal y="0" height="8"/>
@@ -2477,7 +2467,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="18" width="0" height="0"/>
-		<Sensor black="2047" white="16000"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="0" height="10"/>
@@ -2520,8 +2509,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="106" y="12" width="-10" height="-66"/>
-		<Sensor black="500" white="2800" iso_min="12800" iso_max="12800"/>
-		<Sensor black="128" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="100"/>
 			<Horizontal y="3062" height="60"/>
@@ -2543,7 +2530,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="18" width="-24" height="0"/>
-		<Sensor black="0" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="80"/>
 			<Horizontal y="0" height="16"/>
@@ -2565,7 +2551,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="192" y="12" width="3958" height="2760"/>
-		<Sensor black="125" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="188"/>
 			<Horizontal y="0" height="10"/>
@@ -2731,7 +2716,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="10" y="18" width="-54" height="-10"/>
-		<Sensor black="125" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="6"/>
 			<Horizontal y="0" height="14"/>
@@ -2753,7 +2737,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="66" y="24" width="-20" height="-24"/>
-		<Sensor black="125" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="50"/>
 			<Vertical x="3738" width="6"/>
@@ -2777,7 +2760,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="104" y="12" width="-10" height="-66"/>
-		<Sensor black="125" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="100"/>
 			<Horizontal y="0" height="10"/>
@@ -2800,8 +2782,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="106" y="12" width="-10" height="-66"/>
-		<Sensor black="500" white="3072" iso_min="12800" iso_max="12800"/>
-		<Sensor black="128" white="4095"/>
 		<BlackAreas>
 			<Vertical x="0" width="100"/>
 			<Horizontal y="3062" height="60"/>
@@ -2823,7 +2803,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="121" y="30" width="-47" height="-14"/>
-		<Sensor black="0" white="4000"/>
 		<BlackAreas>
 			<Vertical x="0" width="74"/>
 			<Horizontal y="0" height="12"/>
@@ -2845,7 +2824,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="100" y="20" width="-10" height="0"/>
-		<Sensor black="127" white="4095"/>
 		<BlackAreas>
 			<Vertical x="6" width="70"/>
 			<Horizontal y="0" height="16"/>
@@ -2867,7 +2845,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="112" y="26" width="-24" height="-10"/>
-		<Sensor black="128" white="4000"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="0" height="16"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -103,12 +103,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="52" width="0" height="0"/>
-		<Sensor black="2048" white="15000"/>
-		<Sensor black="2047" white="12277" iso_list="100"/>
-		<Sensor black="2047" white="15000" iso_list="200 6400"/>
-		<Sensor black="2048" white="15000" iso_list="800 3200"/>
-		<Sensor black="2049" white="15000" iso_list="1600"/>
-		<Sensor black="2046" white="15000" iso_list="25600"/>
 		<BlackAreas>
 			<Vertical x="0" width="72"/>
 			<Horizontal y="8" height="44"/>
@@ -488,9 +482,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="38" width="0" height="0"/>
-		<Sensor black="2026" white="13653" iso_min="0" iso_max="199"/>
-		<Sensor black="2026" white="16383" iso_min="6400" iso_max="25600"/>
-		<Sensor black="2026" white="15387"/>
 		<BlackAreas>
 			<Vertical x="0" width="72"/>
 			<Horizontal y="0" height="38"/>
@@ -506,7 +497,6 @@
 	<Camera make="Canon" model="Canon EOS 70D" mode="sRaw1">
 		<ID make="Canon" model="EOS 70D">Canon EOS 70D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13250"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -522,7 +512,6 @@
 	<Camera make="Canon" model="Canon EOS 70D" mode="sRaw2">
 		<ID make="Canon" model="EOS 70D">Canon EOS 70D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13250"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -617,9 +606,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="76" y="60" width="-6" height="-6"/>
-		<Sensor black="2052" white="15000"/>
-		<Sensor black="2048" white="12277" iso_list="100"/>
-		<Sensor black="2048" white="11222" iso_list="160 320 640 1250 2500 5000"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="50"/>
@@ -825,8 +811,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="76" y="56" width="0" height="0"/>
-		<Sensor black="2026" white="13584" iso_min="0" iso_max="199"/>
-		<Sensor black="2026" white="15304"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="44"/>
@@ -917,12 +901,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="124" y="82" width="-2" height="0"/>
-		<Sensor black="2060" white="16383"/>
-		<Sensor black="2060" white="15700" iso_list="400 500 1600"/>
-		<Sensor black="2060" white="15200" iso_list="100 125 200 250 800 2000"/>
-		<Sensor black="2060" white="15100" iso_list="2500 10000"/>
-		<Sensor black="2060" white="13700" iso_list="160 320 1250"/>
-		<Sensor black="2060" white="14200" iso_list="640 5000"/>
 		<BlackAreas>
 			<Vertical x="0" width="120"/>
 			<Horizontal y="2" height="78"/>
@@ -938,10 +916,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark III" mode="sRaw1">
 		<ID make="Canon" model="EOS 5D Mark III">Canon EOS 5D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="11028" iso_list="160 320 640 1250 2500 5000 10000"/>
-		<Sensor black="0" white="12575" iso_list="100 20000"/>
-		<Sensor black="0" white="13782" iso_list="25600 51200 102400"/>
-		<Sensor black="0" white="13305"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -957,10 +931,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark III" mode="sRaw2">
 		<ID make="Canon" model="EOS 5D Mark III">Canon EOS 5D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="11028" iso_list="160 320 640 1250 2500 5000 10000"/>
-		<Sensor black="0" white="12825" iso_list="250"/>
-		<Sensor black="0" white="13757" iso_list="25600 51200 102400"/>
-		<Sensor black="0" white="13250"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1155,12 +1125,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="74" y="40" width="0" height="-2"/>
-		<Sensor black="2048" white="15000"/>
-		<Sensor black="2047" white="15000" iso_list="50 100 125 200 250 16000"/>
-		<Sensor black="2047" white="13100" iso_list="160"/>
-		<Sensor black="2047" white="13000" iso_list="320"/>
-		<Sensor black="2048" white="13000" iso_list="640 1250 2500 5000 10000 20000"/>
-		<Sensor black="2048" white="16000" iso_list="51200 102400"/>
 		<BlackAreas>
 			<Vertical x="0" width="68"/>
 			<Horizontal y="2" height="36"/>
@@ -1176,7 +1140,6 @@
 	<Camera make="Canon" model="Canon EOS 6D" mode="sRaw1" decoder_version="3">
 		<ID make="Canon" model="EOS 6D">Canon EOS 6D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="12166"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1192,7 +1155,6 @@
 	<Camera make="Canon" model="Canon EOS 6D" mode="sRaw2">
 		<ID make="Canon" model="EOS 6D">Canon EOS 6D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="12166"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1558,8 +1520,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="76" y="56" width="0" height="0"/>
-		<Sensor black="2026" white="13584" iso_min="0" iso_max="199"/>
-		<Sensor black="2026" white="15304"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="44"/>
@@ -1581,8 +1541,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="52" width="0" height="0"/>
-		<Sensor black="2026" white="13584" iso_min="0" iso_max="199"/>
-		<Sensor black="2026" white="15304"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="44"/>
@@ -1971,7 +1929,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="128" y="102" width="0" height="-2"/>
-		<Sensor black="2050" white="15100"/>
 		<BlackAreas>
 			<Vertical x="0" width="120"/>
 			<Horizontal y="0" height="98"/>
@@ -1987,7 +1944,6 @@
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw1">
 		<ID make="Canon" model="EOS-1D X">Canon EOS-1D X</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -2003,7 +1959,6 @@
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw2">
 		<ID make="Canon" model="EOS-1D X">Canon EOS-1D X</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1971,7 +1971,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="62" y="20" width="5640" height="3752"/>
-		<Sensor black="1021" white="15100"/>
 		<BlackAreas>
 			<Vertical x="0" width="60"/>
 			<Horizontal y="4" height="14"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -128,10 +128,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2049" white="14338"/>
-		<Sensor black="511" white="11892" iso_list="100"/>
-		<Sensor black="511" white="14338" iso_list="200"/>
-		<Sensor black="2041" white="14338" iso_list="51200"/>
 		<BlackAreas>
 			<Vertical x="0" width="260"/>
 			<Horizontal y="0" height="38"/>
@@ -630,9 +626,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2049" white="14338"/>
-		<Sensor black="511" white="11892" iso_list="100"/>
-		<Sensor black="511" white="14338" iso_list="200"/>
 		<BlackAreas>
 			<Vertical x="0" width="260"/>
 			<Horizontal y="2" height="36"/>
@@ -680,12 +673,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2049" white="14338"/>
-		<Sensor black="511" white="11892" iso_list="100 125"/>
-		<Sensor black="511" white="10755" iso_list="160"/>
-		<Sensor black="511" white="14338" iso_list="200 250"/>
-		<Sensor black="2048" white="10755" iso_list="320 640 1250 2500 5000"/>
-		<Sensor black="2041" white="14338" iso_list="51200"/>
 		<BlackAreas>
 			<Vertical x="0" width="260"/>
 			<Horizontal y="2" height="32"/>
@@ -1130,10 +1117,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="128" y="52" width="-4" height="-4"/>
-		<Sensor black="2049" white="14558"/>
-		<Sensor black="513" white="14558" iso_list="50 100 125 200 250"/>
-		<Sensor black="513" white="11301" iso_list="160"/>
-		<Sensor black="2049" white="11301" iso_list="320 640 1250 2500 5000 10000"/>
 		<BlackAreas>
 			<Vertical x="2" width="116"/>
 			<Horizontal y="8" height="32"/>
@@ -1149,7 +1132,6 @@
 	<Camera make="Canon" model="Canon EOS 6D Mark II" mode="sRaw1" decoder_version="9">
 		<ID make="Canon" model="EOS 6D Mark II">Canon EOS 6D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1165,7 +1147,6 @@
 	<Camera make="Canon" model="Canon EOS 6D Mark II" mode="sRaw2" decoder_version="9">
 		<ID make="Canon" model="EOS 6D Mark II">Canon EOS 6D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1357,10 +1338,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="146" y="54" width="0" height="0"/>
-		<Sensor black="2048" white="15000"/>
-		<Sensor black="2046" white="12279" iso_list="100"/>
-		<Sensor black="2046" white="15000" iso_list="200"/>
-		<Sensor black="2047" white="15000" iso_list="3200"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="44"/>
@@ -1386,8 +1363,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="78" y="42" width="-4" height="-6"/>
-		<Sensor black="2048" white="15092"/>
-		<Sensor black="2048" white="12277" iso_list="100"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="30"/>
@@ -1414,8 +1389,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="146" y="56" width="0" height="0"/>
-		<Sensor black="2051" white="15000"/>
-		<Sensor black="2046" white="12279" iso_list="100"/>
 		<BlackAreas>
 			<Vertical x="0" width="130"/>
 			<Horizontal y="4" height="40"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -753,7 +753,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="62" y="30" width="4722" height="3142"/>
-		<Sensor black="1020" white="16000"/>
 		<BlackAreas>
 			<Vertical x="0" width="56"/>
 			<Horizontal y="2" height="22"/>
@@ -779,8 +778,6 @@
 			<Color x="0" y="1">RED</Color>
 		</CFA>
 		<Crop x="148" y="54" width="0" height="0"/>
-		<Sensor black="2054" white="15000"/>
-		<Sensor black="2048" white="13926" iso_list="100"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="44"/>
@@ -1279,9 +1276,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="158" y="52" width="5202" height="3464"/>
-		<Sensor black="2049" white="15400"/>
-		<Sensor black="2048" white="13600" iso_list="100 125"/>
-		<Sensor black="2048" white="12600" iso_list="160 320 640 1250 2500"/>
 		<BlackAreas>
 			<Vertical x="8" width="156"/>
 			<Horizontal y="32" height="18"/>
@@ -1297,7 +1291,6 @@
 	<Camera make="Canon" model="Canon EOS 7D" mode="sRaw1">
 		<ID make="Canon" model="EOS 7D">Canon EOS 7D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="7500"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6844 -996 -856</ColorMatrixRow>
@@ -1309,7 +1302,6 @@
 	<Camera make="Canon" model="Canon EOS 7D" mode="sRaw2">
 		<ID make="Canon" model="EOS 7D">Canon EOS 7D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="7500"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6844 -996 -856</ColorMatrixRow>
@@ -1891,7 +1883,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="144" y="46" width="-64" height="-2"/>
-		<Sensor black="2000" white="13000"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="26" height="16"/>
@@ -1907,7 +1898,6 @@
 	<Camera make="Canon" model="Canon EOS-1D Mark IV" mode="sRaw1">
 		<ID make="Canon" model="EOS-1D Mark IV">Canon EOS-1D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6014 -220 -795</ColorMatrixRow>
@@ -1919,7 +1909,6 @@
 	<Camera make="Canon" model="Canon EOS-1D Mark IV" mode="sRaw2">
 		<ID make="Canon" model="EOS-1D Mark IV">Canon EOS-1D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6014 -220 -795</ColorMatrixRow>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -445,7 +445,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="146" y="54" width="0" height="0"/>
-		<Sensor black="2026" white="14200"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="46"/>
@@ -461,7 +460,6 @@
 	<Camera make="Canon" model="Canon EOS 60D" mode="sRaw1">
 		<ID make="Canon" model="EOS 60D">Canon EOS 60D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6719 -994 -925</ColorMatrixRow>
@@ -473,7 +471,6 @@
 	<Camera make="Canon" model="Canon EOS 60D" mode="sRaw2">
 		<ID make="Canon" model="EOS 60D">Canon EOS 60D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">6719 -994 -925</ColorMatrixRow>
@@ -1403,7 +1400,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="64" y="20" width="0" height="0"/>
-		<Sensor black="2036" white="15500"/>
 		<BlackAreas>
 			<Vertical x="0" width="58"/>
 			<Horizontal y="4" height="12"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1007,8 +1007,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="164" y="72" width="-6" height="-8"/>
-		<Sensor black="2048" white="15181"/>
-		<Sensor black="2048" white="14466" iso_list="50 100"/>
 		<BlackAreas>
 			<Vertical x="0" width="150"/>
 			<Horizontal y="40" height="60"/>
@@ -1024,8 +1022,6 @@
 	<Camera make="Canon" model="Canon EOS 5DS" mode="sRaw1" decoder_version="6">
 		<ID make="Canon" model="EOS 5DS">Canon EOS 5DS</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13000"/>
-		<Sensor black="0" white="11500" iso_list="50"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1041,8 +1037,6 @@
 	<Camera make="Canon" model="Canon EOS 5DS" mode="sRaw2" decoder_version="6">
 		<ID make="Canon" model="EOS 5DS">Canon EOS 5DS</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13000"/>
-		<Sensor black="0" white="11500" iso_list="50"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1064,8 +1058,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="164" y="72" width="-6" height="-8"/>
-		<Sensor black="2048" white="15181"/>
-		<Sensor black="2048" white="14466" iso_list="50 100"/>
 		<BlackAreas>
 			<Vertical x="0" width="150"/>
 			<Horizontal y="40" height="60"/>
@@ -1081,8 +1073,6 @@
 	<Camera make="Canon" model="Canon EOS 5DS R" mode="sRaw1" decoder_version="6">
 		<ID make="Canon" model="EOS 5DS R">Canon EOS 5DS R</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13000"/>
-		<Sensor black="0" white="11500" iso_list="50"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1098,8 +1088,6 @@
 	<Camera make="Canon" model="Canon EOS 5DS R" mode="sRaw2" decoder_version="6">
 		<ID make="Canon" model="EOS 5DS R">Canon EOS 5DS R</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="13000"/>
-		<Sensor black="0" white="11500" iso_list="50"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -318,7 +318,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="30" y="18" width="3908" height="2602"/>
-		<Sensor black="1021" white="13600"/>
 		<BlackAreas>
 			<Vertical x="0" width="28"/>
 			<Horizontal y="4" height="12"/>
@@ -334,7 +333,6 @@
 	<Camera make="Canon" model="Canon EOS 40D" mode="sRaw1">
 		<ID make="Canon" model="EOS 40D">Canon EOS 40D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_40d" value=""/>
 		</Hints>
@@ -349,7 +347,6 @@
 	<Camera make="Canon" model="Canon EOS 40D" mode="sRaw2">
 		<ID make="Canon" model="EOS 40D">Canon EOS 40D</ID>
 		<Crop x="0" y="0" width="1944" height="1296"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_40d" value=""/>
 		</Hints>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -631,8 +631,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="34" width="0" height="0"/>
-		<Sensor black="2047" white="11765" iso_min="0" iso_max="199"/>
-		<Sensor black="2047" white="14580"/>
 		<Aliases>
 			<Alias id="EOS Rebel T6i">Canon EOS Rebel T6i</Alias>
 			<Alias id="EOS Kiss X8i">Canon EOS Kiss X8i</Alias>
@@ -683,8 +681,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="34" width="0" height="0"/>
-		<Sensor black="2047" white="11765" iso_min="0" iso_max="199"/>
-		<Sensor black="2047" white="14580"/>
 		<Aliases>
 			<Alias id="EOS Rebel T6s">Canon EOS Rebel T6s</Alias>
 			<Alias id="EOS 8000D">Canon EOS 8000D</Alias>
@@ -1276,11 +1272,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="38" width="0" height="0"/>
-		<Sensor black="2048" white="15100"/>
-		<Sensor black="2047" white="13400" iso_list="100 125"/>
-		<Sensor black="2048" white="12400" iso_list="160 320 640 1250 2500 5000"/>
-		<Sensor black="2047" white="15300" iso_list="10000 12800 16000 25600"/>
-		<Sensor black="2040" white="16000" iso_list="51200"/>
 		<BlackAreas>
 			<Vertical x="4" width="64"/>
 			<Horizontal y="24" height="8"/>
@@ -1296,7 +1287,6 @@
 	<Camera make="Canon" model="Canon EOS 7D Mark II" mode="sRaw1">
 		<ID make="Canon" model="EOS 7D Mark II">Canon EOS 7D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="7500"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1312,7 +1302,6 @@
 	<Camera make="Canon" model="Canon EOS 7D Mark II" mode="sRaw2">
 		<ID make="Canon" model="EOS 7D Mark II">Canon EOS 7D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="7500"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -533,14 +533,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-8" height="-4"/>
-		<Sensor black="512" white="11892" iso_list="100 125"/>
-		<Sensor black="512" white="10749" iso_list="160"/>
-		<Sensor black="511" white="14338" iso_list="200 250"/>
-		<Sensor black="2048" white="10749" iso_list="320 640 1250 2500 5000"/>
-		<Sensor black="2048" white="14338" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 16000"/>
-		<Sensor black="2046" white="14338" iso_list="8000 25600"/>
-		<Sensor black="2045" white="14338" iso_list="10000"/>
-		<Sensor black="2049" white="14338" iso_list="12800"/>
 		<BlackAreas>
 			<Vertical x="0" width="263"/>
 			<Horizontal y="0" height="33"/>
@@ -556,11 +548,6 @@
 	<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" decoder_version="8">
 		<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 		<Crop x="28" y="10" width="0" height="0"/>
-		<Sensor black="0" white="12204" iso_list="320 640 1250 2500 5000"/>
-		<Sensor black="0" white="12984" iso_list="160"/>
-		<Sensor black="0" white="13920" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
-		<Sensor black="0" white="13922" iso_list="8000 10000"/>
-		<Sensor black="0" white="14708" iso_list="100 125 200 250"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -576,15 +563,6 @@
 	<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2" decoder_version="7">
 		<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="12117" iso_list="2500"/>
-		<Sensor black="0" white="12122" iso_list="1250"/>
-		<Sensor black="0" white="12123" iso_list="320"/>
-		<Sensor black="0" white="12124" iso_list="640"/>
-		<Sensor black="0" white="12147" iso_list="5000"/>
-		<Sensor black="0" white="12983" iso_list="160"/>
-		<Sensor black="0" white="13920" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
-		<Sensor black="0" white="13922" iso_list="8000 10000"/>
-		<Sensor black="0" white="14708" iso_list="100 125 200 250"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -948,12 +926,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="136" y="44" width="0" height="0"/>
-		<Sensor black="2049" white="14448"/>
-		<Sensor black="513" white="14008" iso_list="50 100 125"/>
-		<Sensor black="512" white="10838" iso_list="160"/>
-		<Sensor black="512" white="14448" iso_list="200 250"/>
-		<Sensor black="2048" white="10838" iso_list="320 640 1250 2500 5000 10000 20000"/>
-		<Sensor black="2049" white="13533" iso_list="102400"/>
 		<BlackAreas>
 			<Vertical x="0" width="134"/>
 			<Horizontal y="0" height="40"/>
@@ -969,7 +941,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark IV" mode="sRaw1">
 		<ID make="Canon" model="EOS 5D Mark IV">Canon EOS 5D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="14008"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -985,7 +956,6 @@
 	<Camera make="Canon" model="Canon EOS 5D Mark IV" mode="sRaw2">
 		<ID make="Canon" model="EOS 5D Mark IV">Canon EOS 5D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="14008"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1957,13 +1927,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="74" y="40" width="-2" height="0"/>
-		<Sensor black="2048" white="14888"/>
-		<Sensor black="512" white="13898" iso_list="50 100"/>
-		<Sensor black="512" white="14888" iso_list="125 160 200 250"/>
-		<Sensor black="2049" white="14888" iso_list="1600 2500 51200"/>
-		<Sensor black="2050" white="13533" iso_list="102400"/>
-		<Sensor black="2048" white="13533" iso_list="204800"/>
-		<Sensor black="2049" white="13533" iso_list="409600"/>
 		<BlackAreas>
 			<Vertical x="0" width="68"/>
 			<Horizontal y="0" height="36"/>
@@ -1979,7 +1942,6 @@
 	<Camera make="Canon" model="Canon EOS-1D X Mark II" mode="sRaw1">
 		<ID make="Canon" model="EOS-1D X Mark II">Canon EOS-1D X Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>
@@ -1995,7 +1957,6 @@
 	<Camera make="Canon" model="Canon EOS-1D X Mark II" mode="sRaw2">
 		<ID make="Canon" model="EOS-1D X Mark II">Canon EOS-1D X Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
 		<Hints>
 			<Hint name="sraw_new" value=""/>
 			<Hint name="invert_sraw_wb" value=""/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1630,10 +1630,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="38" width="0" height="0"/>
-		<Sensor black="2048" white="16000"/>
-		<Sensor black="512" white="16000" iso_list="100 125 200 250"/>
-		<Sensor black="512" white="13200" iso_list="160"/>
-		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000"/>
 		<BlackAreas>
 			<Vertical x="4" width="260"/>
 			<Horizontal y="4" height="30"/>
@@ -1655,10 +1651,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2048" white="16000"/>
-		<Sensor black="512" white="16000" iso_list="100 125 200 250"/>
-		<Sensor black="512" white="13200" iso_list="160"/>
-		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000"/>
 		<BlackAreas>
 			<Vertical x="4" width="260"/>
 			<Horizontal y="4" height="30"/>
@@ -1702,10 +1694,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2048" white="16000"/>
-		<Sensor black="512" white="16000" iso_list="100 125 200 250"/>
-		<Sensor black="512" white="13200" iso_list="160"/>
-		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000"/>
 		<BlackAreas>
 			<Vertical x="4" width="260"/>
 			<Horizontal y="4" height="30"/>
@@ -2317,11 +2305,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="96" y="22" width="0" height="0"/>
-		<Sensor black="2047" white="16000"/>
-		<Sensor black="2046" white="16000" iso_list="1600 2000 2500"/>
-		<Sensor black="2048" white="16000" iso_list="3200 4000"/>
-		<Sensor black="2049" white="16000" iso_list="5000 6400 8000"/>
-		<Sensor black="2050" white="16000" iso_list="10000 12800"/>
 		<BlackAreas>
 			<Vertical x="0" width="76"/>
 			<Horizontal y="0" height="14"/>
@@ -2387,10 +2370,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="266" y="42" width="-6" height="-4"/>
-		<Sensor black="2048" white="16000"/>
-		<Sensor black="512" white="16000" iso_list="100 125 200 250"/>
-		<Sensor black="512" white="13200" iso_list="160"/>
-		<Sensor black="2048" white="13200" iso_list="320 640 1250 2500 5000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">8532 -701 -1167</ColorMatrixRow>
@@ -2520,7 +2499,6 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="104" y="22" width="-6" height="-6"/>
-		<Sensor black="2048" white="16000"/>
 		<BlackAreas>
 			<Vertical x="0" width="76"/>
 			<Horizontal y="0" height="14"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -800,8 +800,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="146" y="54" width="0" height="0"/>
-		<Sensor black="2026" white="13584" iso_min="0" iso_max="199"/>
-		<Sensor black="2026" white="15304"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="44"/>
@@ -1425,8 +1423,6 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="146" y="54" width="0" height="0"/>
-		<Sensor black="2046" white="12279" iso_min="0" iso_max="199"/>
-		<Sensor black="2046" white="15000"/>
 		<BlackAreas>
 			<Vertical x="0" width="140"/>
 			<Horizontal y="4" height="44"/>

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -360,8 +360,8 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
   case ColorData8:
     switch (colorDataVersion) {
     case 12:
-      return {{778, 783}};
     case 13:
+      return {{778, 783}};
     case 14:
     case 15:
       return std::nullopt;

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -313,6 +313,8 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case 4:
     case 5:
       return {{692, 697}};
+    case 6:
+      return {{715, 720}};
     default:
       return std::nullopt; // FIXME
     }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -314,6 +314,7 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case 5:
       return {{692, 697}};
     case 6:
+    case 7:
       return {{715, 720}};
     default:
       return std::nullopt; // FIXME

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -321,6 +321,13 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     default:
       __builtin_unreachable();
     }
+  case ColorData5:
+    switch (colorDataVersion) {
+    case -4:
+      return {{333, 1386}};
+    default:
+      return std::nullopt;
+    }
   default: // FIXME
     return std::nullopt;
   }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -361,10 +361,10 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     switch (colorDataVersion) {
     case 12:
     case 13:
+    case 15:
       return {{778, 783}};
     case 14:
-    case 15:
-      return std::nullopt;
+      return {{556, 561}};
     default:
       __builtin_unreachable();
     }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -309,6 +309,7 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case 3:
       return std::nullopt; // Still no `SpecularWhiteLevel`.
     case 4:
+    case 5:
       return {{692, 697}};
     default:
       return std::nullopt; // FIXME

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -340,6 +340,14 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     default:
       __builtin_unreachable();
     }
+  case ColorData6:
+    // NOLINTNEXTLINE(hicpp-multiway-paths-covered)
+    switch (colorDataVersion) {
+    case 10:
+      return {{479, 484}};
+    default:
+      __builtin_unreachable();
+    }
   default: // FIXME
     return std::nullopt;
   }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -325,8 +325,10 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     switch (colorDataVersion) {
     case -4:
       return {{333, 1386}};
+    case -3:
+      return std::nullopt; // FIXME
     default:
-      return std::nullopt;
+      __builtin_unreachable();
     }
   default: // FIXME
     return std::nullopt;

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -348,6 +348,15 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     default:
       __builtin_unreachable();
     }
+  case ColorData7:
+    switch (colorDataVersion) {
+    case 10:
+      return {{504, 509}};
+    case 11:
+      return std::nullopt;
+    default:
+      __builtin_unreachable();
+    }
   default: // FIXME
     return std::nullopt;
   }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -231,7 +231,6 @@ enum class ColorDataFormat {
   ColorData6,
   ColorData7,
   ColorData8,
-  ColorData9,
 };
 
 [[nodiscard]] std::optional<ColorDataFormat>
@@ -267,11 +266,6 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   case 14:
   case 15:
     return ColorDataFormat::ColorData8;
-  case 16:
-  case 17:
-  case 18:
-  case 19:
-    return ColorDataFormat::ColorData9;
   default:
     break;
   }
@@ -292,7 +286,6 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   case ColorData8:
     return 126;
   case ColorData5:
-  case ColorData9:
     return 142;
   }
   __builtin_unreachable();

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -357,8 +357,17 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     default:
       __builtin_unreachable();
     }
-  default: // FIXME
-    return std::nullopt;
+  case ColorData8:
+    switch (colorDataVersion) {
+    case 12:
+      return {{778, 783}};
+    case 13:
+    case 14:
+    case 15:
+      return std::nullopt;
+    default:
+      __builtin_unreachable();
+    }
   }
   __builtin_unreachable();
 }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -318,8 +318,9 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
   case ColorData4:
     switch (colorDataVersion) {
     case 2:
-    case 3:
       return std::nullopt; // Still no `SpecularWhiteLevel`.
+    case 3:
+      return {{231, 617}};
     case 4:
     case 5:
       return {{692, 697}};

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -353,7 +353,7 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case 10:
       return {{504, 509}};
     case 11:
-      return std::nullopt;
+      return {{728, 733}};
     default:
       __builtin_unreachable();
     }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -316,8 +316,10 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case 6:
     case 7:
       return {{715, 720}};
+    case 9:
+      return {{719, 724}};
     default:
-      return std::nullopt; // FIXME
+      __builtin_unreachable();
     }
   default: // FIXME
     return std::nullopt;

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -326,7 +326,7 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     case -4:
       return {{333, 1386}};
     case -3:
-      return std::nullopt; // FIXME
+      return {{264, 662}};
     default:
       __builtin_unreachable();
     }
@@ -334,6 +334,11 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
     return std::nullopt;
   }
   __builtin_unreachable();
+}
+
+[[nodiscard]] bool shouldRescaleBlackLevels(ColorDataFormat f,
+                                            int colorDataVersion) {
+  return f != ColorDataFormat::ColorData5 || colorDataVersion != -3;
 }
 
 } // namespace
@@ -370,8 +375,10 @@ bool Cr2Decoder::decodeCanonColorData() const {
   if (makernotesPrecision > ljpegSamplePrecision) {
     int bitDepthDiff = makernotesPrecision - ljpegSamplePrecision;
     assert(bitDepthDiff >= 1 && bitDepthDiff <= 12);
-    for (int c = 0; c != 4; ++c)
-      mRaw->blackLevelSeparate[c] >>= bitDepthDiff;
+    if (shouldRescaleBlackLevels(f, *ver)) {
+      for (int c = 0; c != 4; ++c)
+        mRaw->blackLevelSeparate[c] >>= bitDepthDiff;
+    }
     mRaw->whitePoint >>= bitDepthDiff;
   }
 

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -232,7 +232,6 @@ enum class ColorDataFormat {
   ColorData7,
   ColorData8,
   ColorData9,
-  ColorData10,
 };
 
 [[nodiscard]] std::optional<ColorDataFormat>
@@ -273,9 +272,6 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   case 18:
   case 19:
     return ColorDataFormat::ColorData9;
-  case 32:
-  case 33:
-    return ColorDataFormat::ColorData10;
   default:
     break;
   }
@@ -298,8 +294,6 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   case ColorData5:
   case ColorData9:
     return 142;
-  case ColorData10:
-    return 170;
   }
   __builtin_unreachable();
 }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -429,7 +429,11 @@ void Cr2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   }
   setMetaData(meta, mode, iso);
   assert(mShiftUpScaleForExif == 0 || mShiftUpScaleForExif == 2);
-  mRaw->blackLevel <<= mShiftUpScaleForExif;
+  if (mShiftUpScaleForExif) {
+    mRaw->blackLevel = 0;
+    for (int c = 0; c != 4; ++c)
+      mRaw->blackLevelSeparate[c] = -1;
+  }
   if (mShiftUpScaleForExif != 0 && isPowerOfTwo(1 + mRaw->whitePoint))
     mRaw->whitePoint = ((1 + mRaw->whitePoint) << mShiftUpScaleForExif) - 1;
   else

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -261,8 +261,18 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   case -4:
   case -3:
     return {{ColorDataFormat::ColorData5, colorDataVersion}};
-  case 10:
-    return {{ColorDataFormat::ColorData6, colorDataVersion}};
+  case 10: {
+    ColorDataFormat f = [count = ccd->count]() {
+      switch (count) {
+      case 1273:
+      case 1275:
+        return ColorDataFormat::ColorData6;
+      default:
+        return ColorDataFormat::ColorData7;
+      }
+    }();
+    return {{f, colorDataVersion}};
+  }
   case 11:
     return {{ColorDataFormat::ColorData7, colorDataVersion}};
   case 12:

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
+#include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/Cr2Decompressor.h"

--- a/src/librawspeed/decoders/Cr2Decoder.h
+++ b/src/librawspeed/decoders/Cr2Decoder.h
@@ -51,6 +51,7 @@ private:
   [[nodiscard]] iPoint2D getSubSampling() const;
   [[nodiscard]] int getHue() const;
   [[nodiscard]] bool decodeCanonColorData() const;
+  int ljpegSamplePrecision;
   int mShiftUpScaleForExif = 0;
 };
 

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -250,20 +250,21 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
     }
   }
 
-  const CameraSensorInfo* sensor = cam->getSensorInfo(iso_speed);
-  mRaw->blackLevel = sensor->mBlackLevel;
-  mRaw->whitePoint = sensor->mWhiteLevel;
   mRaw->blackAreas = cam->blackAreas;
-  if (mRaw->blackAreas.empty() && !sensor->mBlackLevelSeparate.empty()) {
-    auto cfaArea = mRaw->cfa.getSize().area();
-    if (mRaw->isCFA && cfaArea <= sensor->mBlackLevelSeparate.size()) {
-      for (auto i = 0UL; i < cfaArea; i++) {
-        mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
-      }
-    } else if (!mRaw->isCFA &&
-               mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
-      for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
-        mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
+  if (const CameraSensorInfo* sensor = cam->getSensorInfo(iso_speed)) {
+    mRaw->blackLevel = sensor->mBlackLevel;
+    mRaw->whitePoint = sensor->mWhiteLevel;
+    if (mRaw->blackAreas.empty() && !sensor->mBlackLevelSeparate.empty()) {
+      auto cfaArea = mRaw->cfa.getSize().area();
+      if (mRaw->isCFA && cfaArea <= sensor->mBlackLevelSeparate.size()) {
+        for (auto i = 0UL; i < cfaArea; i++) {
+          mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
+        }
+      } else if (!mRaw->isCFA &&
+                 mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
+        for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
+          mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
+        }
       }
     }
   }

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.h
@@ -165,6 +165,7 @@ class AbstractLJpegDecoder : public AbstractDecompressor {
 
 public:
   AbstractLJpegDecoder(ByteStream bs, RawImage img);
+  [[nodiscard]] int getSamplePrecision() const { return frame.prec; }
 
   virtual ~AbstractLJpegDecoder() = default;
 

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -398,10 +398,8 @@ void Camera::parseCameraChild(const xml_node& cur) {
 #endif
 
 const CameraSensorInfo* Camera::getSensorInfo(int iso) const {
-  if (sensorInfo.empty()) {
-    ThrowCME("Camera '%s' '%s', mode '%s' has no <Sensor> entries.",
-             make.c_str(), model.c_str(), mode.c_str());
-  }
+  if (sensorInfo.empty())
+    return nullptr;
 
   // If only one, just return that
   if (sensorInfo.size() == 1)
@@ -412,6 +410,7 @@ const CameraSensorInfo* Camera::getSensorInfo(int iso) const {
     if (i.isIsoWithin(iso))
       candidates.push_back(&i);
   }
+  assert(!candidates.empty());
 
   if (candidates.size() == 1)
     return candidates.front();

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -24,6 +24,7 @@
 #include "metadata/CameraMetadataException.h"
 #include "metadata/CameraSensorInfo.h"
 #include "metadata/ColorFilterArray.h"
+#include <cassert>
 #include <cstdint>
 #include <map>
 #include <string>


### PR DESCRIPTION
This handles basically everything CR2, except a few of the oldest cameras,
it is not obvious if they even store `SpecularWhiteLevel` in the `MakerNotes`.

Fixes https://github.com/darktable-org/rawspeed/issues/102
Fixes https://github.com/darktable-org/rawspeed/issues/417
