### PR TITLE
`BitPumpJPEG::fillCache()`: make it -7% faster 

### DIFF
--- a/bench/librawspeed/io/BitPumpJPEGBenchmark.cpp
+++ b/bench/librawspeed/io/BitPumpJPEGBenchmark.cpp
@@ -221,7 +221,7 @@ void CustomArguments(benchmark::internal::Benchmark* b) {
 
   static constexpr int L1dByteSize = 32U * (1U << 10U);
   static constexpr int L2dByteSize = 512U * (1U << 10U);
-  static constexpr int MaxBytesOptimal = L2dByteSize * (1U << 4);
+  static constexpr int MaxBytesOptimal = L2dByteSize * (1U << 5);
 
   if (benchmarkDryRun()) {
     b->Arg(L1dByteSize);

--- a/src/librawspeed/io/BitPumpJPEG.h
+++ b/src/librawspeed/io/BitPumpJPEG.h
@@ -76,33 +76,33 @@ BitPumpJPEG::fillCache(Array1DRef<const uint8_t> input) {
     const int c0 = prefetch[p];
     ++p;
     cache.push(c0, 8);
-    if (c0 == 0xFF) {
-      // Found FF -> pre-execute case of FF/00, which represents an FF data byte
-      // -> ignore the 00
-      const int c1 = prefetch[p];
-      ++p;
-      if (c1 != 0) {
-        // Found FF/xx with xx != 00. This is the end of stream marker.
-        // That means we shouldn't have pushed last 8 bits (0xFF, from c0).
-        // We need to "unpush" them, and fill the vacant cache bits with zeros.
+    if (c0 != 0xFF)
+      continue;
+    // Found FF -> pre-execute case of FF/00, which represents an FF data byte
+    // -> ignore the 00
+    const int c1 = prefetch[p];
+    ++p;
+    if (c1 != 0) {
+      // Found FF/xx with xx != 00. This is the end of stream marker.
+      // That means we shouldn't have pushed last 8 bits (0xFF, from c0).
+      // We need to "unpush" them, and fill the vacant cache bits with zeros.
 
-        // First, recover the cache fill level.
-        cache.fillLevel -= 8;
-        // Now, this code is incredibly underencapsulated, and the
-        // implementation details are leaking into here. Thus, we know that
-        // all the fillLevel bits in cache are all high bits. So to "unpush"
-        // the last 8 bits, and fill the vacant cache bits with zeros, we only
-        // need to keep the high fillLevel bits. So just create a mask with only
-        // high fillLevel bits set, and 'and' the cache with it.
-        // Caution, we know fillLevel won't be 64, but it may be 0,
-        // so pick the mask-creation idiom accordingly.
-        cache.cache &= ~((~0ULL) >> cache.fillLevel);
-        cache.fillLevel = 64;
+      // First, recover the cache fill level.
+      cache.fillLevel -= 8;
+      // Now, this code is incredibly underencapsulated, and the
+      // implementation details are leaking into here. Thus, we know that
+      // all the fillLevel bits in cache are all high bits. So to "unpush"
+      // the last 8 bits, and fill the vacant cache bits with zeros, we only
+      // need to keep the high fillLevel bits. So just create a mask with only
+      // high fillLevel bits set, and 'and' the cache with it.
+      // Caution, we know fillLevel won't be 64, but it may be 0,
+      // so pick the mask-creation idiom accordingly.
+      cache.cache &= ~((~0ULL) >> cache.fillLevel);
+      cache.fillLevel = 64;
 
-        // No further reading from this buffer shall happen. Do signal that by
-        // claiming that we have consumed all the remaining bytes of the buffer.
-        return getRemainingSize();
-      }
+      // No further reading from this buffer shall happen. Do signal that by
+      // claiming that we have consumed all the remaining bytes of the buffer.
+      return getRemainingSize();
     }
   }
   return p;


### PR DESCRIPTION
... does not seem to have similar effect outside of the microbenchmark, though.