### PR TITLE
Refactor `blackLevelSeparate` towards being an `Array2DRef`

### DIFF
--- a/src/librawspeed/adt/Array1DRef.h
+++ b/src/librawspeed/adt/Array1DRef.h
@@ -102,6 +102,7 @@ template <class T>
                                                           int size) const {
   invariant(offset >= 0);
   invariant(size >= 0);
+  invariant(offset <= numElts);
   invariant(offset + size <= numElts);
   return {*this, offset, size};
 }

--- a/src/librawspeed/adt/Array1DRef.h
+++ b/src/librawspeed/adt/Array1DRef.h
@@ -93,8 +93,8 @@ template <typename T> Array1DRef(T* data_, int numElts_) -> Array1DRef<T>;
 template <class T>
 Array1DRef<T>::Array1DRef(T* data_, const int numElts_)
     : data(data_), numElts(numElts_) {
-  invariant(data);
   invariant(numElts >= 0);
+  invariant(data || numElts == 0);
 }
 
 template <class T>

--- a/src/librawspeed/adt/Array2DRef.h
+++ b/src/librawspeed/adt/Array2DRef.h
@@ -112,6 +112,7 @@ Array2DRef<T>::Array2DRef(T* data, const int width_, const int height_,
   invariant(height >= 0);
   invariant(_pitch >= 0);
   invariant(_pitch >= width);
+  invariant(data || (width == 0 && height == 0));
 }
 
 template <class T>

--- a/src/librawspeed/adt/CroppedArray1DRef.h
+++ b/src/librawspeed/adt/CroppedArray1DRef.h
@@ -89,6 +89,7 @@ CroppedArray1DRef<T>::CroppedArray1DRef(Array1DRef<T> base_, const int offset_,
     : base(base_), offset(offset_), numElts(numElts_) {
   invariant(offset >= 0);
   invariant(numElts >= 0);
+  invariant(offset <= base.size());
   invariant(offset + numElts <= base.size());
 }
 

--- a/src/librawspeed/adt/CroppedArray2DRef.h
+++ b/src/librawspeed/adt/CroppedArray2DRef.h
@@ -94,6 +94,8 @@ CroppedArray2DRef<T>::CroppedArray2DRef(Array2DRef<T> base_, int offsetCols_,
   invariant(offsetRows_ >= 0);
   invariant(croppedWidth_ >= 0);
   invariant(croppedHeight_ >= 0);
+  invariant(offsetCols_ <= base.width);
+  invariant(offsetRows_ <= base.height);
   invariant(offsetCols_ + croppedWidth_ <= base.width);
   invariant(offsetRows_ + croppedHeight_ <= base.height);
 }

--- a/src/librawspeed/common/RawImage.cpp
+++ b/src/librawspeed/common/RawImage.cpp
@@ -53,7 +53,9 @@ void RawImageData::anchor() const {
   // the class's vtable to this Translational Unit.
 }
 
-RawImageData::RawImageData() { blackLevelSeparate.fill(-1); }
+RawImageData::RawImageData() {
+  std::fill(blackLevelSeparate.begin(), blackLevelSeparate.end(), -1);
+}
 
 RawImageData::RawImageData(RawImageType type, const iPoint2D& _dim, int _bpc,
                            int _cpp)
@@ -64,7 +66,7 @@ RawImageData::RawImageData(RawImageType type, const iPoint2D& _dim, int _bpc,
     ThrowRDE("Components-per-pixel is too large.");
 
   bpp = _bpc * _cpp;
-  blackLevelSeparate.fill(-1);
+  std::fill(blackLevelSeparate.begin(), blackLevelSeparate.end(), -1);
   createData();
 }
 

--- a/src/librawspeed/common/RawImage.cpp
+++ b/src/librawspeed/common/RawImage.cpp
@@ -53,10 +53,6 @@ void RawImageData::anchor() const {
   // the class's vtable to this Translational Unit.
 }
 
-RawImageData::RawImageData() {
-  std::fill(blackLevelSeparate.begin(), blackLevelSeparate.end(), -1);
-}
-
 RawImageData::RawImageData(RawImageType type, const iPoint2D& _dim, int _bpc,
                            int _cpp)
     : dim(_dim), isCFA(_cpp == 1), dataType(type), cpp(_cpp) {
@@ -66,7 +62,6 @@ RawImageData::RawImageData(RawImageType type, const iPoint2D& _dim, int _bpc,
     ThrowRDE("Components-per-pixel is too large.");
 
   bpp = _bpc * _cpp;
-  std::fill(blackLevelSeparate.begin(), blackLevelSeparate.end(), -1);
   createData();
 }
 

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -161,7 +161,7 @@ public:
   ColorFilterArray cfa;
   int blackLevel = -1;
   std::array<int, 4> blackLevelSeparateStorage;
-  Array1DRef<int> blackLevelSeparate = {blackLevelSeparateStorage.data(), 4};
+  Array1DRef<int> blackLevelSeparate;
   int whitePoint = 65536;
   std::vector<BlackArea> blackAreas;
 
@@ -180,7 +180,7 @@ public:
 
 protected:
   RawImageType dataType;
-  RawImageData();
+  RawImageData() = default;
   RawImageData(RawImageType type, const iPoint2D& dim, int bpp, int cpp = 1);
   virtual void scaleValues(int start_y, int end_y) = 0;
   virtual void doLookup(int start_y, int end_y) = 0;

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -161,7 +161,7 @@ public:
   ColorFilterArray cfa;
   int blackLevel = -1;
   std::array<int, 4> blackLevelSeparateStorage;
-  Array1DRef<int> blackLevelSeparate;
+  Array2DRef<int> blackLevelSeparate;
   int whitePoint = 65536;
   std::vector<BlackArea> blackAreas;
 

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -160,7 +160,8 @@ public:
   bool isCFA{true};
   ColorFilterArray cfa;
   int blackLevel = -1;
-  std::array<int, 4> blackLevelSeparate;
+  std::array<int, 4> blackLevelSeparateStorage;
+  Array1DRef<int> blackLevelSeparate = {blackLevelSeparateStorage.data(), 4};
   int whitePoint = 65536;
   std::vector<BlackArea> blackAreas;
 

--- a/src/librawspeed/common/RawImageDataFloat.cpp
+++ b/src/librawspeed/common/RawImageDataFloat.cpp
@@ -87,7 +87,7 @@ void RawImageDataFloat::calculateBlackAreas() {
     }
   }
 
-  blackLevelSeparate = Array2DRef(blackLevelSeparateStorage.data(), 4, 1);
+  blackLevelSeparate = Array2DRef(blackLevelSeparateStorage.data(), 2, 2);
   auto blackLevelSeparate1D = *blackLevelSeparate.getAsArray1DRef();
 
   if (!totalpixels) {
@@ -154,7 +154,7 @@ void RawImageDataFloat::scaleValues(int start_y, int end_y) {
   int gw = dim.x * cpp;
   std::array<float, 4> mul;
   std::array<float, 4> sub;
-  assert(blackLevelSeparate.width == 4 && blackLevelSeparate.height == 1);
+  assert(blackLevelSeparate.width == 2 && blackLevelSeparate.height == 2);
   auto blackLevelSeparate1D = *blackLevelSeparate.getAsArray1DRef();
   for (int i = 0; i < 4; i++) {
     int v = i;

--- a/src/librawspeed/common/RawImageDataFloat.cpp
+++ b/src/librawspeed/common/RawImageDataFloat.cpp
@@ -97,7 +97,7 @@ void RawImageDataFloat::calculateBlackAreas() {
   totalpixels /= 4;
 
   for (int i = 0; i < 4; i++) {
-    blackLevelSeparate[i] = static_cast<int>(65535.0F * accPixels[i] /
+    blackLevelSeparate(i) = static_cast<int>(65535.0F * accPixels[i] /
                                              implicit_cast<float>(totalpixels));
   }
 
@@ -117,7 +117,7 @@ void RawImageDataFloat::scaleBlackWhite() {
 
   const int skipBorder = 150;
   int gw = (dim.x - skipBorder) * cpp;
-  if ((blackAreas.empty() && blackLevelSeparate[0] < 0 && blackLevel < 0) ||
+  if ((blackAreas.empty() && blackLevelSeparate(0) < 0 && blackLevel < 0) ||
       whitePoint == 65536) { // Estimate
     float b = 100000000;
     float m = -10000000;
@@ -137,7 +137,7 @@ void RawImageDataFloat::scaleBlackWhite() {
   }
 
   /* If filter has not set separate blacklevel, compute or fetch it */
-  if (blackLevelSeparate[0] < 0)
+  if (blackLevelSeparate(0) < 0)
     calculateBlackAreas();
 
   startWorker(RawImageWorker::RawImageWorkerTask::SCALE_VALUES, true);
@@ -154,8 +154,8 @@ void RawImageDataFloat::scaleValues(int start_y, int end_y) {
       v ^= 1;
     if ((mOffset.y & 1) != 0)
       v ^= 2;
-    mul[i] = 65535.0F / static_cast<float>(whitePoint - blackLevelSeparate[v]);
-    sub[i] = static_cast<float>(blackLevelSeparate[v]);
+    mul[i] = 65535.0F / static_cast<float>(whitePoint - blackLevelSeparate(v));
+    sub[i] = static_cast<float>(blackLevelSeparate(v));
   }
   for (int y = start_y; y < end_y; y++) {
     for (int x = 0; x < gw; x++)

--- a/src/librawspeed/common/RawImageDataU16.cpp
+++ b/src/librawspeed/common/RawImageDataU16.cpp
@@ -108,7 +108,7 @@ void RawImageDataU16::calculateBlackAreas() {
     }
   }
 
-  blackLevelSeparate = Array2DRef(blackLevelSeparateStorage.data(), 4, 1);
+  blackLevelSeparate = Array2DRef(blackLevelSeparateStorage.data(), 2, 2);
   auto blackLevelSeparate1D = *blackLevelSeparate.getAsArray1DRef();
 
   if (!totalpixels) {
@@ -204,7 +204,7 @@ void RawImageDataU16::scaleValues(int start_y, int end_y) {
 
 #ifdef WITH_SSE2
 void RawImageDataU16::scaleValues_SSE2(int start_y, int end_y) {
-  assert(blackLevelSeparate.width == 4 && blackLevelSeparate.height == 1);
+  assert(blackLevelSeparate.width == 2 && blackLevelSeparate.height == 2);
   auto blackLevelSeparate1D = *blackLevelSeparate.getAsArray1DRef();
 
   int depth_values = whitePoint - blackLevelSeparate1D(0);
@@ -345,7 +345,7 @@ void RawImageDataU16::scaleValues_SSE2(int start_y, int end_y) {
 void RawImageDataU16::scaleValues_plain(int start_y, int end_y) {
   const CroppedArray2DRef<uint16_t> img(getU16DataAsCroppedArray2DRef());
 
-  assert(blackLevelSeparate.width == 4 && blackLevelSeparate.height == 1);
+  assert(blackLevelSeparate.width == 2 && blackLevelSeparate.height == 2);
   auto blackLevelSeparate1D = *blackLevelSeparate.getAsArray1DRef();
 
   int depth_values = whitePoint - blackLevelSeparate1D(0);

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -646,7 +646,7 @@ void ArwDecoder::GetWB() const {
       if (bl->count != 4)
         ThrowRDE("Black Level has %d entries instead of 4", bl->count);
       mRaw->blackLevelSeparate =
-          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
       auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int i = 0; i < 4; ++i)
         blackLevelSeparate1D(i) = bl->getU16(i) >> mShiftDownScaleForExif;

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -646,9 +646,10 @@ void ArwDecoder::GetWB() const {
       if (bl->count != 4)
         ThrowRDE("Black Level has %d entries instead of 4", bl->count);
       mRaw->blackLevelSeparate =
-          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int i = 0; i < 4; ++i)
-        mRaw->blackLevelSeparate(i) = bl->getU16(i) >> mShiftDownScaleForExif;
+        blackLevelSeparate1D(i) = bl->getU16(i) >> mShiftDownScaleForExif;
     }
 
     if (encryptedIFD.hasEntry(TiffTag::SONYWHITELEVEL)) {

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -646,7 +646,7 @@ void ArwDecoder::GetWB() const {
       if (bl->count != 4)
         ThrowRDE("Black Level has %d entries instead of 4", bl->count);
       for (int i = 0; i < 4; ++i)
-        mRaw->blackLevelSeparate[i] = bl->getU16(i) >> mShiftDownScaleForExif;
+        mRaw->blackLevelSeparate(i) = bl->getU16(i) >> mShiftDownScaleForExif;
     }
 
     if (encryptedIFD.hasEntry(TiffTag::SONYWHITELEVEL)) {

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -645,6 +645,8 @@ void ArwDecoder::GetWB() const {
       const TiffEntry* bl = encryptedIFD.getEntry(TiffTag::SONYBLACKLEVEL);
       if (bl->count != 4)
         ThrowRDE("Black Level has %d entries instead of 4", bl->count);
+      mRaw->blackLevelSeparate =
+          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
       for (int i = 0; i < 4; ++i)
         mRaw->blackLevelSeparate(i) = bl->getU16(i) >> mShiftDownScaleForExif;
     }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -407,7 +407,7 @@ bool Cr2Decoder::decodeCanonColorData() const {
   mRaw->whitePoint = wb->getU16(levelOffsets->second);
 
   mRaw->blackLevelSeparate =
-      Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
   auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
   for (int c = 0; c != 4; ++c)
     blackLevelSeparate1D(c) = wb->getU16(c + levelOffsets->first);

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -407,9 +407,10 @@ bool Cr2Decoder::decodeCanonColorData() const {
   mRaw->whitePoint = wb->getU16(levelOffsets->second);
 
   mRaw->blackLevelSeparate =
-      Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+      Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+  auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
   for (int c = 0; c != 4; ++c)
-    mRaw->blackLevelSeparate(c) = wb->getU16(c + levelOffsets->first);
+    blackLevelSeparate1D(c) = wb->getU16(c + levelOffsets->first);
 
   // In Canon MakerNotes, the levels are always unscaled, and are 14-bit,
   // and so if the LJpeg precision was lower, we need to adjust.
@@ -419,7 +420,7 @@ bool Cr2Decoder::decodeCanonColorData() const {
     assert(bitDepthDiff >= 1 && bitDepthDiff <= 12);
     if (shouldRescaleBlackLevels(f, ver)) {
       for (int c = 0; c != 4; ++c)
-        mRaw->blackLevelSeparate(c) >>= bitDepthDiff;
+        blackLevelSeparate1D(c) >>= bitDepthDiff;
     }
     mRaw->whitePoint >>= bitDepthDiff;
   }

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -22,6 +22,7 @@
 
 #include "decoders/Cr2Decoder.h"
 #include "MemorySanitizer.h"
+#include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
@@ -404,6 +405,9 @@ bool Cr2Decoder::decodeCanonColorData() const {
     return false;
 
   mRaw->whitePoint = wb->getU16(levelOffsets->second);
+
+  mRaw->blackLevelSeparate =
+      Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
   for (int c = 0; c != 4; ++c)
     mRaw->blackLevelSeparate(c) = wb->getU16(c + levelOffsets->first);
 
@@ -494,8 +498,7 @@ void Cr2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   assert(mShiftUpScaleForExif == 0 || mShiftUpScaleForExif == 2);
   if (mShiftUpScaleForExif) {
     mRaw->blackLevel = 0;
-    for (int c = 0; c != 4; ++c)
-      mRaw->blackLevelSeparate(c) = -1;
+    mRaw->blackLevelSeparate = {};
   }
   if (mShiftUpScaleForExif != 0 && isPowerOfTwo(1 + mRaw->whitePoint))
     mRaw->whitePoint = ((1 + mRaw->whitePoint) << mShiftUpScaleForExif) - 1;

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -405,7 +405,7 @@ bool Cr2Decoder::decodeCanonColorData() const {
 
   mRaw->whitePoint = wb->getU16(levelOffsets->second);
   for (int c = 0; c != 4; ++c)
-    mRaw->blackLevelSeparate[c] = wb->getU16(c + levelOffsets->first);
+    mRaw->blackLevelSeparate(c) = wb->getU16(c + levelOffsets->first);
 
   // In Canon MakerNotes, the levels are always unscaled, and are 14-bit,
   // and so if the LJpeg precision was lower, we need to adjust.
@@ -415,7 +415,7 @@ bool Cr2Decoder::decodeCanonColorData() const {
     assert(bitDepthDiff >= 1 && bitDepthDiff <= 12);
     if (shouldRescaleBlackLevels(f, ver)) {
       for (int c = 0; c != 4; ++c)
-        mRaw->blackLevelSeparate[c] >>= bitDepthDiff;
+        mRaw->blackLevelSeparate(c) >>= bitDepthDiff;
     }
     mRaw->whitePoint >>= bitDepthDiff;
   }
@@ -495,7 +495,7 @@ void Cr2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   if (mShiftUpScaleForExif) {
     mRaw->blackLevel = 0;
     for (int c = 0; c != 4; ++c)
-      mRaw->blackLevelSeparate[c] = -1;
+      mRaw->blackLevelSeparate(c) = -1;
   }
   if (mShiftUpScaleForExif != 0 && isPowerOfTwo(1 + mRaw->whitePoint))
     mRaw->whitePoint = ((1 + mRaw->whitePoint) << mShiftUpScaleForExif) - 1;

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -633,7 +633,7 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
     mRaw->blackAreas.clear();
     mRaw->blackLevel = 0;
     mRaw->blackLevelSeparate =
-        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
     auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     std::fill(blackLevelSeparate1D.begin(), blackLevelSeparate1D.end(), 0);
     // FIXME: why do we provide both the `blackLevel` and `blackLevelSeparate`?
@@ -831,7 +831,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
       ThrowRDE("Error decoding black level");
 
     mRaw->blackLevelSeparate =
-        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
     auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     for (int y = 0; y < 2; y++) {
       for (int x = 0; x < 2; x++)
@@ -839,7 +839,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
     }
   } else {
     mRaw->blackLevelSeparate =
-        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
     auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     for (int y = 0; y < 2; y++) {
       for (int x = 0; x < 2; x++) {
@@ -914,7 +914,7 @@ void DngDecoder::setBlack(const TiffIFD* raw) const {
   // Black defaults to 0
   // FIXME: is this the right thing to do?
   mRaw->blackLevelSeparate =
-      Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
   auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
   std::fill(blackLevelSeparate1D.begin(), blackLevelSeparate1D.end(), 0);
 

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -630,8 +630,8 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
     }
     mRaw->blackAreas.clear();
     mRaw->blackLevel = 0;
-    mRaw->blackLevelSeparate[0] = mRaw->blackLevelSeparate[1] =
-        mRaw->blackLevelSeparate[2] = mRaw->blackLevelSeparate[3] = 0;
+    mRaw->blackLevelSeparate(0) = mRaw->blackLevelSeparate(1) =
+        mRaw->blackLevelSeparate(2) = mRaw->blackLevelSeparate(3) = 0;
     mRaw->whitePoint = 65535;
   }
 }
@@ -827,7 +827,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
 
     for (int y = 0; y < 2; y++) {
       for (int x = 0; x < 2; x++)
-        mRaw->blackLevelSeparate[y * 2 + x] = implicit_cast<int>(value);
+        mRaw->blackLevelSeparate(y * 2 + x) = implicit_cast<int>(value);
     }
   } else {
     for (int y = 0; y < 2; y++) {
@@ -839,7 +839,7 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
             static_cast<double>(value) > std::numeric_limits<BlackType>::max())
           ThrowRDE("Error decoding black level");
 
-        mRaw->blackLevelSeparate[y * 2 + x] = implicit_cast<int>(value);
+        mRaw->blackLevelSeparate(y * 2 + x) = implicit_cast<int>(value);
       }
     }
   }
@@ -861,9 +861,9 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
           static_cast<double>(value) > std::numeric_limits<BlackType>::max())
         ThrowRDE("Error decoding black level");
 
-      if (__builtin_sadd_overflow(mRaw->blackLevelSeparate[i],
+      if (__builtin_sadd_overflow(mRaw->blackLevelSeparate(i),
                                   implicit_cast<int>(value),
-                                  &mRaw->blackLevelSeparate[i]))
+                                  &mRaw->blackLevelSeparate(i)))
         ThrowRDE("Integer overflow when calculating black level");
     }
   }
@@ -884,9 +884,9 @@ bool DngDecoder::decodeBlackLevels(const TiffIFD* raw) const {
           static_cast<double>(value) > std::numeric_limits<BlackType>::max())
         ThrowRDE("Error decoding black level");
 
-      if (__builtin_sadd_overflow(mRaw->blackLevelSeparate[i],
+      if (__builtin_sadd_overflow(mRaw->blackLevelSeparate(i),
                                   implicit_cast<int>(value),
-                                  &mRaw->blackLevelSeparate[i]))
+                                  &mRaw->blackLevelSeparate(i)))
         ThrowRDE("Integer overflow when calculating black level");
     }
   }
@@ -899,7 +899,8 @@ void DngDecoder::setBlack(const TiffIFD* raw) const {
     return;
 
   // Black defaults to 0
-  mRaw->blackLevelSeparate.fill(0);
+  std::fill(mRaw->blackLevelSeparate.begin(), mRaw->blackLevelSeparate.end(),
+            0);
 
   if (raw->hasEntry(TiffTag::BLACKLEVEL))
     decodeBlackLevels(raw);

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -628,11 +628,12 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       ThrowRDE("Bad bit per pixel: %i", bitPerPixel);
     const int sh = 14 - bitPerPixel;
     mRaw->blackLevelSeparate =
-        Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
-    mRaw->blackLevelSeparate(0) = bl->getU16(0) >> sh;
-    mRaw->blackLevelSeparate(1) = bl->getU16(1) >> sh;
-    mRaw->blackLevelSeparate(2) = bl->getU16(2) >> sh;
-    mRaw->blackLevelSeparate(3) = bl->getU16(3) >> sh;
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+    auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
+    blackLevelSeparate1D(0) = bl->getU16(0) >> sh;
+    blackLevelSeparate1D(1) = bl->getU16(1) >> sh;
+    blackLevelSeparate1D(2) = bl->getU16(2) >> sh;
+    blackLevelSeparate1D(3) = bl->getU16(3) >> sh;
   }
 
   if (meta->hasCamera(id.make, id.model, extended_mode)) {

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decoders/NefDecoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
@@ -626,6 +627,8 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     if (bitPerPixel != 12 && bitPerPixel != 14)
       ThrowRDE("Bad bit per pixel: %i", bitPerPixel);
     const int sh = 14 - bitPerPixel;
+    mRaw->blackLevelSeparate =
+        Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
     mRaw->blackLevelSeparate(0) = bl->getU16(0) >> sh;
     mRaw->blackLevelSeparate(1) = bl->getU16(1) >> sh;
     mRaw->blackLevelSeparate(2) = bl->getU16(2) >> sh;

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -628,7 +628,7 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       ThrowRDE("Bad bit per pixel: %i", bitPerPixel);
     const int sh = 14 - bitPerPixel;
     mRaw->blackLevelSeparate =
-        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
     auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     blackLevelSeparate1D(0) = bl->getU16(0) >> sh;
     blackLevelSeparate1D(1) = bl->getU16(1) >> sh;

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -626,10 +626,10 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     if (bitPerPixel != 12 && bitPerPixel != 14)
       ThrowRDE("Bad bit per pixel: %i", bitPerPixel);
     const int sh = 14 - bitPerPixel;
-    mRaw->blackLevelSeparate[0] = bl->getU16(0) >> sh;
-    mRaw->blackLevelSeparate[1] = bl->getU16(1) >> sh;
-    mRaw->blackLevelSeparate[2] = bl->getU16(2) >> sh;
-    mRaw->blackLevelSeparate[3] = bl->getU16(3) >> sh;
+    mRaw->blackLevelSeparate(0) = bl->getU16(0) >> sh;
+    mRaw->blackLevelSeparate(1) = bl->getU16(1) >> sh;
+    mRaw->blackLevelSeparate(2) = bl->getU16(2) >> sh;
+    mRaw->blackLevelSeparate(3) = bl->getU16(3) >> sh;
   }
 
   if (meta->hasCamera(id.make, id.model, extended_mode)) {

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -482,17 +482,7 @@ const std::array<uint8_t, 256> NefDecoder::keymap = {
      0xc6, 0x67, 0x4a, 0xf5, 0xa5, 0x12, 0x65, 0x7e, 0xb0, 0xdf, 0xaf, 0x4e,
      0xb3, 0x61, 0x7f, 0x2f}};
 
-void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
-  int iso = 0;
-  mRaw->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
-                   CFAColor::GREEN, CFAColor::BLUE);
-
-  int white = mRaw->whitePoint;
-  int black = mRaw->blackLevel;
-
-  if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
-    iso = mRootIFD->getEntryRecursive(TiffTag::ISOSPEEDRATINGS)->getU32();
-
+void NefDecoder::parseWhiteBalance() const {
   // Read the whitebalance
 
   if (mRootIFD->hasEntryRecursive(static_cast<TiffTag>(12))) {
@@ -607,6 +597,20 @@ void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     mRaw->metadata.wbCoeffs[0] *= 256.0F / 527.0F;
     mRaw->metadata.wbCoeffs[2] *= 256.0F / 317.0F;
   }
+}
+
+void NefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
+  int iso = 0;
+  mRaw->cfa.setCFA(iPoint2D(2, 2), CFAColor::RED, CFAColor::GREEN,
+                   CFAColor::GREEN, CFAColor::BLUE);
+
+  int white = mRaw->whitePoint;
+  int black = mRaw->blackLevel;
+
+  if (mRootIFD->hasEntryRecursive(TiffTag::ISOSPEEDRATINGS))
+    iso = mRootIFD->getEntryRecursive(TiffTag::ISOSPEEDRATINGS)->getU32();
+
+  parseWhiteBalance();
 
   auto id = mRootIFD->getID();
   std::string mode = getMode();

--- a/src/librawspeed/decoders/NefDecoder.h
+++ b/src/librawspeed/decoders/NefDecoder.h
@@ -61,6 +61,7 @@ private:
   void readCoolpixSplitRaw(ByteStream input, const iPoint2D& size,
                            const iPoint2D& offset, int inputPitch) const;
   void DecodeNikonSNef(ByteStream input) const;
+  void parseWhiteBalance() const;
   [[nodiscard]] int getBitPerSample() const;
   [[nodiscard]] std::string getMode() const;
   [[nodiscard]] std::string getExtendedMode(const std::string& mode) const;

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -317,7 +317,7 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       // Order is assumed to be RGGB
       if (blackEntry->count == 4) {
         mRaw->blackLevelSeparate =
-            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
         auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (int i = 0; i < 4; i++) {
           auto c = mRaw->cfa.getColorAt(i & 1, i >> 1);

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -333,11 +333,11 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
             ThrowRDE("Unexpected CFA color: %u", static_cast<unsigned>(c));
           }
 
-          mRaw->blackLevelSeparate[i] = blackEntry->getU16(j);
+          mRaw->blackLevelSeparate(i) = blackEntry->getU16(j);
         }
         // Adjust whitelevel based on the read black (we assume the dynamic
         // range is the same)
-        mRaw->whitePoint -= (mRaw->blackLevel - mRaw->blackLevelSeparate[0]);
+        mRaw->whitePoint -= (mRaw->blackLevel - mRaw->blackLevelSeparate(0));
       }
     }
   }

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -317,7 +317,8 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
       // Order is assumed to be RGGB
       if (blackEntry->count == 4) {
         mRaw->blackLevelSeparate =
-            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (int i = 0; i < 4; i++) {
           auto c = mRaw->cfa.getColorAt(i & 1, i >> 1);
           int j;
@@ -336,11 +337,11 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
             ThrowRDE("Unexpected CFA color: %u", static_cast<unsigned>(c));
           }
 
-          mRaw->blackLevelSeparate(i) = blackEntry->getU16(j);
+          blackLevelSeparate1D(i) = blackEntry->getU16(j);
         }
         // Adjust whitelevel based on the read black (we assume the dynamic
         // range is the same)
-        mRaw->whitePoint -= (mRaw->blackLevel - mRaw->blackLevelSeparate(0));
+        mRaw->whitePoint -= (mRaw->blackLevel - blackLevelSeparate1D(0));
       }
     }
   }

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "decoders/OrfDecoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/NORangesSet.h"
@@ -315,6 +316,8 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
           image_processing.getEntry(static_cast<TiffTag>(0x0600));
       // Order is assumed to be RGGB
       if (blackEntry->count == 4) {
+        mRaw->blackLevelSeparate =
+            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
         for (int i = 0; i < 4; i++) {
           auto c = mRaw->cfa.getColorAt(i & 1, i >> 1);
           int j;

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -21,6 +21,7 @@
 
 #include "decoders/PefDecoder.h"
 #include "adt/Array1DRef.h"
+#include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "common/Common.h"
@@ -131,9 +132,10 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x200));
     if (black->count == 4) {
       mRaw->blackLevelSeparate =
-          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int i = 0; i < 4; i++)
-        mRaw->blackLevelSeparate(i) = black->getU32(i);
+        blackLevelSeparate1D(i) = black->getU32(i);
     }
   }
 

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -132,7 +132,7 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x200));
     if (black->count == 4) {
       mRaw->blackLevelSeparate =
-          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
       auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int i = 0; i < 4; i++)
         blackLevelSeparate1D(i) = black->getU32(i);

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -130,7 +130,7 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x200));
     if (black->count == 4) {
       for (int i = 0; i < 4; i++)
-        mRaw->blackLevelSeparate[i] = black->getU32(i);
+        mRaw->blackLevelSeparate(i) = black->getU32(i);
     }
   }
 

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decoders/PefDecoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "common/Common.h"
@@ -129,6 +130,8 @@ void PefDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* black =
         mRootIFD->getEntryRecursive(static_cast<TiffTag>(0x200));
     if (black->count == 4) {
+      mRaw->blackLevelSeparate =
+          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
       for (int i = 0; i < 4; i++)
         mRaw->blackLevelSeparate(i) = black->getU32(i);
     }

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -299,14 +299,14 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(TiffTag::FUJI_BLACKLEVEL);
     if (sep_black->count == 4) {
       for (int k = 0; k < 4; k++)
-        mRaw->blackLevelSeparate[k] = sep_black->getU32(k);
+        mRaw->blackLevelSeparate(k) = sep_black->getU32(k);
     } else if (sep_black->count == 36) {
       for (int& k : mRaw->blackLevelSeparate)
         k = 0;
 
       for (int y = 0; y < 6; y++) {
         for (int x = 0; x < 6; x++)
-          mRaw->blackLevelSeparate[2 * (y % 2) + (x % 2)] +=
+          mRaw->blackLevelSeparate(2 * (y % 2) + (x % 2)) +=
               sep_black->getU32(6 * y + x);
       }
 

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -300,13 +300,13 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(TiffTag::FUJI_BLACKLEVEL);
     if (sep_black->count == 4) {
       mRaw->blackLevelSeparate =
-          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
       auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int k = 0; k < 4; k++)
         blackLevelSeparate1D(k) = sep_black->getU32(k);
     } else if (sep_black->count == 36) {
       mRaw->blackLevelSeparate =
-          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
       auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int& k : blackLevelSeparate1D)
         k = 0;

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -300,28 +300,31 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(TiffTag::FUJI_BLACKLEVEL);
     if (sep_black->count == 4) {
       mRaw->blackLevelSeparate =
-          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int k = 0; k < 4; k++)
-        mRaw->blackLevelSeparate(k) = sep_black->getU32(k);
+        blackLevelSeparate1D(k) = sep_black->getU32(k);
     } else if (sep_black->count == 36) {
       mRaw->blackLevelSeparate =
-          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
-      for (int& k : mRaw->blackLevelSeparate)
+          Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+      auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
+      for (int& k : blackLevelSeparate1D)
         k = 0;
 
       for (int y = 0; y < 6; y++) {
         for (int x = 0; x < 6; x++)
-          mRaw->blackLevelSeparate(2 * (y % 2) + (x % 2)) +=
+          blackLevelSeparate1D(2 * (y % 2) + (x % 2)) +=
               sep_black->getU32(6 * y + x);
       }
 
-      for (int& k : mRaw->blackLevelSeparate)
+      for (int& k : blackLevelSeparate1D)
         k /= 9;
     }
 
     // Set black level to average of EXIF data, can be overridden by XML data.
     int sum = 0;
-    for (int b : mRaw->blackLevelSeparate)
+    auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
+    for (int b : blackLevelSeparate1D)
       sum += b;
     mRaw->blackLevel = (sum + 2) >> 2;
   }

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decoders/RafDecoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
@@ -298,9 +299,13 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const TiffEntry* sep_black =
         mRootIFD->getEntryRecursive(TiffTag::FUJI_BLACKLEVEL);
     if (sep_black->count == 4) {
+      mRaw->blackLevelSeparate =
+          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
       for (int k = 0; k < 4; k++)
         mRaw->blackLevelSeparate(k) = sep_black->getU32(k);
     } else if (sep_black->count == 36) {
+      mRaw->blackLevelSeparate =
+          Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
       for (int& k : mRaw->blackLevelSeparate)
         k = 0;
 

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -39,7 +39,6 @@
 #include "tiff/TiffEntry.h"
 #include "tiff/TiffIFD.h"
 #include "tiff/TiffTag.h"
-#include <array>
 #include <cassert>
 #include <cstdint>
 #include <string>
@@ -255,15 +254,16 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
     mRaw->blackLevel = sensor->mBlackLevel;
     mRaw->whitePoint = sensor->mWhiteLevel;
     if (mRaw->blackAreas.empty() && !sensor->mBlackLevelSeparate.empty()) {
-      auto cfaArea = mRaw->cfa.getSize().area();
-      if (mRaw->isCFA && cfaArea <= sensor->mBlackLevelSeparate.size()) {
-        for (auto i = 0UL; i < cfaArea; i++) {
-          mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
+      auto cfaArea = implicit_cast<int>(mRaw->cfa.getSize().area());
+      if (mRaw->isCFA &&
+          cfaArea <= implicit_cast<int>(sensor->mBlackLevelSeparate.size())) {
+        for (int i = 0; i < cfaArea; i++) {
+          mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
         }
       } else if (!mRaw->isCFA &&
                  mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
         for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
-          mRaw->blackLevelSeparate[i] = sensor->mBlackLevelSeparate[i];
+          mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
         }
       }
     }
@@ -281,7 +281,7 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
                      "final_cfa_black hint.");
     } else {
       for (int i = 0; i < 4; i++) {
-        mRaw->blackLevelSeparate[i] = stoi(v[i]);
+        mRaw->blackLevelSeparate(i) = stoi(v[i]);
       }
     }
   }

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -21,6 +21,7 @@
 
 #include "decoders/RawDecoder.h"
 #include "MemorySanitizer.h"
+#include "adt/Array1DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "common/Common.h"
@@ -257,11 +258,15 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
       auto cfaArea = implicit_cast<int>(mRaw->cfa.getSize().area());
       if (mRaw->isCFA &&
           cfaArea <= implicit_cast<int>(sensor->mBlackLevelSeparate.size())) {
+        mRaw->blackLevelSeparate =
+            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
         for (int i = 0; i < cfaArea; i++) {
           mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
         }
       } else if (!mRaw->isCFA &&
                  mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
+        mRaw->blackLevelSeparate =
+            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
         for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
           mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
         }

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -22,6 +22,7 @@
 #include "decoders/RawDecoder.h"
 #include "MemorySanitizer.h"
 #include "adt/Array1DRef.h"
+#include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "common/Common.h"
@@ -259,16 +260,18 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
       if (mRaw->isCFA &&
           cfaArea <= implicit_cast<int>(sensor->mBlackLevelSeparate.size())) {
         mRaw->blackLevelSeparate =
-            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (int i = 0; i < cfaArea; i++) {
-          mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
+          blackLevelSeparate1D(i) = sensor->mBlackLevelSeparate[i];
         }
       } else if (!mRaw->isCFA &&
                  mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
         mRaw->blackLevelSeparate =
-            Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
-          mRaw->blackLevelSeparate(i) = sensor->mBlackLevelSeparate[i];
+          blackLevelSeparate1D(i) = sensor->mBlackLevelSeparate[i];
         }
       }
     }
@@ -285,8 +288,9 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
       mRaw->setError("Expected 4 values '10,20,30,20' as values for "
                      "final_cfa_black hint.");
     } else {
+      auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
       for (int i = 0; i < 4; i++) {
-        mRaw->blackLevelSeparate(i) = stoi(v[i]);
+        blackLevelSeparate1D(i) = stoi(v[i]);
       }
     }
   }

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -260,7 +260,7 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
       if (mRaw->isCFA &&
           cfaArea <= implicit_cast<int>(sensor->mBlackLevelSeparate.size())) {
         mRaw->blackLevelSeparate =
-            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
         auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (int i = 0; i < cfaArea; i++) {
           blackLevelSeparate1D(i) = sensor->mBlackLevelSeparate[i];
@@ -268,7 +268,7 @@ void RawDecoder::setMetaData(const CameraMetaData* meta,
       } else if (!mRaw->isCFA &&
                  mRaw->getCpp() <= sensor->mBlackLevelSeparate.size()) {
         mRaw->blackLevelSeparate =
-            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+            Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
         auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
         for (uint32_t i = 0; i < mRaw->getCpp(); i++) {
           blackLevelSeparate1D(i) = sensor->mBlackLevelSeparate[i];

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -268,7 +268,7 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const int blackBlue = getBlack(static_cast<TiffTag>(0x1e));
 
     mRaw->blackLevelSeparate =
-        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 2, 2);
     auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     for (int i = 0; i < 2; i++) {
       for (int j = 0; j < 2; j++) {

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -21,6 +21,7 @@
 
 #include "decoders/Rw2Decoder.h"
 #include "adt/Array1DRef.h"
+#include "adt/Array2DRef.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -267,20 +268,21 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const int blackBlue = getBlack(static_cast<TiffTag>(0x1e));
 
     mRaw->blackLevelSeparate =
-        Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
+        Array2DRef(mRaw->blackLevelSeparateStorage.data(), 4, 1);
+    auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
     for (int i = 0; i < 2; i++) {
       for (int j = 0; j < 2; j++) {
         const int k = i + 2 * j;
         const CFAColor c = mRaw->cfa.getColorAt(i, j);
         switch (c) {
         case CFAColor::RED:
-          mRaw->blackLevelSeparate(k) = blackRed;
+          blackLevelSeparate1D(k) = blackRed;
           break;
         case CFAColor::GREEN:
-          mRaw->blackLevelSeparate(k) = blackGreen;
+          blackLevelSeparate1D(k) = blackGreen;
           break;
         case CFAColor::BLUE:
-          mRaw->blackLevelSeparate(k) = blackBlue;
+          blackLevelSeparate1D(k) = blackBlue;
           break;
         default:
           ThrowRDE("Unexpected CFA color %s.",

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decoders/Rw2Decoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -265,6 +266,8 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
     const int blackGreen = getBlack(static_cast<TiffTag>(0x1d));
     const int blackBlue = getBlack(static_cast<TiffTag>(0x1e));
 
+    mRaw->blackLevelSeparate =
+        Array1DRef(mRaw->blackLevelSeparateStorage.data(), 4);
     for (int i = 0; i < 2; i++) {
       for (int j = 0; j < 2; j++) {
         const int k = i + 2 * j;

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -271,13 +271,13 @@ void Rw2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         const CFAColor c = mRaw->cfa.getColorAt(i, j);
         switch (c) {
         case CFAColor::RED:
-          mRaw->blackLevelSeparate[k] = blackRed;
+          mRaw->blackLevelSeparate(k) = blackRed;
           break;
         case CFAColor::GREEN:
-          mRaw->blackLevelSeparate[k] = blackGreen;
+          mRaw->blackLevelSeparate(k) = blackGreen;
           break;
         case CFAColor::BLUE:
-          mRaw->blackLevelSeparate[k] = blackBlue;
+          mRaw->blackLevelSeparate(k) = blackBlue;
           break;
         default:
           ThrowRDE("Unexpected CFA color %s.",

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -21,7 +21,6 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -182,10 +181,14 @@ int main(int argc_, char* argv_[]) { // NOLINT
     fprintf(stdout, "blackLevel: %d\n", r->blackLevel);
     fprintf(stdout, "whitePoint: %d\n", r->whitePoint);
 
-    assert(r->blackLevelSeparate.size() == 4);
-    fprintf(stdout, "blackLevelSeparate: %d %d %d %d\n",
-            r->blackLevelSeparate(0), r->blackLevelSeparate(1),
-            r->blackLevelSeparate(2), r->blackLevelSeparate(3));
+    fprintf(stdout, "blackLevelSeparate: (%i x %i)",
+            r->blackLevelSeparate.size(),
+            r->blackLevelSeparate.size() != 0 ? 1 : 0);
+    if (r->blackLevelSeparate.size() != 0) {
+      for (auto l : r->blackLevelSeparate)
+        fprintf(stdout, " %d", l);
+    }
+    fprintf(stdout, "\n");
 
     fprintf(stdout, "wbCoeffs: %f %f %f %f\n",
             implicit_cast<double>(r->metadata.wbCoeffs[0]),

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -182,10 +182,10 @@ int main(int argc_, char* argv_[]) { // NOLINT
     fprintf(stdout, "whitePoint: %d\n", r->whitePoint);
 
     fprintf(stdout, "blackLevelSeparate: (%i x %i)",
-            r->blackLevelSeparate.size(),
-            r->blackLevelSeparate.size() != 0 ? 1 : 0);
-    if (r->blackLevelSeparate.size() != 0) {
-      for (auto l : r->blackLevelSeparate)
+            r->blackLevelSeparate.width, r->blackLevelSeparate.height);
+    auto blackLevelSeparate1D = *r->blackLevelSeparate.getAsArray1DRef();
+    if (blackLevelSeparate1D.size() != 0) {
+      for (auto l : blackLevelSeparate1D)
         fprintf(stdout, " %d", l);
     }
     fprintf(stdout, "\n");

--- a/src/utilities/identify/rawspeed-identify.cpp
+++ b/src/utilities/identify/rawspeed-identify.cpp
@@ -21,6 +21,7 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -181,9 +182,10 @@ int main(int argc_, char* argv_[]) { // NOLINT
     fprintf(stdout, "blackLevel: %d\n", r->blackLevel);
     fprintf(stdout, "whitePoint: %d\n", r->whitePoint);
 
+    assert(r->blackLevelSeparate.size() == 4);
     fprintf(stdout, "blackLevelSeparate: %d %d %d %d\n",
-            r->blackLevelSeparate[0], r->blackLevelSeparate[1],
-            r->blackLevelSeparate[2], r->blackLevelSeparate[3]);
+            r->blackLevelSeparate(0), r->blackLevelSeparate(1),
+            r->blackLevelSeparate(2), r->blackLevelSeparate(3));
 
     fprintf(stdout, "wbCoeffs: %f %f %f %f\n",
             implicit_cast<double>(r->metadata.wbCoeffs[0]),

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -185,10 +185,13 @@ std::string img_hash(const RawImage& r, bool noSamples) {
   APPEND(&oss, "blackLevel: %d\n", r->blackLevel);
   APPEND(&oss, "whitePoint: %d\n", r->whitePoint);
 
-  assert(r->blackLevelSeparate.size() == 4);
-  APPEND(&oss, "blackLevelSeparate: %d %d %d %d\n", r->blackLevelSeparate(0),
-         r->blackLevelSeparate(1), r->blackLevelSeparate(2),
-         r->blackLevelSeparate(3));
+  APPEND(&oss, "blackLevelSeparate: (%i x %i)", r->blackLevelSeparate.size(),
+         r->blackLevelSeparate.size() != 0 ? 1 : 0);
+  if (r->blackLevelSeparate.size() != 0) {
+    for (auto l : r->blackLevelSeparate)
+      APPEND(&oss, " %d", l);
+  }
+  APPEND(&oss, "\n");
 
   APPEND(&oss, "wbCoeffs: %f %f %f %f\n",
          implicit_cast<double>(r->metadata.wbCoeffs[0]),

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -185,10 +185,11 @@ std::string img_hash(const RawImage& r, bool noSamples) {
   APPEND(&oss, "blackLevel: %d\n", r->blackLevel);
   APPEND(&oss, "whitePoint: %d\n", r->whitePoint);
 
-  APPEND(&oss, "blackLevelSeparate: (%i x %i)", r->blackLevelSeparate.size(),
-         r->blackLevelSeparate.size() != 0 ? 1 : 0);
-  if (r->blackLevelSeparate.size() != 0) {
-    for (auto l : r->blackLevelSeparate)
+  APPEND(&oss, "blackLevelSeparate: (%i x %i)", r->blackLevelSeparate.width,
+         r->blackLevelSeparate.height);
+  auto blackLevelSeparate1D = *r->blackLevelSeparate.getAsArray1DRef();
+  if (blackLevelSeparate1D.size() != 0) {
+    for (auto l : blackLevelSeparate1D)
       APPEND(&oss, " %d", l);
   }
   APPEND(&oss, "\n");

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -185,9 +185,10 @@ std::string img_hash(const RawImage& r, bool noSamples) {
   APPEND(&oss, "blackLevel: %d\n", r->blackLevel);
   APPEND(&oss, "whitePoint: %d\n", r->whitePoint);
 
-  APPEND(&oss, "blackLevelSeparate: %d %d %d %d\n", r->blackLevelSeparate[0],
-         r->blackLevelSeparate[1], r->blackLevelSeparate[2],
-         r->blackLevelSeparate[3]);
+  assert(r->blackLevelSeparate.size() == 4);
+  APPEND(&oss, "blackLevelSeparate: %d %d %d %d\n", r->blackLevelSeparate(0),
+         r->blackLevelSeparate(1), r->blackLevelSeparate(2),
+         r->blackLevelSeparate(3));
 
   APPEND(&oss, "wbCoeffs: %f %f %f %f\n",
          implicit_cast<double>(r->metadata.wbCoeffs[0]),

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -8,7 +8,6 @@ Checks: >
   -cppcoreguidelines-rvalue-reference-param-not-moved,
   -google-global-names-in-headers,
   -misc-definitions-in-headers,
-  -misc-include-cleaner,
   -misc-use-anonymous-namespace,
   -modernize-avoid-c-arrays,
   -modernize-type-traits,

--- a/test/librawspeed/adt/NORangesSetTest.cpp
+++ b/test/librawspeed/adt/NORangesSetTest.cpp
@@ -21,7 +21,6 @@
 #include "adt/NORangesSet.h"
 #include "adt/Range.h"
 #include "adt/RangeTest.h"
-#include <string>
 #include <tuple>
 #include <gtest/gtest.h>
 

--- a/test/librawspeed/adt/PointTest.cpp
+++ b/test/librawspeed/adt/PointTest.cpp
@@ -25,9 +25,7 @@
 #include <ostream>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <utility>
-#include <variant>
 #include <gtest/gtest.h>
 
 using rawspeed::iPoint2D;

--- a/test/librawspeed/adt/RangeTest.cpp
+++ b/test/librawspeed/adt/RangeTest.cpp
@@ -21,6 +21,7 @@
 #include "adt/Range.h"
 #include "adt/RangeTest.h"
 #include <set>
+#include <gtest/gtest.h>
 
 using rawspeed::Range;
 

--- a/test/librawspeed/codes/HuffmanCodeTest.cpp
+++ b/test/librawspeed/codes/HuffmanCodeTest.cpp
@@ -20,6 +20,8 @@
 
 #include "codes/HuffmanCode.h"
 #include "adt/Array1DRef.h"
+#include "adt/Casts.h"
+#include "codes/AbstractPrefixCode.h"
 #include "codes/AbstractPrefixCodeDecoder.h"
 #include "io/Buffer.h"
 #include <algorithm>
@@ -30,10 +32,13 @@
 #include <ostream>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 #include <gtest/gtest.h>
+
+#ifndef NDEBUG
+#include <cstdlib>
+#endif
 
 namespace rawspeed {
 struct BaselineCodeTag;

--- a/test/librawspeed/common/ChecksumFileTest.cpp
+++ b/test/librawspeed/common/ChecksumFileTest.cpp
@@ -20,7 +20,6 @@
 
 #include "common/ChecksumFile.h"
 #include "common/RawspeedException.h"
-#include <memory>
 #include <string>
 #include <vector>
 #include <gtest/gtest.h>

--- a/test/librawspeed/common/CommonTest.cpp
+++ b/test/librawspeed/common/CommonTest.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <vector>
 #include <gtest/gtest.h>
 

--- a/test/librawspeed/common/CpuidTest.cpp
+++ b/test/librawspeed/common/CpuidTest.cpp
@@ -21,7 +21,6 @@
 #include "rawspeedconfig.h" // IWYU pragma: keep
 #include "common/Cpuid.h"
 #include <cstdlib>
-#include <string>
 #include <gtest/gtest.h>
 
 using rawspeed::Cpuid;

--- a/test/librawspeed/common/SplineTest.cpp
+++ b/test/librawspeed/common/SplineTest.cpp
@@ -29,7 +29,6 @@
 #include <cstdlib>
 #include <iterator>
 #include <limits>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <tuple>

--- a/test/librawspeed/io/BitPumpJPEGTest.cpp
+++ b/test/librawspeed/io/BitPumpJPEGTest.cpp
@@ -20,14 +20,11 @@
 
 #include "io/BitPumpJPEG.h"
 #include "io/BitPumpTest.h"
-#include "io/BitStream.h"
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include "io/Endianness.h"
 #include <array>
 #include <cstdint>
-#include <initializer_list>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::BitPumpJPEG;

--- a/test/librawspeed/io/BitPumpLSBTest.cpp
+++ b/test/librawspeed/io/BitPumpLSBTest.cpp
@@ -22,7 +22,6 @@
 #include "io/BitPumpTest.h"
 #include <array>
 #include <cstdint>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::BitPumpLSB;

--- a/test/librawspeed/io/BitPumpMSB16Test.cpp
+++ b/test/librawspeed/io/BitPumpMSB16Test.cpp
@@ -22,7 +22,6 @@
 #include "io/BitPumpTest.h"
 #include <array>
 #include <cstdint>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::BitPumpMSB16;

--- a/test/librawspeed/io/BitPumpMSB32Test.cpp
+++ b/test/librawspeed/io/BitPumpMSB32Test.cpp
@@ -22,7 +22,6 @@
 #include "io/BitPumpTest.h"
 #include <array>
 #include <cstdint>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::BitPumpMSB32;

--- a/test/librawspeed/io/BitPumpMSBTest.cpp
+++ b/test/librawspeed/io/BitPumpMSBTest.cpp
@@ -22,7 +22,6 @@
 #include "io/BitPumpTest.h"
 #include <array>
 #include <cstdint>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::BitPumpMSB;

--- a/test/librawspeed/io/EndiannessTest.cpp
+++ b/test/librawspeed/io/EndiannessTest.cpp
@@ -20,11 +20,10 @@
 
 #include "EndiannessTest.h"
 #include "io/Endianness.h"
-#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
-#include <memory>
 #include <gtest/gtest.h>
 
 using rawspeed::Endianness;

--- a/test/librawspeed/metadata/BlackAreaTest.cpp
+++ b/test/librawspeed/metadata/BlackAreaTest.cpp
@@ -21,7 +21,6 @@
 
 #include "metadata/BlackArea.h"
 #include <memory>
-#include <string>
 #include <tuple>
 #include <gtest/gtest.h>
 

--- a/test/librawspeed/metadata/CameraSensorInfoTest.cpp
+++ b/test/librawspeed/metadata/CameraSensorInfoTest.cpp
@@ -25,7 +25,6 @@
 #include <iostream>
 #include <limits>
 #include <memory>
-#include <string>
 #include <tuple>
 #include <vector>
 #include <gmock/gmock.h>

--- a/test/librawspeed/metadata/ColorFilterArrayTest.cpp
+++ b/test/librawspeed/metadata/ColorFilterArrayTest.cpp
@@ -21,7 +21,6 @@
 
 #include "metadata/ColorFilterArray.h"
 #include "adt/Point.h"
-#include <algorithm>
 #include <cstdint>
 #include <iosfwd>
 #include <string>


### PR DESCRIPTION
`std::array<int, 4>` is neither expressive-enough, nor wide-enough.
It kind-of assumes that levels are specified for each color of Bayer (2x2) CFA,
which means it can't really represent X-Trans (6x6) CFA,
nor does it really work for non-CFA images (https://github.com/darktable-org/rawspeed/issues/215).

This only refactors it towards that goal, but does not actually add support for other cases.

If you used to have `mRaw->blackLevelSeparate[c]` in your code,
a no-op refactoring is:
```
  assert(mRaw->blackLevelSeparate.width == 2 && mRaw->blackLevelSeparate.height == 2);
  auto blackLevelSeparate1D = *mRaw->blackLevelSeparate.getAsArray1DRef();
<...>
  blackLevelSeparate1D(c)
```