### PR TITLE
`rawspeed-no-std-optional` check

### DIFF
--- a/src/librawspeed/adt/Optional.h
+++ b/src/librawspeed/adt/Optional.h
@@ -27,6 +27,7 @@
 namespace rawspeed {
 
 template <typename T> class Optional final {
+  // NOLINTNEXTLINE(rawspeed-no-std-optional): we're in the wrapper.
   std::optional<T> impl;
 
 public:


### PR DESCRIPTION
X-Ref: https://github.com/darktable-org/rawspeed-clang-tidy-module/pull/6
X-Ref: https://github.com/darktable-org/rawspeed/pull/599