### PR TITLE
`*ArrayRef.D` shall not be default-constructible

### DIFF
--- a/src/librawspeed/adt/Array1DRef.h
+++ b/src/librawspeed/adt/Array1DRef.h
@@ -30,8 +30,8 @@ namespace rawspeed {
 template <class T> class CroppedArray1DRef;
 
 template <class T> class Array1DRef final {
-  T* data = nullptr;
-  int numElts = 0;
+  T* data;
+  int numElts;
 
   friend Array1DRef<const T>; // We need to be able to convert to const version.
 
@@ -45,7 +45,7 @@ public:
   using value_type = T;
   using cvless_value_type = std::remove_cv_t<value_type>;
 
-  Array1DRef() = default;
+  Array1DRef() = delete;
 
   Array1DRef(T* data, int numElts);
 

--- a/src/librawspeed/adt/Array2DRef.h
+++ b/src/librawspeed/adt/Array2DRef.h
@@ -31,8 +31,8 @@
 namespace rawspeed {
 
 template <class T> class Array2DRef final {
-  T* _data = nullptr;
-  int _pitch = 0;
+  T* _data;
+  int _pitch;
 
   friend Array2DRef<const T>; // We need to be able to convert to const version.
 
@@ -46,10 +46,10 @@ public:
   using value_type = T;
   using cvless_value_type = std::remove_cv_t<value_type>;
 
-  int width = 0;
-  int height = 0;
+  int width;
+  int height;
 
-  Array2DRef() = default;
+  Array2DRef() = delete;
 
   Array2DRef(T* data, int width, int height, int pitch = 0);
 
@@ -125,11 +125,6 @@ Array2DRef<T>::Array2DRef(T* data, const int width_, const int height_,
 template <class T>
 [[nodiscard]] inline Optional<Array1DRef<T>>
 Array2DRef<T>::getAsArray1DRef() const {
-  // FIXME: this might be called for default-constructed `Array2DRef`,
-  // and it really doesn't work for them.
-  if (!_data)
-    return std::nullopt;
-
   establishClassInvariants();
   if (height == 1 || _pitch == width)
     return {{_data, width * height}};

--- a/src/librawspeed/adt/CroppedArray1DRef.h
+++ b/src/librawspeed/adt/CroppedArray1DRef.h
@@ -29,8 +29,8 @@ namespace rawspeed {
 
 template <class T> class CroppedArray1DRef final {
   Array1DRef<T> base;
-  int offset = 0;
-  int numElts = 0;
+  int offset;
+  int numElts;
 
   friend CroppedArray1DRef<const T>; // We need to be able to convert to const
                                      // version.
@@ -46,7 +46,7 @@ public:
   using value_type = T;
   using cvless_value_type = std::remove_cv_t<value_type>;
 
-  CroppedArray1DRef() = default;
+  CroppedArray1DRef() = delete;
 
   // Can not cast away constness.
   template <typename T2>

--- a/src/librawspeed/adt/CroppedArray2DRef.h
+++ b/src/librawspeed/adt/CroppedArray2DRef.h
@@ -40,12 +40,12 @@ public:
   using value_type = T;
   using cvless_value_type = std::remove_cv_t<value_type>;
 
-  int offsetCols = 0;
-  int offsetRows = 0;
-  int croppedWidth = 0;
-  int croppedHeight = 0;
+  int offsetCols;
+  int offsetRows;
+  int croppedWidth;
+  int croppedHeight;
 
-  CroppedArray2DRef() = default;
+  CroppedArray2DRef() = delete;
 
   // Can not cast away constness.
   template <typename T2>
@@ -60,7 +60,8 @@ public:
 
   // Conversion from Array2DRef<T> to CroppedArray2DRef<T>.
   CroppedArray2DRef(Array2DRef<T> RHS) // NOLINT google-explicit-constructor
-      : base(RHS), croppedWidth(base.width), croppedHeight(base.height) {}
+      : base(RHS), offsetCols(0), offsetRows(0), croppedWidth(base.width),
+        croppedHeight(base.height) {}
 
   CroppedArray2DRef(Array2DRef<T> base_, int offsetCols_, int offsetRows_,
                     int croppedWidth_, int croppedHeight_);

--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -161,7 +161,7 @@ public:
   ColorFilterArray cfa;
   int blackLevel = -1;
   std::array<int, 4> blackLevelSeparateStorage;
-  Array2DRef<int> blackLevelSeparate;
+  Array2DRef<int> blackLevelSeparate = {blackLevelSeparateStorage.data(), 0, 0};
   int whitePoint = 65536;
   std::vector<BlackArea> blackAreas;
 

--- a/src/librawspeed/decoders/Cr2Decoder.cpp
+++ b/src/librawspeed/decoders/Cr2Decoder.cpp
@@ -498,7 +498,7 @@ void Cr2Decoder::decodeMetaDataInternal(const CameraMetaData* meta) {
   assert(mShiftUpScaleForExif == 0 || mShiftUpScaleForExif == 2);
   if (mShiftUpScaleForExif) {
     mRaw->blackLevel = 0;
-    mRaw->blackLevelSeparate = {};
+    mRaw->blackLevelSeparate = {mRaw->blackLevelSeparateStorage.data(), 0, 0};
   }
   if (mShiftUpScaleForExif != 0 && isPowerOfTwo(1 + mRaw->whitePoint))
     mRaw->whitePoint = ((1 + mRaw->whitePoint) << mShiftUpScaleForExif) - 1;

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -300,8 +300,6 @@ fuji_compressed_block::fuji_compressed_block(
     : img(img_), header(header_), common_info(common_info_) {}
 
 void fuji_compressed_block::reset() {
-  const unsigned line_size = sizeof(uint16_t) * (common_info.line_width + 2);
-
   linealloc.resize(ltotal * (common_info.line_width + 2), 0);
   lines =
       Array2DRef<uint16_t>(&linealloc[0], common_info.line_width + 2, ltotal);
@@ -312,7 +310,7 @@ void fuji_compressed_block::reset() {
   // including first and last helper columns of the second row.
   // This is needed for correctness.
   for (xt_lines color : {R0, G0, B0}) {
-    memset(&lines(color, 0), 0, 2 * line_size);
+    memset(&lines(color, 0), 0, 2 * sizeof(uint16_t) * lines.width);
 
     // On the first row, we don't need to zero-init helper columns.
     MSan::Allocated(lines(color, 0));

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -249,7 +249,7 @@ struct fuji_compressed_block final {
 
   void reset(const fuji_compressed_params& params);
 
-  BitPumpMSB pump;
+  Optional<BitPumpMSB> pump;
 
   // tables of gradients
   std::array<std::array<int_pair, 41>, 3> grad_even;
@@ -447,7 +447,7 @@ fuji_compressed_block::fuji_decode_sample(int grad, int interp_val,
                                           std::array<int_pair, 41>& grads) {
   int gradient = std::abs(grad);
 
-  int sampleBits = fuji_zerobits(pump);
+  int sampleBits = fuji_zerobits(*pump);
 
   int codeBits;
   int codeDelta;
@@ -460,9 +460,9 @@ fuji_compressed_block::fuji_decode_sample(int grad, int interp_val,
   }
 
   int code = 0;
-  pump.fill(32);
+  pump->fill(32);
   if (codeBits)
-    code = pump.getBitsNoFill(codeBits);
+    code = pump->getBitsNoFill(codeBits);
   code += codeDelta;
 
   if (code < 0 || code >= common_info.total_values) {

--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -297,13 +297,11 @@ struct fuji_compressed_block final {
 fuji_compressed_block::fuji_compressed_block(
     Array2DRef<uint16_t> img_, const FujiDecompressor::FujiHeader& header_,
     const fuji_compressed_params& common_info_)
-    : img(img_), header(header_), common_info(common_info_) {}
+    : img(img_), header(header_), common_info(common_info_),
+      linealloc(ltotal * (common_info.line_width + 2), 0),
+      lines(&linealloc[0], common_info.line_width + 2, ltotal) {}
 
 void fuji_compressed_block::reset() {
-  linealloc.resize(ltotal * (common_info.line_width + 2), 0);
-  lines =
-      Array2DRef<uint16_t>(&linealloc[0], common_info.line_width + 2, ltotal);
-
   MSan::Allocated(CroppedArray2DRef(lines));
 
   // Zero-initialize first two (read-only, carry-in) lines of each color,

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -182,10 +182,8 @@ struct ConvolutionParams final {
 VC5Decompressor::BandData VC5Decompressor::Wavelet::reconstructPass(
     const Array2DRef<const int16_t> high,
     const Array2DRef<const int16_t> low) noexcept {
-  BandData combined;
+  BandData combined(high.width, 2 * high.height);
   auto& dst = combined.description;
-  dst = Array2DRef<int16_t>::create(combined.storage, high.width,
-                                    2 * high.height);
 
   auto process = [low, high, dst]<typename SegmentTy>(int row, int col) {
     auto lowGetter = [&row, &col, low](int delta) {
@@ -236,10 +234,8 @@ VC5Decompressor::BandData VC5Decompressor::Wavelet::combineLowHighPass(
     const Array2DRef<const int16_t> low, const Array2DRef<const int16_t> high,
     int descaleShift, bool clampUint = false,
     [[maybe_unused]] bool finalWavelet = false) noexcept {
-  BandData combined;
+  BandData combined(2 * high.width, high.height);
   auto& dst = combined.description;
-  dst = Array2DRef<int16_t>::create(combined.storage, 2 * high.width,
-                                    high.height);
 
   auto process = [low, high, descaleShift, clampUint,
                   dst]<typename SegmentTy>(int row, int col) {
@@ -662,10 +658,8 @@ VC5Decompressor::Wavelet::LowPassBand::LowPassBand(Wavelet& wavelet_,
 
 VC5Decompressor::BandData
 VC5Decompressor::Wavelet::LowPassBand::decode() const noexcept {
-  BandData lowpass;
+  BandData lowpass(wavelet.width, wavelet.height);
   auto& band = lowpass.description;
-  band = Array2DRef<int16_t>::create(lowpass.storage, wavelet.width,
-                                     wavelet.height);
 
   BitPumpMSB bits(input);
   for (auto row = 0; row < band.height; ++row) {
@@ -728,10 +722,8 @@ VC5Decompressor::Wavelet::HighPassBand::decode() const {
 
   // decode highpass band
   DeRLVer d(*decoder, input, quant);
-  BandData highpass;
+  BandData highpass(wavelet.width, wavelet.height);
   auto& band = highpass.description;
-  band = Array2DRef<int16_t>::create(highpass.storage, wavelet.width,
-                                     wavelet.height);
   for (int row = 0; row != wavelet.height; ++row)
     for (int col = 0; col != wavelet.width; ++col)
       band(row, col) = d.decode();

--- a/src/librawspeed/decompressors/VC5Decompressor.h
+++ b/src/librawspeed/decompressors/VC5Decompressor.h
@@ -132,6 +132,9 @@ class VC5Decompressor final : public AbstractDecompressor {
   struct BandData final {
     std::vector<int16_t, DefaultInitAllocatorAdaptor<int16_t>> storage;
     Array2DRef<int16_t> description;
+
+    BandData(int width, int height)
+        : description(Array2DRef<int16_t>::create(storage, width, height)) {}
   };
 
   class Wavelet final {

--- a/src/librawspeed/io/BitStream.h
+++ b/src/librawspeed/io/BitStream.h
@@ -104,7 +104,7 @@ template <typename Tag> struct BitStreamReplenisherBase {
   Array1DRef<const uint8_t> input;
   unsigned pos = 0;
 
-  BitStreamReplenisherBase() = default;
+  BitStreamReplenisherBase() = delete;
 
   explicit BitStreamReplenisherBase(Array1DRef<const uint8_t> input_)
       : input(input_) {
@@ -128,9 +128,9 @@ struct BitStreamForwardSequentialReplenisher final
     : public BitStreamReplenisherBase<Tag> {
   using Base = BitStreamReplenisherBase<Tag>;
 
-  BitStreamForwardSequentialReplenisher() = default;
-
   using Base::BitStreamReplenisherBase;
+
+  BitStreamForwardSequentialReplenisher() = delete;
 
   [[nodiscard]] inline typename Base::size_type getPos() const {
     return Base::pos;
@@ -187,7 +187,7 @@ class BitStream final {
 public:
   using tag = Tag;
 
-  BitStream() = default;
+  BitStream() = delete;
 
   explicit BitStream(Array1DRef<const uint8_t> input) : replenisher(input) {}
 


### PR DESCRIPTION
This way, the `establishClassInvariants()` actually always hold for any constructed type.