### PR TITLE
Variable length load meandering

### DIFF
--- a/bench/librawspeed/adt/CMakeLists.txt
+++ b/bench/librawspeed/adt/CMakeLists.txt
@@ -1,5 +1,6 @@
 FILE(GLOB RAWSPEED_BENCHS_SOURCES
   "DefaultInitAllocatorAdaptorBenchmark.cpp"
+  "VariableLengthLoadBenchmark.cpp"
 )
 
 foreach(SRC ${RAWSPEED_BENCHS_SOURCES})

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -1,0 +1,120 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "adt/VariableLengthLoad.h"
+#include "adt/Array1DRef.h"
+#include "adt/Casts.h"
+#include "bench/Common.h"
+#include "common/Common.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <benchmark/benchmark.h>
+
+namespace rawspeed {
+
+namespace {}
+
+} // namespace rawspeed
+
+namespace {
+
+using rawspeed::variableLengthLoadNaiveViaMemcpy;
+
+template <decltype(variableLengthLoadNaiveViaMemcpy) Impl, typename T>
+void BM_Impl(benchmark::State& state) {
+  constexpr int bytesPerItem = sizeof(T);
+
+  int64_t numBytes = rawspeed::roundUp(state.range(0), bytesPerItem);
+  benchmark::DoNotOptimize(numBytes);
+
+  const std::vector<uint8_t> inStorage(
+      rawspeed::implicit_cast<size_t>(numBytes));
+
+  const auto in = rawspeed::Array1DRef<const uint8_t>(
+      inStorage.data(), rawspeed::implicit_cast<int>(numBytes));
+
+  std::array<uint8_t, bytesPerItem> outStorage;
+  auto out = rawspeed::Array1DRef<uint8_t>(
+      outStorage.data(), rawspeed::implicit_cast<int>(bytesPerItem));
+
+  for (auto _ : state) {
+    for (int inPos = 0; inPos < numBytes; inPos += bytesPerItem) {
+      Impl(out, in, inPos);
+      benchmark::DoNotOptimize(out.begin());
+    }
+  }
+
+  state.SetComplexityN(numBytes);
+  state.counters.insert({
+      {"Throughput",
+       benchmark::Counter(sizeof(uint8_t) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate,
+                          benchmark::Counter::kIs1024)},
+      {"Latency",
+       benchmark::Counter(sizeof(uint8_t) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate |
+                              benchmark::Counter::Flags::kInvert,
+                          benchmark::Counter::kIs1000)},
+  });
+}
+
+void CustomArguments(benchmark::internal::Benchmark* b) {
+  b->Unit(benchmark::kMicrosecond);
+
+  static constexpr int L1dByteSize = 32U * (1U << 10U);
+  static constexpr int L2dByteSize = 512U * (1U << 10U);
+  static constexpr int MaxBytesOptimal = L2dByteSize;
+
+  if (benchmarkDryRun()) {
+    b->Arg(L1dByteSize);
+    return;
+  }
+
+  b->RangeMultiplier(2);
+  if constexpr ((true))
+    b->Arg(MaxBytesOptimal);
+  else
+    b->Range(1, 2048UL << 20)->Complexity(benchmark::oN);
+}
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+#define GEN(I, T) BENCHMARK(BM_Impl<I, T>)->Apply(CustomArguments)
+
+#define GEN_CALLABLE(I)                                                        \
+  GEN(I, uint8_t);                                                             \
+  GEN(I, uint16_t);                                                            \
+  GEN(I, uint32_t);                                                            \
+  GEN(I, uint64_t)
+
+#define GEN_TIME() GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))
+
+#undef GEN_WRAPPER
+#define GEN_WRAPPER(I) I
+
+GEN_TIME();
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+} // namespace
+
+BENCHMARK_MAIN();

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -74,6 +74,7 @@ namespace {
 
 using rawspeed::fixedLengthLoad;
 using rawspeed::fixedLengthLoadOr;
+using rawspeed::variableLengthLoad;
 using rawspeed::variableLengthLoadNaiveViaConditionalLoad;
 using rawspeed::variableLengthLoadNaiveViaMemcpy;
 using rawspeed::variableLengthLoadNaiveViaStdCopy;
@@ -147,6 +148,7 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
 
 #define GEN_TIME()                                                             \
   GEN_CALLABLE(GEN_WRAPPER(fixedLengthLoad));                                  \
+  GEN_CALLABLE(GEN_WRAPPER(variableLengthLoad));                               \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaConditionalLoad));        \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaStdCopy));                \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -39,6 +39,7 @@ namespace {
 
 using rawspeed::variableLengthLoadNaiveViaConditionalLoad;
 using rawspeed::variableLengthLoadNaiveViaMemcpy;
+using rawspeed::variableLengthLoadNaiveViaStdCopy;
 
 template <decltype(variableLengthLoadNaiveViaMemcpy) Impl, typename T>
 void BM_Impl(benchmark::State& state) {
@@ -109,6 +110,7 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
 
 #define GEN_TIME()                                                             \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaConditionalLoad));        \
+  GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaStdCopy));                \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))
 
 #undef GEN_WRAPPER

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -46,7 +46,7 @@ namespace {
   invariant(inPos < in.size());
   invariant(inPos + out.size() <= in.size());
 
-  variableLengthLoadNaiveViaStdCopy(out, in, inPos);
+  variableLengthLoadNaiveViaMemcpy(out, in, inPos);
 }
 
 template <decltype(fixedLengthLoad) Callable>
@@ -77,7 +77,6 @@ using rawspeed::fixedLengthLoadOr;
 using rawspeed::variableLengthLoad;
 using rawspeed::variableLengthLoadNaiveViaConditionalLoad;
 using rawspeed::variableLengthLoadNaiveViaMemcpy;
-using rawspeed::variableLengthLoadNaiveViaStdCopy;
 
 template <decltype(variableLengthLoadNaiveViaMemcpy) Impl, typename T>
 void BM_Impl(benchmark::State& state) {
@@ -150,7 +149,6 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
   GEN_CALLABLE(GEN_WRAPPER(fixedLengthLoad));                                  \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoad));                               \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaConditionalLoad));        \
-  GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaStdCopy));                \
   GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))
 
 #undef GEN_WRAPPER

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -49,6 +49,23 @@ namespace {
   variableLengthLoadNaiveViaStdCopy(out, in, inPos);
 }
 
+template <decltype(fixedLengthLoad) Callable>
+[[maybe_unused]] inline void
+fixedLengthLoadOr(rawspeed::Array1DRef<uint8_t> out,
+                  rawspeed::Array1DRef<const uint8_t> in, int inPos) {
+  invariant(out.size() != 0);
+  invariant(in.size() != 0);
+  invariant(out.size() <= in.size());
+  invariant(inPos >= 0);
+
+  if (inPos + out.size() <= in.size()) {
+    fixedLengthLoad(out, in, inPos);
+    return;
+  }
+
+  Callable(out, in, inPos);
+}
+
 } // namespace
 
 } // namespace rawspeed
@@ -56,6 +73,7 @@ namespace {
 namespace {
 
 using rawspeed::fixedLengthLoad;
+using rawspeed::fixedLengthLoadOr;
 using rawspeed::variableLengthLoadNaiveViaConditionalLoad;
 using rawspeed::variableLengthLoadNaiveViaMemcpy;
 using rawspeed::variableLengthLoadNaiveViaStdCopy;
@@ -135,6 +153,11 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
 
 #undef GEN_WRAPPER
 #define GEN_WRAPPER(I) I
+
+GEN_TIME();
+
+#undef GEN_WRAPPER
+#define GEN_WRAPPER(I) fixedLengthLoadOr<I>
 
 GEN_TIME();
 

--- a/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
+++ b/bench/librawspeed/adt/VariableLengthLoadBenchmark.cpp
@@ -37,6 +37,7 @@ namespace {}
 
 namespace {
 
+using rawspeed::variableLengthLoadNaiveViaConditionalLoad;
 using rawspeed::variableLengthLoadNaiveViaMemcpy;
 
 template <decltype(variableLengthLoadNaiveViaMemcpy) Impl, typename T>
@@ -106,7 +107,9 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
   GEN(I, uint32_t);                                                            \
   GEN(I, uint64_t)
 
-#define GEN_TIME() GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))
+#define GEN_TIME()                                                             \
+  GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaConditionalLoad));        \
+  GEN_CALLABLE(GEN_WRAPPER(variableLengthLoadNaiveViaMemcpy))
 
 #undef GEN_WRAPPER
 #define GEN_WRAPPER(I) I

--- a/cmake/compiler-warnings-gcc.cmake
+++ b/cmake/compiler-warnings-gcc.cmake
@@ -36,6 +36,8 @@ endif()
 
 set (GCC_DISABLED_WARNING_FLAGS
   "unused-parameter"
+  "stringop-overflow" # bogus warnings at least as of GCC13
+  "array-bounds" # bogus warnings at least as of GCC13
 )
 
 set (GCC_NOERROR_WARNING_FLAGS

--- a/src/librawspeed/adt/CMakeLists.txt
+++ b/src/librawspeed/adt/CMakeLists.txt
@@ -16,6 +16,7 @@ FILE(GLOB SOURCES
   "NotARational.h"
   "Point.h"
   "Range.h"
+  "VariableLengthLoad.h"
   "iterator_range.h"
 )
 

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -45,6 +45,28 @@ inline void variableLengthLoadNaiveViaConditionalLoad(
   }
 }
 
+inline void variableLengthLoadNaiveViaStdCopy(Array1DRef<uint8_t> out,
+                                              Array1DRef<const uint8_t> in,
+                                              int inPos) {
+  invariant(out.size() != 0);
+  invariant(in.size() != 0);
+  invariant(out.size() <= in.size());
+  invariant(inPos >= 0);
+
+  inPos = std::min(inPos, in.size());
+
+  int inPosEnd = inPos + out.size();
+  inPosEnd = std::min(inPosEnd, in.size());
+  invariant(inPos <= inPosEnd);
+
+  const int copySize = inPosEnd - inPos;
+  invariant(copySize >= 0);
+  invariant(copySize <= out.size());
+
+  std::fill(out.begin(), out.end(), 0);
+  std::copy(in.addressOf(inPos), in.addressOf(inPosEnd), out.begin());
+}
+
 inline void variableLengthLoadNaiveViaMemcpy(Array1DRef<uint8_t> out,
                                              Array1DRef<const uint8_t> in,
                                              int inPos) {

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -28,6 +28,23 @@
 
 namespace rawspeed {
 
+inline void variableLengthLoadNaiveViaConditionalLoad(
+    Array1DRef<uint8_t> out, Array1DRef<const uint8_t> in, int inPos) {
+  invariant(out.size() != 0);
+  invariant(in.size() != 0);
+  invariant(out.size() <= in.size());
+  invariant(inPos >= 0);
+
+  std::fill(out.begin(), out.end(), 0);
+
+  for (int outIndex = 0; outIndex != out.size(); ++outIndex) {
+    const int inIndex = inPos + outIndex;
+    if (inIndex >= in.size())
+      return;
+    out(outIndex) = in(inIndex); // masked load
+  }
+}
+
 inline void variableLengthLoadNaiveViaMemcpy(Array1DRef<uint8_t> out,
                                              Array1DRef<const uint8_t> in,
                                              int inPos) {

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -1,0 +1,55 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "adt/Array1DRef.h"
+#include "adt/Invariant.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+namespace rawspeed {
+
+inline void variableLengthLoadNaiveViaMemcpy(Array1DRef<uint8_t> out,
+                                             Array1DRef<const uint8_t> in,
+                                             int inPos) {
+  invariant(out.size() != 0);
+  invariant(in.size() != 0);
+  invariant(out.size() <= in.size());
+  invariant(inPos >= 0);
+
+  std::fill(out.begin(), out.end(), 0);
+
+  // How many bytes are left in input buffer?
+  // Since pos can be past-the-end we need to carefully handle overflow.
+  int bytesRemaining = (inPos < in.size()) ? in.size() - inPos : 0;
+  // And if we are not at the end of the input, we may have more than we need.
+  bytesRemaining = std::min<int>(out.size(), bytesRemaining);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wunsafe-buffer-usage"
+  memcpy(out.begin(), in.begin() + inPos, bytesRemaining);
+#pragma GCC diagnostic pop
+}
+
+} // namespace rawspeed

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -25,6 +25,7 @@
 #include "adt/CroppedArray1DRef.h"
 #include "adt/Invariant.h"
 #include "common/Common.h"
+#include "io/Endianness.h"
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -86,12 +87,12 @@ inline void variableLengthLoad(Array1DRef<uint8_t> out,
   in = in.getCrop(inPos, out.size()).getAsArray1DRef();
   invariant(in.size() == out.size());
 
-  T tmp;
-  memcpy(&tmp, in.begin(), sizeof(T));
+  auto tmp = getLE<T>(in.begin());
 
   int posMismatchBits = CHAR_BIT * (-inPosFixup);
   tmp = logicalRightShiftSafe(tmp, posMismatchBits);
 
+  tmp = getLE<T>(&tmp);
   memcpy(out.begin(), &tmp, sizeof(T));
 }
 

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -173,20 +173,18 @@ inline void variableLengthLoadNaiveViaMemcpy(Array1DRef<uint8_t> out,
   invariant(out.size() <= in.size());
   invariant(inPos >= 0);
 
+  inPos = std::min(inPos, in.size());
+
+  int inPosEnd = inPos + out.size();
+  inPosEnd = std::min(inPosEnd, in.size());
+  invariant(inPos <= inPosEnd);
+
+  const int copySize = inPosEnd - inPos;
+  invariant(copySize >= 0);
+  invariant(copySize <= out.size());
+
   std::fill(out.begin(), out.end(), 0);
-
-  // How many bytes are left in input buffer?
-  // Since pos can be past-the-end we need to carefully handle overflow.
-  int bytesRemaining = (inPos < in.size()) ? in.size() - inPos : 0;
-  // And if we are not at the end of the input, we may have more than we need.
-  bytesRemaining = std::min<int>(out.size(), bytesRemaining);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#pragma GCC diagnostic ignored "-Wunsafe-buffer-usage"
-  memcpy(out.begin(), in.begin() + inPos, bytesRemaining);
-#pragma GCC diagnostic pop
+  memcpy(out.begin(), in.addressOf(inPos), copySize);
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -143,28 +143,6 @@ inline void variableLengthLoadNaiveViaConditionalLoad(
   }
 }
 
-inline void variableLengthLoadNaiveViaStdCopy(Array1DRef<uint8_t> out,
-                                              Array1DRef<const uint8_t> in,
-                                              int inPos) {
-  invariant(out.size() != 0);
-  invariant(in.size() != 0);
-  invariant(out.size() <= in.size());
-  invariant(inPos >= 0);
-
-  inPos = std::min(inPos, in.size());
-
-  int inPosEnd = inPos + out.size();
-  inPosEnd = std::min(inPosEnd, in.size());
-  invariant(inPos <= inPosEnd);
-
-  const int copySize = inPosEnd - inPos;
-  invariant(copySize >= 0);
-  invariant(copySize <= out.size());
-
-  std::fill(out.begin(), out.end(), 0);
-  std::copy(in.addressOf(inPos), in.addressOf(inPosEnd), out.begin());
-}
-
 inline void variableLengthLoadNaiveViaMemcpy(Array1DRef<uint8_t> out,
                                              Array1DRef<const uint8_t> in,
                                              int inPos) {

--- a/src/librawspeed/adt/VariableLengthLoad.h
+++ b/src/librawspeed/adt/VariableLengthLoad.h
@@ -21,12 +21,109 @@
 #pragma once
 
 #include "adt/Array1DRef.h"
+#include "adt/Casts.h"
+#include "adt/CroppedArray1DRef.h"
 #include "adt/Invariant.h"
+#include "common/Common.h"
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 namespace rawspeed {
+
+namespace impl {
+
+template <typename T> struct zext {};
+
+template <> struct zext<uint8_t> {
+  using type = uint16_t;
+};
+template <> struct zext<uint16_t> {
+  using type = uint32_t;
+};
+template <> struct zext<uint32_t> {
+  using type = uint64_t;
+};
+
+template <typename T>
+concept CanZExt = requires { typename zext<T>::type; };
+
+template <typename T>
+  requires std::is_unsigned_v<T> && CanZExt<T>
+inline T logicalRightShiftSafe(T val, int shAmt) {
+  invariant(shAmt >= 0);
+  shAmt = std::min(shAmt, implicit_cast<int>(bitwidth<T>()));
+  using WideT = typename zext<T>::type;
+  auto valWide = static_cast<WideT>(val);
+  valWide >>= shAmt;
+  return implicit_cast<T>(valWide);
+}
+
+template <typename T>
+  requires std::is_unsigned_v<T> && (!CanZExt<T>)
+inline T logicalRightShiftSafe(T val, int shAmt) {
+  invariant(shAmt >= 0);
+  if (shAmt >= implicit_cast<int>(bitwidth<T>()))
+    return 0;
+  val >>= shAmt;
+  return val;
+}
+
+template <typename T>
+  requires std::is_unsigned_v<T>
+inline void variableLengthLoad(Array1DRef<uint8_t> out,
+                               Array1DRef<const uint8_t> in, int inPos) {
+  invariant(out.size() == sizeof(T));
+
+  int inPosFixup = 0;
+  if (int inPosEnd = inPos + out.size(); in.size() < inPosEnd)
+    inPosFixup = in.size() - inPosEnd;
+  invariant(inPosFixup <= 0);
+
+  inPos += inPosFixup;
+
+  in = in.getCrop(inPos, out.size()).getAsArray1DRef();
+  invariant(in.size() == out.size());
+
+  T tmp;
+  memcpy(&tmp, in.begin(), sizeof(T));
+
+  int posMismatchBits = CHAR_BIT * (-inPosFixup);
+  tmp = logicalRightShiftSafe(tmp, posMismatchBits);
+
+  memcpy(out.begin(), &tmp, sizeof(T));
+}
+
+} // namespace impl
+
+inline void variableLengthLoad(const Array1DRef<uint8_t> out,
+                               Array1DRef<const uint8_t> in, int inPos) {
+
+  invariant(out.size() != 0);
+  invariant(isPowerOfTwo(out.size()));
+  invariant(out.size() <= 8);
+  invariant(in.size() != 0);
+  invariant(out.size() <= in.size());
+  invariant(inPos >= 0);
+
+  switch (out.size()) {
+  case 1:
+    impl::variableLengthLoad<uint8_t>(out, in, inPos);
+    return;
+  case 2:
+    impl::variableLengthLoad<uint16_t>(out, in, inPos);
+    return;
+  case 4:
+    impl::variableLengthLoad<uint32_t>(out, in, inPos);
+    return;
+  case 8:
+    impl::variableLengthLoad<uint64_t>(out, in, inPos);
+    return;
+  default:
+    __builtin_unreachable();
+  }
+}
 
 inline void variableLengthLoadNaiveViaConditionalLoad(
     Array1DRef<uint8_t> out, Array1DRef<const uint8_t> in, int inPos) {

--- a/test/librawspeed/adt/CMakeLists.txt
+++ b/test/librawspeed/adt/CMakeLists.txt
@@ -2,6 +2,7 @@ FILE(GLOB RAWSPEED_TEST_SOURCES
   "NORangesSetTest.cpp"
   "PointTest.cpp"
   "RangeTest.cpp"
+  "VariableLengthLoadTest.cpp"
 )
 
 foreach(SRC ${RAWSPEED_TEST_SOURCES})

--- a/test/librawspeed/adt/VariableLengthLoadTest.cpp
+++ b/test/librawspeed/adt/VariableLengthLoadTest.cpp
@@ -97,6 +97,14 @@ TEST(VariableLengthLoadTest, Exhaustive) {
             outputImpl2, Array1DRef<const unsigned char>(input), inPos);
 
         EXPECT_THAT(outputImpl2, testing::ContainerEq(outputReference));
+
+        std::vector<unsigned char> outputImpl3Storage(numOutputBytes);
+        auto outputImpl3 =
+            Array1DRef(outputImpl3Storage.data(), numOutputBytes);
+        variableLengthLoad(outputImpl3, Array1DRef<const unsigned char>(input),
+                           inPos);
+
+        EXPECT_THAT(outputImpl3, testing::ContainerEq(outputReference));
       }
     }
   }

--- a/test/librawspeed/adt/VariableLengthLoadTest.cpp
+++ b/test/librawspeed/adt/VariableLengthLoadTest.cpp
@@ -89,6 +89,14 @@ TEST(VariableLengthLoadTest, Exhaustive) {
             outputImpl1, Array1DRef<const unsigned char>(input), inPos);
 
         EXPECT_THAT(outputImpl1, testing::ContainerEq(outputReference));
+
+        std::vector<unsigned char> outputImpl2Storage(numOutputBytes);
+        auto outputImpl2 =
+            Array1DRef(outputImpl2Storage.data(), numOutputBytes);
+        variableLengthLoadNaiveViaStdCopy(
+            outputImpl2, Array1DRef<const unsigned char>(input), inPos);
+
+        EXPECT_THAT(outputImpl2, testing::ContainerEq(outputReference));
       }
     }
   }

--- a/test/librawspeed/adt/VariableLengthLoadTest.cpp
+++ b/test/librawspeed/adt/VariableLengthLoadTest.cpp
@@ -1,0 +1,89 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; withexpected even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "adt/VariableLengthLoad.h"
+#include "adt/Array1DRef.h"
+#include <algorithm>
+#include <numeric>
+#include <ostream>
+#include <vector>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace rawspeed {
+
+template <typename T>
+bool operator==(const rawspeed::Array1DRef<T> a,
+                const rawspeed::Array1DRef<T> b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+
+template <typename T>
+::std::ostream& operator<<(::std::ostream& os, const Array1DRef<T>& r) {
+  os << "{";
+  for (int i = 0; i != r.size(); ++i) {
+    if (i != 0)
+      os << ", ";
+    os << r(i);
+  }
+  os << "}";
+  return os;
+}
+
+} // namespace rawspeed
+
+using rawspeed::Array1DRef;
+
+namespace rawpeed_test {
+
+TEST(VariableLengthLoadTest, Exhaustive) {
+  static constexpr int MaxBytes = 256;
+
+  for (int numInputBytes = 1; numInputBytes <= MaxBytes; ++numInputBytes) {
+    std::vector<unsigned char> inputStorage(numInputBytes);
+    auto input = Array1DRef(inputStorage.data(), numInputBytes);
+    std::iota(input.begin(), input.end(), 0);
+
+    for (int numOutputBytes = 1;
+         numOutputBytes <= numInputBytes && numOutputBytes <= 8;
+         numOutputBytes *= 2) {
+      for (int inPos = 0; inPos <= 4 * numInputBytes; ++inPos) {
+        std::vector<unsigned char> outputReferenceStorage(numOutputBytes);
+        auto outputReference =
+            Array1DRef(outputReferenceStorage.data(), numOutputBytes);
+        std::fill(outputReference.begin(), outputReference.end(), 0);
+        std::iota(outputReference.begin(),
+                  outputReference.addressOf(
+                      std::clamp(numInputBytes - inPos, 0, numOutputBytes)),
+                  inPos);
+
+        std::vector<unsigned char> outputImpl0Storage(numOutputBytes);
+        auto outputImpl0 =
+            Array1DRef(outputImpl0Storage.data(), numOutputBytes);
+        variableLengthLoadNaiveViaMemcpy(
+            outputImpl0, Array1DRef<const unsigned char>(input), inPos);
+
+        EXPECT_THAT(outputImpl0, testing::ContainerEq(outputReference));
+      }
+    }
+  }
+}
+
+} // namespace rawpeed_test

--- a/test/librawspeed/adt/VariableLengthLoadTest.cpp
+++ b/test/librawspeed/adt/VariableLengthLoadTest.cpp
@@ -93,18 +93,10 @@ TEST(VariableLengthLoadTest, Exhaustive) {
         std::vector<unsigned char> outputImpl2Storage(numOutputBytes);
         auto outputImpl2 =
             Array1DRef(outputImpl2Storage.data(), numOutputBytes);
-        variableLengthLoadNaiveViaStdCopy(
-            outputImpl2, Array1DRef<const unsigned char>(input), inPos);
-
-        EXPECT_THAT(outputImpl2, testing::ContainerEq(outputReference));
-
-        std::vector<unsigned char> outputImpl3Storage(numOutputBytes);
-        auto outputImpl3 =
-            Array1DRef(outputImpl3Storage.data(), numOutputBytes);
-        variableLengthLoad(outputImpl3, Array1DRef<const unsigned char>(input),
+        variableLengthLoad(outputImpl2, Array1DRef<const unsigned char>(input),
                            inPos);
 
-        EXPECT_THAT(outputImpl3, testing::ContainerEq(outputReference));
+        EXPECT_THAT(outputImpl2, testing::ContainerEq(outputReference));
       }
     }
   }

--- a/test/librawspeed/adt/VariableLengthLoadTest.cpp
+++ b/test/librawspeed/adt/VariableLengthLoadTest.cpp
@@ -81,6 +81,14 @@ TEST(VariableLengthLoadTest, Exhaustive) {
             outputImpl0, Array1DRef<const unsigned char>(input), inPos);
 
         EXPECT_THAT(outputImpl0, testing::ContainerEq(outputReference));
+
+        std::vector<unsigned char> outputImpl1Storage(numOutputBytes);
+        auto outputImpl1 =
+            Array1DRef(outputImpl1Storage.data(), numOutputBytes);
+        variableLengthLoadNaiveViaConditionalLoad(
+            outputImpl1, Array1DRef<const unsigned char>(input), inPos);
+
+        EXPECT_THAT(outputImpl1, testing::ContainerEq(outputReference));
       }
     }
   }


### PR DESCRIPTION
```
build-Clang17-release$ bench/librawspeed/adt/VariableLengthLoadBenchmark --benchmark_filter="uint[3][2]_t" --benchmark_repetitions=1000 --benchmark_min_time=1x --benchmark_display_aggregates_only=true
2024-01-07T03:11:09+03:00
Running bench/librawspeed/adt/VariableLengthLoadBenchmark
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 1.45, 1.13, 1.00
--------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                              Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Impl<fixedLengthLoad, uint32_t>/524288_mean                                                      58.0 us         58.0 us         1000 Latency=121.66ps Throughput=8.41783Gi/s
BM_Impl<fixedLengthLoad, uint32_t>/524288_median                                                    58.0 us         58.0 us         1000 Latency=121.53ps Throughput=8.42591Gi/s
BM_Impl<fixedLengthLoad, uint32_t>/524288_stddev                                                   0.732 us        0.652 us         1000 Latency=1.36709ps Throughput=83.6357Mi/s
BM_Impl<fixedLengthLoad, uint32_t>/524288_cv                                                        1.26 %          1.12 %          1000 Latency=1.12% Throughput=0.97%
BM_Impl<variableLengthLoad, uint32_t>/524288_mean                                                    116 us          116 us         1000 Latency=243.646ps Throughput=4.20289Gi/s
BM_Impl<variableLengthLoad, uint32_t>/524288_median                                                  116 us          116 us         1000 Latency=243.479ps Throughput=4.2057Gi/s
BM_Impl<variableLengthLoad, uint32_t>/524288_stddev                                                0.486 us        0.484 us         1000 Latency=1.01467ps Throughput=17.4973Mi/s
BM_Impl<variableLengthLoad, uint32_t>/524288_cv                                                     0.42 %          0.42 %          1000 Latency=0.42% Throughput=0.41%
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint32_t>/524288_mean                             168 us          168 us         1000 Latency=351.597ps Throughput=2.91248Gi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint32_t>/524288_median                           168 us          168 us         1000 Latency=351.294ps Throughput=2.91494Gi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint32_t>/524288_stddev                         0.834 us        0.731 us         1000 Latency=1.5323ps Throughput=12.5236Mi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint32_t>/524288_cv                              0.50 %          0.44 %          1000 Latency=0.44% Throughput=0.42%
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint32_t>/524288_mean                                     540 us          540 us         1000 Latency=1.10682ns Throughput=925.179Mi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint32_t>/524288_median                                   540 us          540 us         1000 Latency=1.10606ns Throughput=925.806Mi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint32_t>/524288_stddev                                  1.24 us         1.11 us         1000 Latency=2.31991ps Throughput=1.86664Mi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint32_t>/524288_cv                                      0.23 %          0.20 %          1000 Latency=0.20% Throughput=0.20%
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint32_t>/524288_mean                                      540 us          540 us         1000 Latency=1.10669ns Throughput=925.28Mi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint32_t>/524288_median                                    540 us          540 us         1000 Latency=1.10608ns Throughput=925.789Mi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint32_t>/524288_stddev                                  0.928 us        0.790 us         1000 Latency=1.65743ps Throughput=1.34762Mi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint32_t>/524288_cv                                       0.17 %          0.15 %          1000 Latency=0.15% Throughput=0.15%
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint32_t>/524288_mean                                   58.0 us         58.0 us         1000 Latency=121.602ps Throughput=8.42126Gi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint32_t>/524288_median                                 58.0 us         57.9 us         1000 Latency=121.509ps Throughput=8.42736Gi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint32_t>/524288_stddev                                0.368 us        0.367 us         1000 Latency=787.756fs Throughput=51.6112Mi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint32_t>/524288_cv                                     0.63 %          0.63 %          1000 Latency=0.63% Throughput=0.60%
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint32_t>/524288_mean                                77.5 us         77.5 us         1000 Latency=162.545ps Throughput=6.29993Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint32_t>/524288_median                              77.5 us         77.4 us         1000 Latency=162.403ps Throughput=6.30528Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint32_t>/524288_stddev                             0.378 us        0.378 us         1000 Latency=811.311fs Throughput=30.3316Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint32_t>/524288_cv                                  0.49 %          0.49 %          1000 Latency=0.49% Throughput=0.47%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint32_t>/524288_mean         77.7 us         77.7 us         1000 Latency=162.858ps Throughput=6.28787Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint32_t>/524288_median       77.6 us         77.6 us         1000 Latency=162.739ps Throughput=6.29228Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint32_t>/524288_stddev      0.517 us        0.446 us         1000 Latency=958.27fs Throughput=35.4747Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint32_t>/524288_cv           0.67 %          0.57 %          1000 Latency=0.57% Throughput=0.55%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint32_t>/524288_mean                 77.9 us         77.9 us         1000 Latency=163.389ps Throughput=6.2674Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint32_t>/524288_median               77.8 us         77.8 us         1000 Latency=163.221ps Throughput=6.27369Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint32_t>/524288_stddev              0.380 us        0.379 us         1000 Latency=813.353fs Throughput=30.1957Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint32_t>/524288_cv                   0.49 %          0.49 %          1000 Latency=0.49% Throughput=0.47%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint32_t>/524288_mean                  78.2 us         78.1 us         1000 Latency=163.884ps Throughput=6.24847Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint32_t>/524288_median                78.1 us         78.1 us         1000 Latency=163.788ps Throughput=6.252Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint32_t>/524288_stddev               0.367 us        0.367 us         1000 Latency=787.45fs Throughput=28.9555Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint32_t>/524288_cv                    0.47 %          0.47 %          1000 Latency=0.47% Throughput=0.45%

```

```
build-Clang17-release$ bench/librawspeed/adt/VariableLengthLoadBenchmark --benchmark_filter="uint[6][4]_t" --benchmark_repetitions=1000 --benchmark_min_time=1x --benchmark_display_aggregates_only=true
2024-01-07T03:11:22+03:00
Running bench/librawspeed/adt/VariableLengthLoadBenchmark
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 1.42, 1.14, 1.00
--------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                              Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Impl<fixedLengthLoad, uint64_t>/524288_mean                                                      40.2 us         40.2 us         1000 Latency=84.229ps Throughput=12.1596Gi/s
BM_Impl<fixedLengthLoad, uint64_t>/524288_median                                                    40.2 us         40.1 us         1000 Latency=84.1797ps Throughput=12.1645Gi/s
BM_Impl<fixedLengthLoad, uint64_t>/524288_stddev                                                   0.639 us        0.602 us         1000 Latency=1.26238ps Throughput=157.635Mi/s
BM_Impl<fixedLengthLoad, uint64_t>/524288_cv                                                        1.59 %          1.50 %          1000 Latency=1.50% Throughput=1.27%
BM_Impl<variableLengthLoad, uint64_t>/524288_mean                                                   58.4 us         58.4 us         1000 Latency=122.476ps Throughput=8.36111Gi/s
BM_Impl<variableLengthLoad, uint64_t>/524288_median                                                 58.4 us         58.4 us         1000 Latency=122.39ps Throughput=8.36671Gi/s
BM_Impl<variableLengthLoad, uint64_t>/524288_stddev                                                0.360 us        0.358 us         1000 Latency=769.389fs Throughput=49.8219Mi/s
BM_Impl<variableLengthLoad, uint64_t>/524288_cv                                                     0.62 %          0.61 %          1000 Latency=0.61% Throughput=0.58%
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint64_t>/524288_mean                             137 us          137 us         1000 Latency=286.67ps Throughput=3.57213Gi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint64_t>/524288_median                           137 us          137 us         1000 Latency=286.607ps Throughput=3.57283Gi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint64_t>/524288_stddev                         0.650 us        0.649 us         1000 Latency=1.36204ps Throughput=16.3394Mi/s
BM_Impl<variableLengthLoadNaiveViaConditionalLoad, uint64_t>/524288_cv                              0.48 %          0.48 %          1000 Latency=0.48% Throughput=0.45%
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint64_t>/524288_mean                                     251 us          251 us         1000 Latency=526.61ps Throughput=1.94453Gi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint64_t>/524288_median                                   251 us          251 us         1000 Latency=526.28ps Throughput=1.94573Gi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint64_t>/524288_stddev                                 0.756 us        0.677 us         1000 Latency=1.41881ps Throughput=5.28031Mi/s
BM_Impl<variableLengthLoadNaiveViaStdCopy, uint64_t>/524288_cv                                      0.30 %          0.27 %          1000 Latency=0.27% Throughput=0.27%
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint64_t>/524288_mean                                      251 us          251 us         1000 Latency=526.693ps Throughput=1.94422Gi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint64_t>/524288_median                                    251 us          251 us         1000 Latency=526.364ps Throughput=1.94542Gi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint64_t>/524288_stddev                                  0.845 us        0.700 us         1000 Latency=1.46732ps Throughput=5.45387Mi/s
BM_Impl<variableLengthLoadNaiveViaMemcpy, uint64_t>/524288_cv                                       0.34 %          0.28 %          1000 Latency=0.28% Throughput=0.27%
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint64_t>/524288_mean                                   40.2 us         40.2 us         1000 Latency=84.2051ps Throughput=12.1615Gi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint64_t>/524288_median                                 40.2 us         40.2 us         1000 Latency=84.2426ps Throughput=12.1554Gi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint64_t>/524288_stddev                                0.310 us        0.309 us         1000 Latency=663.128fs Throughput=90.6958Mi/s
BM_Impl<fixedLengthLoadOr<fixedLengthLoad>, uint64_t>/524288_cv                                     0.77 %          0.77 %          1000 Latency=0.77% Throughput=0.73%
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint64_t>/524288_mean                                58.1 us         58.1 us         1000 Latency=121.842ps Throughput=8.41092Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint64_t>/524288_median                              58.2 us         58.1 us         1000 Latency=121.949ps Throughput=8.39693Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint64_t>/524288_stddev                              1.35 us         1.35 us         1000 Latency=2.84149ps Throughput=289.884Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoad>, uint64_t>/524288_cv                                  2.33 %          2.33 %          1000 Latency=2.33% Throughput=3.37%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint64_t>/524288_mean         39.3 us         39.3 us         1000 Latency=82.388ps Throughput=12.4299Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint64_t>/524288_median       39.2 us         39.2 us         1000 Latency=82.2503ps Throughput=12.4498Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint64_t>/524288_stddev      0.357 us        0.356 us         1000 Latency=763.755fs Throughput=105.899Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaConditionalLoad>, uint64_t>/524288_cv           0.91 %          0.91 %          1000 Latency=0.91% Throughput=0.83%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint64_t>/524288_mean                 39.3 us         39.3 us         1000 Latency=82.3689ps Throughput=12.4334Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint64_t>/524288_median               39.2 us         39.2 us         1000 Latency=82.3132ps Throughput=12.4403Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint64_t>/524288_stddev              0.486 us        0.484 us         1000 Latency=1.01573ps Throughput=125.609Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaStdCopy>, uint64_t>/524288_cv                   1.24 %          1.23 %          1000 Latency=1.23% Throughput=0.99%
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint64_t>/524288_mean                  39.7 us         39.7 us         1000 Latency=83.2796ps Throughput=12.2968Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint64_t>/524288_median                39.7 us         39.7 us         1000 Latency=83.215ps Throughput=12.3055Gi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint64_t>/524288_stddev               0.434 us        0.346 us         1000 Latency=742.698fs Throughput=101.825Mi/s
BM_Impl<fixedLengthLoadOr<variableLengthLoadNaiveViaMemcpy>, uint64_t>/524288_cv                    1.09 %          0.87 %          1000 Latency=0.87% Throughput=0.81%

```