### PR TITLE
BitStream: sizes are signed!!!11, sprinkle invariants

### DIFF
--- a/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV5Decompressor.cpp
@@ -199,7 +199,7 @@ inline void PanasonicV5Decompressor::processPixelPacket(BitPumpLSB& bs, int row,
 
   for (int p = 0; p < dsc.pixelsPerPacket;) {
     bs.fill();
-    for (; bs.getFillLevel() >= dsc.bps; ++p, ++col)
+    for (; bs.getFillLevel() >= implicit_cast<int>(dsc.bps); ++p, ++col)
       out(row, col) = implicit_cast<uint16_t>(bs.getBitsNoFill(dsc.bps));
   }
   bs.skipBitsNoFill(bs.getFillLevel()); // get rid of padding.

--- a/src/librawspeed/io/BitPumpJPEG.h
+++ b/src/librawspeed/io/BitPumpJPEG.h
@@ -55,6 +55,7 @@ template <>
 inline BitPumpJPEG::size_type
 BitPumpJPEG::fillCache(Array1DRef<const uint8_t> input) {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "check implementation");
+  establishClassInvariants();
   invariant(input.size() == BitStreamTraits<tag>::MaxProcessBytes);
 
   std::array<uint8_t, BitStreamTraits<JPEGBitPumpTag>::MaxProcessBytes>

--- a/src/librawspeed/io/BitPumpLSB.h
+++ b/src/librawspeed/io/BitPumpLSB.h
@@ -45,6 +45,7 @@ template <>
 inline BitPumpLSB::size_type
 BitPumpLSB::fillCache(Array1DRef<const uint8_t> input) {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "check implementation");
+  establishClassInvariants();
   invariant(input.size() == BitStreamTraits<tag>::MaxProcessBytes);
 
   cache.push(getLE<uint32_t>(input.getCrop(0, sizeof(uint32_t)).begin()), 32);

--- a/src/librawspeed/io/BitPumpMSB.h
+++ b/src/librawspeed/io/BitPumpMSB.h
@@ -47,6 +47,7 @@ template <>
 inline BitPumpMSB::size_type
 BitPumpMSB::fillCache(Array1DRef<const uint8_t> input) {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "check implementation");
+  establishClassInvariants();
   invariant(input.size() == BitStreamTraits<tag>::MaxProcessBytes);
 
   cache.push(getBE<uint32_t>(input.getCrop(0, sizeof(uint32_t)).begin()), 32);

--- a/src/librawspeed/io/BitPumpMSB16.h
+++ b/src/librawspeed/io/BitPumpMSB16.h
@@ -45,6 +45,7 @@ template <>
 inline BitPumpMSB16::size_type
 BitPumpMSB16::fillCache(Array1DRef<const uint8_t> input) {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "check implementation");
+  establishClassInvariants();
   invariant(input.size() == BitStreamTraits<tag>::MaxProcessBytes);
 
   for (size_type i = 0; i < 4; i += sizeof(uint16_t)) {

--- a/src/librawspeed/io/BitPumpMSB32.h
+++ b/src/librawspeed/io/BitPumpMSB32.h
@@ -47,6 +47,7 @@ template <>
 inline BitPumpMSB32::size_type
 BitPumpMSB32::fillCache(Array1DRef<const uint8_t> input) {
   static_assert(BitStreamCacheBase::MaxGetBits >= 32, "check implementation");
+  establishClassInvariants();
   invariant(input.size() == BitStreamTraits<tag>::MaxProcessBytes);
 
   cache.push(getLE<uint32_t>(input.getCrop(0, sizeof(uint32_t)).begin()), 32);

--- a/src/librawspeed/io/BitStream.h
+++ b/src/librawspeed/io/BitStream.h
@@ -45,64 +45,112 @@ template <typename BIT_STREAM> struct BitStreamTraits final {
 // Each BitStream specialization uses one of the two.
 
 struct BitStreamCacheBase {
-  uint64_t cache = 0;         // the actual bits stored in the cache
-  unsigned int fillLevel = 0; // bits left in cache
+  uint64_t cache = 0; // the actual bits stored in the cache
+  int fillLevel = 0;  // bits left in cache
 
-  static constexpr unsigned Size = bitwidth<decltype(cache)>();
+  static constexpr int Size = bitwidth<decltype(cache)>();
 
   // how many bits could be requested to be filled
-  static constexpr unsigned MaxGetBits = bitwidth<uint32_t>();
+  static constexpr int MaxGetBits = bitwidth<uint32_t>();
+
+  void establishClassInvariants() const noexcept;
 };
 
+__attribute__((always_inline)) inline void
+BitStreamCacheBase::establishClassInvariants() const noexcept {
+  invariant(fillLevel >= 0);
+  invariant(fillLevel <= Size);
+}
+
 struct BitStreamCacheLeftInRightOut final : BitStreamCacheBase {
-  inline void push(uint64_t bits, uint32_t count) noexcept {
-    invariant(count + fillLevel <= bitwidth(cache));
+  inline void push(uint64_t bits, int count) noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
+    invariant(count != 0);
+    invariant(count <= Size);
+    invariant(count + fillLevel <= Size);
     cache |= bits << fillLevel;
     fillLevel += count;
   }
 
-  [[nodiscard]] inline uint32_t peek(uint32_t count) const noexcept {
+  [[nodiscard]] inline uint32_t peek(int count) const noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
+    invariant(count <= MaxGetBits);
+    invariant(count != 0);
+    invariant(count <= Size);
+    invariant(count <= fillLevel);
+    invariant(count <= 31);
     return cache & ((1U << count) - 1U);
   }
 
-  inline void skip(uint32_t count) noexcept {
+  inline void skip(int count) noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
+    // `count` *could* be larger than `MaxGetBits`.
+    invariant(count != 0);
+    invariant(count <= Size);
+    invariant(count <= fillLevel);
     cache >>= count;
     fillLevel -= count;
   }
 };
 
 struct BitStreamCacheRightInLeftOut final : BitStreamCacheBase {
-  inline void push(uint64_t bits, uint32_t count) noexcept {
-    invariant(count + fillLevel <= Size);
+  inline void push(uint64_t bits, int count) noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
     invariant(count != 0);
+    invariant(count <= Size);
+    invariant(count + fillLevel <= Size);
     // If the maximal size of the cache is BitStreamCacheBase::Size, and we
     // have fillLevel [high] bits set, how many empty [low] bits do we have?
-    const uint32_t vacantBits = BitStreamCacheBase::Size - fillLevel;
+    const int vacantBits = BitStreamCacheBase::Size - fillLevel;
+    invariant(vacantBits >= 0);
+    invariant(vacantBits <= Size);
+    invariant(vacantBits != 0);
+    invariant(vacantBits >= count);
     // If we just directly 'or' these low bits into the cache right now,
     // how many unfilled bits of a gap will there be in the middle of a cache?
-    const uint32_t emptyBitsGap = vacantBits - count;
+    const int emptyBitsGap = vacantBits - count;
+    invariant(emptyBitsGap >= 0);
+    invariant(emptyBitsGap < Size);
     // So just shift the new bits so that there is no gap in the middle.
     cache |= bits << emptyBitsGap;
     fillLevel += count;
   }
 
-  [[nodiscard]] inline auto peek(uint32_t count) const noexcept {
+  [[nodiscard]] inline auto peek(int count) const noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
+    invariant(count <= Size);
+    invariant(count <= MaxGetBits);
+    invariant(count != 0);
+    invariant(count <= fillLevel);
     return implicit_cast<uint32_t>(
         extractHighBits(cache, count,
                         /*effectiveBitwidth=*/BitStreamCacheBase::Size));
   }
 
-  inline void skip(uint32_t count) noexcept {
+  inline void skip(int count) noexcept {
+    establishClassInvariants();
+    invariant(count >= 0);
+    // `count` *could* be larger than `MaxGetBits`.
+    // `count` could be zero.
+    invariant(count <= Size);
+    invariant(count <= fillLevel);
     fillLevel -= count;
     cache <<= count;
   }
 };
 
 template <typename Tag> struct BitStreamReplenisherBase {
-  using size_type = uint32_t;
+  using size_type = int32_t;
 
   Array1DRef<const uint8_t> input;
-  unsigned pos = 0;
+  int pos = 0;
+
+  void establishClassInvariants() const noexcept;
 
   BitStreamReplenisherBase() = delete;
 
@@ -124,6 +172,15 @@ template <typename Tag> struct BitStreamReplenisherBase {
 };
 
 template <typename Tag>
+__attribute__((always_inline)) inline void
+BitStreamReplenisherBase<Tag>::establishClassInvariants() const noexcept {
+  input.establishClassInvariants();
+  invariant(input.size() >= BitStreamTraits<Tag>::MaxProcessBytes);
+  invariant(pos >= 0);
+  // `pos` *could* be out-of-bounds of `input`.
+}
+
+template <typename Tag>
 struct BitStreamForwardSequentialReplenisher final
     : public BitStreamReplenisherBase<Tag> {
   using Base = BitStreamReplenisherBase<Tag>;
@@ -133,23 +190,30 @@ struct BitStreamForwardSequentialReplenisher final
   BitStreamForwardSequentialReplenisher() = delete;
 
   [[nodiscard]] inline typename Base::size_type getPos() const {
+    Base::establishClassInvariants();
     return Base::pos;
   }
   [[nodiscard]] inline typename Base::size_type getRemainingSize() const {
+    Base::establishClassInvariants();
     return Base::input.size() - getPos();
   }
   inline void markNumBytesAsConsumed(typename Base::size_type numBytes) {
+    Base::establishClassInvariants();
+    invariant(numBytes >= 0);
+    invariant(numBytes != 0);
     Base::pos += numBytes;
   }
 
   inline Array1DRef<const uint8_t> getInput() {
+    Base::establishClassInvariants();
+
 #if !defined(DEBUG)
     // Do we have BitStreamTraits<Tag>::MaxProcessBytes or more bytes left in
     // the input buffer? If so, then we can just read from said buffer.
-    if (Base::pos + BitStreamTraits<Tag>::MaxProcessBytes <=
-        implicit_cast<unsigned>(Base::input.size())) {
+    if (getPos() + BitStreamTraits<Tag>::MaxProcessBytes <=
+        Base::input.size()) {
       return Base::input
-          .getCrop(Base::pos, BitStreamTraits<Tag>::MaxProcessBytes)
+          .getCrop(getPos(), BitStreamTraits<Tag>::MaxProcessBytes)
           .getAsArray1DRef();
     }
 #endif
@@ -159,12 +223,11 @@ struct BitStreamForwardSequentialReplenisher final
 
     // Note that in order to keep all fill-level invariants we must allow to
     // over-read past-the-end a bit.
-    if (Base::pos > implicit_cast<unsigned>(Base::input.size()) +
-                        2 * BitStreamTraits<Tag>::MaxProcessBytes)
+    if (getPos() >
+        Base::input.size() + 2 * BitStreamTraits<Tag>::MaxProcessBytes)
       ThrowIOE("Buffer overflow read in BitStream");
 
-    variableLengthLoadNaiveViaMemcpy(Base::tmp(), Base::input,
-                                     implicit_cast<int>(Base::pos));
+    variableLengthLoadNaiveViaMemcpy(Base::tmp(), Base::input, getPos());
 
     return Base::tmp();
   }
@@ -177,7 +240,7 @@ class BitStream final {
 
   Replenisher replenisher;
 
-  using size_type = uint32_t;
+  using size_type = int32_t;
 
   // this method hase to be implemented in the concrete BitStream template
   // specializations. It will return the number of bytes processed. It needs
@@ -187,12 +250,22 @@ class BitStream final {
 public:
   using tag = Tag;
 
+  void establishClassInvariants() const noexcept {
+    cache.establishClassInvariants();
+    replenisher.establishClassInvariants();
+  }
+
   BitStream() = delete;
 
   inline explicit BitStream(Array1DRef<const uint8_t> input)
-      : replenisher(input) {}
+      : replenisher(input) {
+    establishClassInvariants();
+  }
 
-  inline void fill(uint32_t nbits = Cache::MaxGetBits) {
+  inline void fill(int nbits = Cache::MaxGetBits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
+    invariant(nbits != 0);
     invariant(nbits <= Cache::MaxGetBits);
 
     if (cache.fillLevel >= nbits)
@@ -203,55 +276,75 @@ public:
 
   // these methods might be specialized by implementations that support it
   [[nodiscard]] inline size_type RAWSPEED_READONLY getInputPosition() const {
+    establishClassInvariants();
     return replenisher.getPos();
   }
 
   // these methods might be specialized by implementations that support it
   [[nodiscard]] inline size_type getStreamPosition() const {
+    establishClassInvariants();
     return getInputPosition() - (cache.fillLevel >> 3);
   }
 
   [[nodiscard]] inline size_type getRemainingSize() const {
+    establishClassInvariants();
     return replenisher.getRemainingSize();
   }
 
   [[nodiscard]] inline size_type RAWSPEED_READONLY getFillLevel() const {
+    establishClassInvariants();
     return cache.fillLevel;
   }
 
-  inline uint32_t RAWSPEED_READONLY peekBitsNoFill(uint32_t nbits) {
+  inline uint32_t RAWSPEED_READONLY peekBitsNoFill(int nbits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
     invariant(nbits != 0);
     invariant(nbits <= Cache::MaxGetBits);
-    invariant(nbits <= cache.fillLevel);
     return cache.peek(nbits);
   }
 
-  inline void skipBitsNoFill(uint32_t nbits) {
+  inline void skipBitsNoFill(int nbits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
+    // `nbits` could be zero.
     invariant(nbits <= Cache::MaxGetBits);
-    invariant(nbits <= cache.fillLevel);
     cache.skip(nbits);
   }
 
-  inline uint32_t getBitsNoFill(uint32_t nbits) {
+  inline uint32_t getBitsNoFill(int nbits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
+    invariant(nbits != 0);
+    invariant(nbits <= Cache::MaxGetBits);
     uint32_t ret = peekBitsNoFill(nbits);
     skipBitsNoFill(nbits);
     return ret;
   }
 
-  inline uint32_t peekBits(uint32_t nbits) {
+  inline uint32_t peekBits(int nbits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
+    invariant(nbits != 0);
+    invariant(nbits <= Cache::MaxGetBits);
     fill(nbits);
     return peekBitsNoFill(nbits);
   }
 
-  inline uint32_t getBits(uint32_t nbits) {
+  inline uint32_t getBits(int nbits) {
+    establishClassInvariants();
+    invariant(nbits >= 0);
+    invariant(nbits != 0);
+    invariant(nbits <= Cache::MaxGetBits);
     fill(nbits);
     return getBitsNoFill(nbits);
   }
 
   // This may be used to skip arbitrarily large number of *bytes*,
   // not limited by the fill level.
-  inline void skipBytes(uint32_t nbytes) {
-    uint32_t remainingBitsToSkip = 8 * nbytes;
+  inline void skipBytes(int nbytes) {
+    establishClassInvariants();
+    int remainingBitsToSkip = 8 * nbytes;
     for (; remainingBitsToSkip >= Cache::MaxGetBits;
          remainingBitsToSkip -= Cache::MaxGetBits) {
       fill(Cache::MaxGetBits);


### PR DESCRIPTION
Again, slight improvement in `BitPumpJPEGBenchmark`, but otherwise mostly performance-neutral.

```
build-Clang17-release$ /usr/src/googlebenchmark/tools/compare.py -a benchmarks bench/librawspeed/io/BitPumpJPEGBenchmark{-old,} --benchmark_repetitions=9 --benchmark_min_warmup_time=0.5RUNNING: bench/librawspeed/io/BitPumpJPEGBenchmark-old --benchmark_repetitions=9 --benchmark_min_warmup_time=0.5 --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpz8tka7pa
2024-01-22T05:11:06+03:00
Running bench/librawspeed/io/BitPumpJPEGBenchmark-old
Run on (32 X 3402.99 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 6.12, 5.70, 6.46
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
BM_BitPumpJPEG/Stuffed/16777216_mean           8844 us         8842 us            9 Latency=527.011ps Throughput=1.76727Gi/s
BM_BitPumpJPEG/Stuffed/16777216_median         8823 us         8821 us            9 Latency=525.793ps Throughput=1.77127Gi/s
BM_BitPumpJPEG/Stuffed/16777216_stddev         68.7 us         68.3 us            9 Latency=4.07066ps Throughput=13.7753Mi/s
BM_BitPumpJPEG/Stuffed/16777216_cv             0.78 %          0.77 %             9 Latency=0.77% Throughput=0.76%
BM_BitPumpJPEG/Unstuffed/16777216_mean         8044 us         8040 us            9 Latency=479.248ps Throughput=1.9433Gi/s
BM_BitPumpJPEG/Unstuffed/16777216_median       8045 us         8040 us            9 Latency=479.237ps Throughput=1.94334Gi/s
BM_BitPumpJPEG/Unstuffed/16777216_stddev       1.69 us         2.29 us            9 Latency=136.419fs Throughput=579.907Ki/s
BM_BitPumpJPEG/Unstuffed/16777216_cv           0.02 %          0.03 %             9 Latency=0.03% Throughput=0.03%
RUNNING: bench/librawspeed/io/BitPumpJPEGBenchmark --benchmark_repetitions=9 --benchmark_min_warmup_time=0.5 --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpmrvdb0x_
2024-01-22T05:11:40+03:00
Running bench/librawspeed/io/BitPumpJPEGBenchmark
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 3.85, 5.18, 6.26
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
BM_BitPumpJPEG/Stuffed/16777216_mean           8314 us         8312 us            9 Latency=495.409ps Throughput=1.8801Gi/s
BM_BitPumpJPEG/Stuffed/16777216_median         8283 us         8281 us            9 Latency=493.574ps Throughput=1.8869Gi/s
BM_BitPumpJPEG/Stuffed/16777216_stddev         90.0 us         90.3 us            9 Latency=5.37952ps Throughput=20.3907Mi/s
BM_BitPumpJPEG/Stuffed/16777216_cv             1.08 %          1.09 %             9 Latency=1.09% Throughput=1.06%
BM_BitPumpJPEG/Unstuffed/16777216_mean         7430 us         7427 us            9 Latency=442.694ps Throughput=2.10376Gi/s
BM_BitPumpJPEG/Unstuffed/16777216_median       7430 us         7425 us            9 Latency=442.588ps Throughput=2.10426Gi/s
BM_BitPumpJPEG/Unstuffed/16777216_stddev       7.38 us         7.18 us            9 Latency=427.866fs Throughput=2.07939Mi/s
BM_BitPumpJPEG/Unstuffed/16777216_cv           0.10 %          0.10 %             9 Latency=0.10% Throughput=0.10%
Comparing bench/librawspeed/io/BitPumpJPEGBenchmark-old to bench/librawspeed/io/BitPumpJPEGBenchmark
Benchmark                                                  Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------
BM_BitPumpJPEG/Stuffed/16777216_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
BM_BitPumpJPEG/Stuffed/16777216_mean                    -0.0599         -0.0600          8844          8314          8842          8312
BM_BitPumpJPEG/Stuffed/16777216_median                  -0.0612         -0.0613          8823          8283          8821          8281
BM_BitPumpJPEG/Stuffed/16777216_stddev                  +0.3094         +0.3215            69            90            68            90
BM_BitPumpJPEG/Stuffed/16777216_cv                      +0.3929         +0.4058             0             0             0             0
BM_BitPumpJPEG/Unstuffed/16777216_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
BM_BitPumpJPEG/Unstuffed/16777216_mean                  -0.0764         -0.0763          8044          7430          8040          7427
BM_BitPumpJPEG/Unstuffed/16777216_median                -0.0765         -0.0765          8045          7430          8040          7425
BM_BitPumpJPEG/Unstuffed/16777216_stddev                +3.3668         +2.1364             2             7             2             7
BM_BitPumpJPEG/Unstuffed/16777216_cv                    +3.7282         +2.3954             0             0             0             0
OVERALL_GEOMEAN                                         -0.0682         -0.0682             0             0             0             0

```