### PR TITLE
Add support for `unknown` and `unknown-no-samples` `support` modes in `cameras.xml`

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -259,6 +259,9 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="Canon" model="Canon EOS 20Da" supported="unknown-no-samples">
+		<ID make="Canon" model="EOS 20Da">Canon EOS 20Da</ID>
+	</Camera>
 	<Camera make="Canon" model="Canon EOS 30D">
 		<ID make="Canon" model="EOS 30D">Canon EOS 30D</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -514,11 +514,13 @@
   </xs:simpleType>
   <xs:simpleType name="CameraTypeSupportedType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="(no|no-samples)"/>
+      <xs:pattern value="(no|no-samples|unknown|unknown-no-samples)"/>
       <xs:minLength value="2"/>
-      <xs:maxLength value="10"/>
+      <xs:maxLength value="18"/>
       <xs:enumeration value="no"/>
       <xs:enumeration value="no-samples"/>
+      <xs:enumeration value="unknown"/>
+      <xs:enumeration value="unknown-no-samples"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="CameraType">

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -175,20 +175,6 @@ bool RawDecoder::handleCameraSupport(const CameraMetaData* meta,
     return false;
   }
 
-  return true;
-}
-
-bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
-                                      const std::string& make,
-                                      const std::string& model,
-                                      const std::string& mode) {
-  mRaw->metadata.make = make;
-  mRaw->metadata.model = model;
-  const Camera* cam = meta->getCamera(make, model, mode);
-
-  if (!handleCameraSupport(meta, make, model, mode))
-    return false;
-
   switch (cam->supportStatus) {
     using enum Camera::SupportStatus;
   case Supported:
@@ -204,6 +190,20 @@ bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
              make.c_str(), model.c_str(), mode.c_str());
     break; // WYSIWYG.
   }
+
+  return true;
+}
+
+bool RawDecoder::checkCameraSupported(const CameraMetaData* meta,
+                                      const std::string& make,
+                                      const std::string& model,
+                                      const std::string& mode) {
+  mRaw->metadata.make = make;
+  mRaw->metadata.model = model;
+  const Camera* cam = meta->getCamera(make, model, mode);
+
+  if (!handleCameraSupport(meta, make, model, mode))
+    return false;
 
   if (cam->decoderVersion > getDecoderVersion())
     ThrowRDE(

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -125,10 +125,6 @@ protected:
   virtual void decodeMetaDataInternal(const CameraMetaData* meta) = 0;
   virtual void checkSupportInternal(const CameraMetaData* meta) = 0;
 
-  /* Ask for sample submission, if makes sense */
-  static void askForSamples(const CameraMetaData* meta, const std::string& make,
-                            const std::string& model, const std::string& mode);
-
   bool handleCameraSupport(const CameraMetaData* meta, const std::string& make,
                            const std::string& model, const std::string& mode);
 

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -129,6 +129,9 @@ protected:
   static void askForSamples(const CameraMetaData* meta, const std::string& make,
                             const std::string& model, const std::string& mode);
 
+  bool handleCameraSupport(const CameraMetaData* meta, const std::string& make,
+                           const std::string& model, const std::string& mode);
+
   /* Check the camera and mode against the camera database. */
   /* A RawDecoderException will be thrown if the camera isn't supported */
   /* Unknown cameras does NOT generate any errors, but returns false */

--- a/src/librawspeed/metadata/Camera.cpp
+++ b/src/librawspeed/metadata/Camera.cpp
@@ -71,7 +71,11 @@ Camera::Camera(const pugi::xml_node& camera) {
     if (v == "no")
       return Unsupported;
     if (v == "no-samples")
-      return NoSamples;
+      return SupportedNoSamples;
+    if (v == "unknown")
+      return Unknown;
+    if (v == "unknown-no-samples")
+      return UnknownNoSamples;
     ThrowCME("Attribute 'supported' has unknown value.");
   }();
   mode = camera.attribute("mode").as_string("");

--- a/src/librawspeed/metadata/Camera.h
+++ b/src/librawspeed/metadata/Camera.h
@@ -77,9 +77,12 @@ public:
 class Camera final {
 public:
   enum class SupportStatus {
-    Unsupported,
-    Supported,
-    NoSamples,
+    SupportedNoSamples, // Tentatively supported, no RPU samples.
+    Supported,          // Claimed as supported (explicitly).
+    Unknown,            // Placeholder camera, support is unknown.
+    UnknownCamera,      // Not found in database.
+    UnknownNoSamples, // Placeholder camera, no RPU samples, support is unknown.
+    Unsupported,      // Claimed as unsupported (explicitly).
   };
 
 #ifdef HAVE_PUGIXML


### PR DESCRIPTION
The idea is that we aren't likely to ever explicitly either support
or unsupport every single camera ever released,
and we must make that determination to enter a camera
into `cameras.xml`, yet it is generally beneficial to list a camera
in `cameras.xml` without making that determination,
for example then RPU can ask for samples for that camera.

Therefore, we need new types of `support=` values in `cameras.xml`,
ones that do not affect the support-ness, but allow to differentiate
the existence of RPU samples.

Thus, patch.

CC @kmilos 