### PR TITLE
Ban `std::optional`

### DIFF
--- a/cmake/compiler-warnings-gcc.cmake
+++ b/cmake/compiler-warnings-gcc.cmake
@@ -36,6 +36,7 @@ endif()
 
 set (GCC_DISABLED_WARNING_FLAGS
   "unused-parameter"
+  "maybe-uninitialized"
   "stringop-overflow" # bogus warnings at least as of GCC13
   "array-bounds" # bogus warnings at least as of GCC13
 )

--- a/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
+++ b/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "adt/Array1DRef.h"
+#include "adt/Optional.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
 #include "codes/PrefixCode.h"
@@ -147,7 +148,7 @@ template <typename T>
 static T createPrefixCodeDecoder(rawspeed::ByteStream& bs) {
   using CodeTag = typename T::Tag;
 
-  std::optional<T> ht;
+  rawspeed::Optional<T> ht;
   if (bool huffmanCode = bs.getByte() != 0; huffmanCode)
     ht = createHuffmanPrefixCodeDecoderImpl<T, CodeTag>(bs);
   else

--- a/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
+++ b/fuzz/librawspeed/codes/PrefixCodeDecoder/Common.h
@@ -30,7 +30,6 @@
 #include "io/ByteStream.h"
 #include <cassert>
 #include <cstdint>
-#include <optional>
 #include <type_traits>
 #include <vector>
 

--- a/fuzz/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -21,6 +21,7 @@
 #include "decompressors/PentaxDecompressor.h"
 #include "MemorySanitizer.h"
 #include "adt/Casts.h"
+#include "adt/Optional.h"
 #include "common/RawImage.h"
 #include "common/RawspeedException.h"
 #include "fuzz/Common.h"
@@ -30,7 +31,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
-#include <optional>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size);
 
@@ -45,7 +45,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
 
     rawspeed::RawImage mRaw(CreateRawImage(bs));
 
-    std::optional<rawspeed::ByteStream> metaData;
+    rawspeed::Optional<rawspeed::ByteStream> metaData;
 
     const bool haveMetadata = bs.get<uint32_t>();
     if (haveMetadata) {

--- a/src/librawspeed/adt/Array2DRef.h
+++ b/src/librawspeed/adt/Array2DRef.h
@@ -25,7 +25,6 @@
 #include "adt/Invariant.h"
 #include "adt/Optional.h"
 #include <cstddef>
-#include <optional>
 #include <type_traits>
 #include <vector>
 

--- a/src/librawspeed/adt/Array2DRef.h
+++ b/src/librawspeed/adt/Array2DRef.h
@@ -23,6 +23,7 @@
 
 #include "adt/Array1DRef.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include <cstddef>
 #include <optional>
 #include <type_traits>
@@ -93,7 +94,7 @@ public:
     return {storage.data(), width, height};
   }
 
-  [[nodiscard]] std::optional<Array1DRef<T>> getAsArray1DRef() const;
+  [[nodiscard]] Optional<Array1DRef<T>> getAsArray1DRef() const;
 
   Array1DRef<T> operator[](int row) const;
 
@@ -123,7 +124,7 @@ Array2DRef<T>::Array2DRef(T* data, const int width_, const int height_,
 }
 
 template <class T>
-[[nodiscard]] inline std::optional<Array1DRef<T>>
+[[nodiscard]] inline Optional<Array1DRef<T>>
 Array2DRef<T>::getAsArray1DRef() const {
   // FIXME: this might be called for default-constructed `Array2DRef`,
   // and it really doesn't work for them.

--- a/src/librawspeed/adt/Optional.h
+++ b/src/librawspeed/adt/Optional.h
@@ -1,0 +1,29 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include <optional>
+
+namespace rawspeed {
+
+template <typename T> using Optional = std::optional<T>;
+
+} // namespace rawspeed

--- a/src/librawspeed/codes/PrefixCodeTreeDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeTreeDecoder.h
@@ -28,7 +28,6 @@
 #include "decoders/RawDecoderException.h"
 #include "io/BitStream.h"
 #include <cassert>
-#include <optional>
 #include <tuple>
 #include <utility>
 

--- a/src/librawspeed/codes/PrefixCodeTreeDecoder.h
+++ b/src/librawspeed/codes/PrefixCodeTreeDecoder.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "codes/AbstractPrefixCodeDecoder.h"
 #include "codes/BinaryPrefixTree.h"
 #include "decoders/RawDecoderException.h"
@@ -57,8 +58,7 @@ protected:
     const auto* top = &(tree.root->getAsBranch());
 
     auto walkBinaryTree = [&partial, &top](bool bit)
-        -> std::optional<
-            std::pair<typename Base::CodeSymbol, int /*codeValue*/>> {
+        -> Optional<std::pair<typename Base::CodeSymbol, int /*codeValue*/>> {
       partial.code <<= 1;
       partial.code |= bit;
       partial.code_len++;

--- a/src/librawspeed/common/BayerPhase.h
+++ b/src/librawspeed/common/BayerPhase.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "adt/Array2DRef.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "metadata/ColorFilterArray.h"
 #include <algorithm>
@@ -29,7 +30,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <iterator>
-#include <optional>
 #include <utility>
 
 namespace rawspeed {
@@ -127,7 +127,7 @@ inline std::array<T, 4> applyStablePhaseShift(std::array<T, 4> srcData,
   return tgtData;
 }
 
-inline std::optional<BayerPhase> getAsBayerPhase(const ColorFilterArray& CFA) {
+inline Optional<BayerPhase> getAsBayerPhase(const ColorFilterArray& CFA) {
   if (CFA.getSize() != iPoint2D(2, 2))
     return {};
 

--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -42,7 +42,6 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -25,6 +25,7 @@
 #include "adt/Casts.h"
 #include "adt/CroppedArray2DRef.h"
 #include "adt/Mutex.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -743,7 +744,7 @@ DngOpcodes::constructor(const RawImage& ri, ByteStream& bs,
 
 // ALL opcodes specified in DNG Specification MUST be listed here.
 // however, some of them might not be implemented.
-std::optional<std::pair<const char*, DngOpcodes::constructor_t>>
+Optional<std::pair<const char*, DngOpcodes::constructor_t>>
 DngOpcodes::Map(uint32_t code) {
   switch (code) {
   case 1U:

--- a/src/librawspeed/common/DngOpcodes.h
+++ b/src/librawspeed/common/DngOpcodes.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
+#include "adt/Optional.h"
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -65,7 +65,7 @@ private:
 
   using constructor_t = std::unique_ptr<DngOpcode> (*)(
       const RawImage& ri, ByteStream& bs, iRectangle2D& integrated_subimg);
-  static std::optional<std::pair<const char*, DngOpcodes::constructor_t>>
+  static Optional<std::pair<const char*, DngOpcodes::constructor_t>>
   Map(uint32_t code);
 };
 

--- a/src/librawspeed/common/XTransPhase.h
+++ b/src/librawspeed/common/XTransPhase.h
@@ -21,13 +21,13 @@
 #pragma once
 
 #include "adt/Array2DRef.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "metadata/ColorFilterArray.h"
 #include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
-#include <optional>
 
 namespace rawspeed {
 
@@ -70,8 +70,7 @@ inline std::array<CFAColor, 6 * 6> getAsCFAColors(XTransPhase p) {
   return applyPhaseShift(basePat, basePhase, /*tgtPhase=*/p);
 }
 
-inline std::optional<XTransPhase>
-getAsXTransPhase(const ColorFilterArray& CFA) {
+inline Optional<XTransPhase> getAsXTransPhase(const ColorFilterArray& CFA) {
   if (CFA.getSize() != iPoint2D(6, 6))
     return {};
 

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -239,7 +240,7 @@ enum class ColorDataFormat {
   ColorData8,
 };
 
-[[nodiscard]] std::optional<std::pair<ColorDataFormat, std::optional<int>>>
+[[nodiscard]] Optional<std::pair<ColorDataFormat, Optional<int>>>
 deduceColorDataFormat(const TiffEntry* ccd) {
   // The original ColorData, detect by it's fixed size.
   if (ccd->count == 582)
@@ -307,9 +308,9 @@ deduceColorDataFormat(const TiffEntry* ccd) {
   __builtin_unreachable();
 }
 
-[[nodiscard]] std::optional<std::pair<int, int>>
+[[nodiscard]] Optional<std::pair<int, int>>
 getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
-                                        std::optional<int> colorDataVersion) {
+                                        Optional<int> colorDataVersion) {
   switch (f) {
     using enum ColorDataFormat;
   case ColorData1:
@@ -374,9 +375,8 @@ getBlackAndWhiteLevelOffsetsInColorData(ColorDataFormat f,
   __builtin_unreachable();
 }
 
-[[nodiscard]] bool
-shouldRescaleBlackLevels(ColorDataFormat f,
-                         std::optional<int> colorDataVersion) {
+[[nodiscard]] bool shouldRescaleBlackLevels(ColorDataFormat f,
+                                            Optional<int> colorDataVersion) {
   return f != ColorDataFormat::ColorData5 || colorDataVersion != -3;
 }
 

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -46,7 +46,6 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -49,7 +49,6 @@
 #include <limits>
 #include <map>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Casts.h"
 #include "adt/NORangesSet.h"
 #include "adt/NotARational.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/DngOpcodes.h"
@@ -153,8 +154,7 @@ void DngDecoder::dropUnsuportedChunks(std::vector<const TiffIFD*>* data) {
   }
 }
 
-std::optional<iRectangle2D>
-DngDecoder::parseACTIVEAREA(const TiffIFD* raw) const {
+Optional<iRectangle2D> DngDecoder::parseACTIVEAREA(const TiffIFD* raw) const {
   if (!raw->hasEntry(TiffTag::ACTIVEAREA))
     return {};
 
@@ -188,7 +188,7 @@ DngDecoder::parseACTIVEAREA(const TiffIFD* raw) const {
 }
 
 namespace {
-std::optional<CFAColor> getDNGCFAPatternAsCFAColor(uint32_t c) {
+Optional<CFAColor> getDNGCFAPatternAsCFAColor(uint32_t c) {
   switch (c) {
     using enum CFAColor;
   case 0:
@@ -251,7 +251,7 @@ void DngDecoder::parseCFA(const TiffIFD* raw) const {
   // the cfa is specified relative to the ActiveArea. we want it relative (0,0)
   // Since in handleMetadata(), in subFrame() we unconditionally shift CFA by
   // activearea+DefaultCropOrigin; here we need to undo the 'ACTIVEAREA' part.
-  const std::optional<iRectangle2D> aa = parseACTIVEAREA(raw);
+  const Optional<iRectangle2D> aa = parseACTIVEAREA(raw);
   if (!aa)
     return;
 
@@ -515,7 +515,7 @@ RawImage DngDecoder::decodeRawInternal() {
 
 void DngDecoder::handleMetadata(const TiffIFD* raw) {
   // Crop
-  if (const std::optional<iRectangle2D> aa = parseACTIVEAREA(raw))
+  if (const Optional<iRectangle2D> aa = parseACTIVEAREA(raw))
     mRaw->subFrame(*aa);
 
   if (raw->hasEntry(TiffTag::DEFAULTCROPORIGIN) &&

--- a/src/librawspeed/decoders/DngDecoder.h
+++ b/src/librawspeed/decoders/DngDecoder.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include "adt/Optional.h"
 #include "common/RawImage.h"
 #include "decoders/AbstractTiffDecoder.h"
 #include "tiff/TiffIFD.h"
 #include <cstdint>
-#include <optional>
 #include <vector>
 
 namespace rawspeed {
@@ -47,7 +47,7 @@ private:
   [[nodiscard]] int getDecoderVersion() const override { return 0; }
   bool mFixLjpeg;
   static void dropUnsuportedChunks(std::vector<const TiffIFD*>* data);
-  std::optional<iRectangle2D> parseACTIVEAREA(const TiffIFD* raw) const;
+  Optional<iRectangle2D> parseACTIVEAREA(const TiffIFD* raw) const;
   void parseCFA(const TiffIFD* raw) const;
   void parseColorMatrix() const;
   void parseWhiteBalance() const;

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Mutex.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -127,7 +128,7 @@ enum class IIQFormat {
 
 };
 
-std::optional<IIQFormat> getAsIIQFormat(uint32_t v) {
+Optional<IIQFormat> getAsIIQFormat(uint32_t v) {
   switch (v) {
     using enum IIQFormat;
   case 1:
@@ -178,8 +179,8 @@ RawImage IiqDecoder::decodeRawInternal() {
   uint32_t split_row = 0;
   uint32_t split_col = 0;
 
-  std::optional<IIQFormat> format;
-  std::optional<Buffer> raw_data;
+  Optional<IIQFormat> format;
+  Optional<Buffer> raw_data;
   ByteStream block_offsets;
   ByteStream wb;
   ByteStream correction_meta_data;

--- a/src/librawspeed/decoders/IiqDecoder.cpp
+++ b/src/librawspeed/decoders/IiqDecoder.cpp
@@ -50,7 +50,6 @@
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -32,7 +32,6 @@
 #include "io/Endianness.h"
 #include "metadata/Camera.h"
 #include <map>
-#include <optional>
 #include <string>
 #include <string_view>
 

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decoders/NakedDecoder.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -46,7 +47,7 @@ NakedDecoder::NakedDecoder(Buffer file, const Camera* c)
 
 namespace {
 
-std::optional<BitOrder> getAsBitOrder(std::string_view s) {
+Optional<BitOrder> getAsBitOrder(std::string_view s) {
   using enum BitOrder;
   if (s == "plain")
     return LSB;

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -23,6 +23,7 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
@@ -38,7 +39,6 @@
 #include <array>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 
 namespace rawspeed {
@@ -98,7 +98,7 @@ RawImage PefDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
 
-  std::optional<ByteStream> metaData;
+  Optional<ByteStream> metaData;
   if (getRootIFD()->hasEntryRecursive(static_cast<TiffTag>(0x220))) {
     /* Attempt to read huffman table, if found in makernote */
     const TiffEntry* t =

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
@@ -23,6 +23,7 @@
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "adt/Array1DRef.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
@@ -36,7 +37,6 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -279,7 +279,7 @@ void AbstractLJpegDecoder::parseDRI(ByteStream dri) {
 }
 
 JpegMarker AbstractLJpegDecoder::getNextMarker(bool allowskip) {
-  auto peekMarker = [&]() -> std::optional<JpegMarker> {
+  auto peekMarker = [&]() -> Optional<JpegMarker> {
     uint8_t c0 = input.peekByte(0);
     uint8_t c1 = input.peekByte(1);
 
@@ -289,7 +289,7 @@ JpegMarker AbstractLJpegDecoder::getNextMarker(bool allowskip) {
   };
 
   while (input.getRemainSize() >= 2) {
-    if (std::optional<JpegMarker> m = peekMarker()) {
+    if (Optional<JpegMarker> m = peekMarker()) {
       input.skipBytes(2); // Skip the bytes we've just consumed.
       return *m;
     }

--- a/src/librawspeed/decompressors/Cr2DecompressorImpl.h
+++ b/src/librawspeed/decompressors/Cr2DecompressorImpl.h
@@ -336,7 +336,7 @@ Cr2Decompressor<PrefixCodeDecoder>::Cr2Decompressor(
   if (frame.area() < dim.area())
     ThrowRDE("Frame area smaller than the image area");
 
-  std::optional<iRectangle2D> lastTile;
+  Optional<iRectangle2D> lastTile;
   for (iRectangle2D output : getAllOutputTiles()) {
     if (lastTile && evaluateConsecutiveTiles(*lastTile, output) ==
                         TileSequenceStatus::Invalid)

--- a/src/librawspeed/decompressors/Cr2DecompressorImpl.h
+++ b/src/librawspeed/decompressors/Cr2DecompressorImpl.h
@@ -23,6 +23,7 @@
 #include "rawspeedconfig.h"
 #include "adt/Array2DRef.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "adt/iterator_range.h"
 #include "common/RawImage.h"
@@ -37,7 +38,6 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
-#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -47,7 +47,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -29,6 +29,7 @@
 #include "adt/Casts.h"
 #include "adt/CroppedArray2DRef.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/BayerPhase.h"
 #include "common/Common.h"
@@ -859,14 +860,14 @@ FujiDecompressor::FujiDecompressor(RawImage img, ByteStream input_)
   }
 
   if (mRaw->cfa.getSize() == iPoint2D(6, 6)) {
-    std::optional<XTransPhase> p = getAsXTransPhase(mRaw->cfa);
+    Optional<XTransPhase> p = getAsXTransPhase(mRaw->cfa);
     if (!p)
       ThrowRDE("Invalid X-Trans CFA");
     if (p != iPoint2D(0, 0))
       ThrowRDE("Unexpected X-Trans phase: {%i,%i}. Please file a bug!", p->x,
                p->y);
   } else if (mRaw->cfa.getSize() == iPoint2D(2, 2)) {
-    std::optional<BayerPhase> p = getAsBayerPhase(mRaw->cfa);
+    Optional<BayerPhase> p = getAsBayerPhase(mRaw->cfa);
     if (!p)
       ThrowRDE("Invalid Bayer CFA");
     if (p != BayerPhase::RGGB)

--- a/src/librawspeed/decompressors/PentaxDecompressor.cpp
+++ b/src/librawspeed/decompressors/PentaxDecompressor.cpp
@@ -23,6 +23,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
@@ -36,7 +37,6 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -51,7 +51,7 @@ const std::array<std::array<std::array<uint8_t, 16>, 2>, 1>
     }};
 
 PentaxDecompressor::PentaxDecompressor(RawImage img,
-                                       std::optional<ByteStream> metaData)
+                                       Optional<ByteStream> metaData)
     : mRaw(std::move(img)), ht(SetupPrefixCodeDecoder(metaData)) {
   if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
       mRaw->getBpp() != sizeof(uint16_t))
@@ -139,8 +139,8 @@ PentaxDecompressor::SetupPrefixCodeDecoder_Modern(ByteStream stream) {
 }
 
 PrefixCodeDecoder<>
-PentaxDecompressor::SetupPrefixCodeDecoder(std::optional<ByteStream> metaData) {
-  std::optional<HuffmanCode<BaselineCodeTag>> hc;
+PentaxDecompressor::SetupPrefixCodeDecoder(Optional<ByteStream> metaData) {
+  Optional<HuffmanCode<BaselineCodeTag>> hc;
 
   if (metaData)
     hc = SetupPrefixCodeDecoder_Modern(*metaData);

--- a/src/librawspeed/decompressors/PentaxDecompressor.h
+++ b/src/librawspeed/decompressors/PentaxDecompressor.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "adt/Optional.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/HuffmanCode.h"
 #include "codes/PrefixCodeDecoder.h"
@@ -28,7 +29,6 @@
 #include "decompressors/AbstractDecompressor.h"
 #include <array>
 #include <cstdint>
-#include <optional>
 
 namespace rawspeed {
 
@@ -39,7 +39,7 @@ class PentaxDecompressor final : public AbstractDecompressor {
   const PrefixCodeDecoder<> ht;
 
 public:
-  PentaxDecompressor(RawImage img, std::optional<ByteStream> metaData);
+  PentaxDecompressor(RawImage img, Optional<ByteStream> metaData);
 
   void decompress(ByteStream data) const;
 
@@ -48,7 +48,7 @@ private:
   static HuffmanCode<BaselineCodeTag>
   SetupPrefixCodeDecoder_Modern(ByteStream stream);
   static PrefixCodeDecoder<>
-  SetupPrefixCodeDecoder(std::optional<ByteStream> metaData);
+  SetupPrefixCodeDecoder(Optional<ByteStream> metaData);
 
   static const std::array<std::array<std::array<uint8_t, 16>, 2>, 1>
       pentax_tree;

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -55,7 +55,6 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -33,6 +33,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/PrefixCode.h"
@@ -395,7 +396,7 @@ VC5Decompressor::VC5Decompressor(ByteStream bs, const RawImage& img)
     ThrowRDE("Height %u is not a multiple of %u", mRaw->dim.y,
              mVC5.patternHeight);
 
-  std::optional<BayerPhase> p = getAsBayerPhase(mRaw->cfa);
+  Optional<BayerPhase> p = getAsBayerPhase(mRaw->cfa);
   if (!p)
     ThrowRDE("Image has invalid CFA.");
   phase = *p;

--- a/src/librawspeed/decompressors/VC5Decompressor.h
+++ b/src/librawspeed/decompressors/VC5Decompressor.h
@@ -24,6 +24,7 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/DefaultInitAllocatorAdaptor.h"
+#include "adt/Optional.h"
 #include "codes/AbstractPrefixCode.h"
 #include "codes/PrefixCodeLUTDecoder.h"
 #include "codes/PrefixCodeVectorDecoder.h"
@@ -36,7 +37,6 @@
 #include <array>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -105,7 +105,7 @@ class VC5Decompressor final : public AbstractDecompressor {
   using PrefixCodeDecoder =
       PrefixCodeLUTDecoder<VC5CodeTag, PrefixCodeVectorDecoder<VC5CodeTag>>;
 
-  std::optional<PrefixCodeDecoder> codeDecoder;
+  Optional<PrefixCodeDecoder> codeDecoder;
 
   void initPrefixCodeDecoder();
 
@@ -119,9 +119,9 @@ class VC5Decompressor final : public AbstractDecompressor {
 
   struct {
     uint16_t iChannel = 0; // 0'th channel is the default
-    std::optional<uint16_t> iSubband;
-    std::optional<uint16_t> lowpassPrecision;
-    std::optional<int16_t> quantization;
+    Optional<uint16_t> iSubband;
+    Optional<uint16_t> lowpassPrecision;
+    Optional<int16_t> quantization;
 
     const uint16_t imgFormat = 4;
     const uint16_t patternWidth = 2;
@@ -142,7 +142,7 @@ class VC5Decompressor final : public AbstractDecompressor {
 
     struct AbstractBand {
       Wavelet& wavelet;
-      std::optional<BandData> data;
+      Optional<BandData> data;
       virtual void anchor() const;
       explicit AbstractBand(Wavelet& wavelet_) : wavelet(wavelet_) {}
       virtual ~AbstractBand() = default;
@@ -153,8 +153,8 @@ class VC5Decompressor final : public AbstractDecompressor {
       bool clampUint;
       bool finalWavelet;
       struct {
-        std::optional<BandData> lowpass;
-        std::optional<BandData> highpass;
+        Optional<BandData> lowpass;
+        Optional<BandData> highpass;
       } intermediates;
       explicit ReconstructableBand(Wavelet& wavelet_, bool clampUint_ = false,
                                    bool finalWavelet_ = false)
@@ -183,11 +183,10 @@ class VC5Decompressor final : public AbstractDecompressor {
       [[nodiscard]] BandData decode() const noexcept override;
     };
     struct HighPassBand final : AbstractDecodeableBand {
-      const std::optional<PrefixCodeDecoder>& decoder;
+      const Optional<PrefixCodeDecoder>& decoder;
       int16_t quant;
       HighPassBand(Wavelet& wavelet_, Array1DRef<const uint8_t> input_,
-                   const std::optional<PrefixCodeDecoder>& decoder_,
-                   int16_t quant_)
+                   const Optional<PrefixCodeDecoder>& decoder_, int16_t quant_)
           : AbstractDecodeableBand(wavelet_, input_), decoder(decoder_),
             quant(quant_) {}
       [[nodiscard]] BandData decode() const override;

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -20,7 +20,6 @@
 */
 
 #include "metadata/Camera.h"
-#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "metadata/CameraMetadataException.h"
 #include "metadata/CameraSensorInfo.h"
@@ -33,11 +32,11 @@
 
 #ifdef HAVE_PUGIXML
 #include "adt/NotARational.h"
+#include "adt/Optional.h"
 #include "common/Common.h"
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
-#include <optional>
 #include <pugixml.hpp>
 #include <string_view>
 

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "metadata/Camera.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "metadata/CameraMetadataException.h"
 #include "metadata/CameraSensorInfo.h"
@@ -100,7 +101,7 @@ namespace {
 
 std::string name(const xml_node& a) { return a.name(); }
 
-std::optional<CFAColor> getAsCFAColor(char c) {
+Optional<CFAColor> getAsCFAColor(char c) {
   switch (c) {
     using enum CFAColor;
   case 'g':
@@ -122,7 +123,7 @@ std::optional<CFAColor> getAsCFAColor(char c) {
   }
 }
 
-std::optional<CFAColor> getAsCFAColor(std::string_view c) {
+Optional<CFAColor> getAsCFAColor(std::string_view c) {
   using enum CFAColor;
   if (c == "GREEN")
     return GREEN;

--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -32,7 +32,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/src/librawspeed/metadata/ColorFilterArray.cpp
+++ b/src/librawspeed/metadata/ColorFilterArray.cpp
@@ -21,6 +21,7 @@
 #include "metadata/ColorFilterArray.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
+#include "adt/Optional.h"
 #include "adt/Point.h"
 #include "common/Common.h"
 #include "decoders/RawDecoderException.h"
@@ -169,7 +170,7 @@ uint32_t ColorFilterArray::shiftDcrawFilter(uint32_t filter, int x, int y) {
 
 namespace {
 
-std::optional<std::string_view> getColorAsString(CFAColor c) {
+Optional<std::string_view> getColorAsString(CFAColor c) {
   switch (c) {
     using enum CFAColor;
   case RED:

--- a/test/librawspeed/common/BayerPhaseTest.cpp
+++ b/test/librawspeed/common/BayerPhaseTest.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "common/BayerPhase.h"
+#include "adt/Optional.h"
 #include "metadata/ColorFilterArray.h"
 #include <array>
 #include <cassert>
@@ -99,7 +100,7 @@ protected:
   }
 
   std::array<CFAColor, 4> in;
-  std::optional<BayerPhase> expected;
+  rawspeed::Optional<BayerPhase> expected;
   ColorFilterArray cfa;
 };
 
@@ -122,7 +123,7 @@ protected:
     assert(in.has_value());
   }
 
-  std::optional<BayerPhase> in;
+  rawspeed::Optional<BayerPhase> in;
   std::array<CFAColor, 4> expected;
 };
 

--- a/test/librawspeed/common/BayerPhaseTest.cpp
+++ b/test/librawspeed/common/BayerPhaseTest.cpp
@@ -24,7 +24,6 @@
 #include <array>
 #include <cassert>
 #include <map>
-#include <optional>
 #include <ostream>
 #include <tuple>
 #include <utility>


### PR DESCRIPTION
`std::optional` does not generally verify that it has value,
and while such checks are optionally provided by some STL's,
they are clearly not enabled unless one goes really out of the way,
and even oss-fuzz does not do that.

That hidden a few (already-fixed by now) bugs.
Let's just do the right thing.
