### PR TITLE
Fujifilm FinePix SL1000 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14681,6 +14681,25 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="FUJIFILM" model="FinePix SL1000">
+		<ID make="Fujifilm" model="FinePix SL1000">Fujifilm FinePix SL1000</ID>
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="200" white="4095"/>
+		<Hints>
+			<Hint name="jpeg32_bitorder" value=""/>
+		</Hints>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11705 -4262 -1107</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-2282 10791 1709</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-555 1713 4945</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="FUJIFILM" model="FinePix HS10 HS11">
 		<ID make="Fujifilm" model="FinePix HS10 HS11">Fujifilm FinePix HS10 HS11</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
After checking [the sample taken from the RPU](https://raw.pixls.us/getfile.php/5760/nice/Fujifilm%20-%20FinePix%20SL1000%20-%2012bit%20uncompressed%20(4:3).RAF) I settled on specifying the entire active area (which is larger than what the ADC reports) as I don't see any garbage pixels.