### PR TITLE
`BitStreamerJPEG`: better JPEG Marker handling

### DIFF
--- a/src/librawspeed/io/BitStreamer.h
+++ b/src/librawspeed/io/BitStreamer.h
@@ -199,7 +199,6 @@ struct BitStreamerForwardSequentialReplenisher final
   inline void markNumBytesAsConsumed(typename Base::size_type numBytes) {
     Base::establishClassInvariants();
     invariant(numBytes >= 0);
-    invariant(numBytes != 0);
     Base::pos += numBytes;
   }
 

--- a/src/librawspeed/io/BitStreamerJPEG.h
+++ b/src/librawspeed/io/BitStreamerJPEG.h
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <numeric>
 
 namespace rawspeed {
 
@@ -69,8 +70,9 @@ BitStreamerJPEG::fillCache(Array1DRef<const uint8_t> input) {
 
   // short-cut path for the most common case (no FF marker in the next 4 bytes)
   // this is slightly faster than the else-case alone.
-  if (std::none_of(&prefetch[0], &prefetch[4],
-                   [](uint8_t byte) { return byte == 0xFF; })) {
+  if (std::accumulate(
+          &prefetch[0], &prefetch[4], bool(true),
+          [](bool b, uint8_t byte) { return b && (byte != 0xFF); })) {
     cache = speculativeOptimisticCache;
     return 4;
   }

--- a/src/librawspeed/io/BitStreamerJPEG.h
+++ b/src/librawspeed/io/BitStreamerJPEG.h
@@ -113,10 +113,17 @@ BitStreamerJPEG::fillCache(Array1DRef<const uint8_t> input) {
     cache.cache &= ~((~0ULL) >> cache.fillLevel);
     cache.fillLevel = 64;
 
-    // No further reading from this buffer shall happen. Do signal that by
-    // claiming that we have consumed all the remaining bytes of the buffer.
-    return getRemainingSize();
+    // This buffer has been exhausted. While it is incredibly tempting to
+    // signal *that* by claiming that we have consumed all the remaining bytes
+    // of the buffer, we can't actually do that, because the caller code
+    // may depend on the position of the end-of-stream marker / marker itself.
+    break;
   }
+
+  invariant(p >= 0);
+  invariant(p <= 8);
+  // NOTE: `p` may be `0`!
+
   return p;
 }
 

--- a/src/librawspeed/io/BitStreamerJPEG.h
+++ b/src/librawspeed/io/BitStreamerJPEG.h
@@ -80,18 +80,19 @@ BitStreamerJPEG::fillCache(Array1DRef<const uint8_t> input) {
   size_type p = 0;
   for (size_type i = 0; i < 4; ++i) {
     // Pre-execute most common case, where next byte is 'normal'/non-FF
-    const int c0 = prefetch[p];
-    ++p;
+    const int c0 = prefetch[p + 0];
     cache.push(c0, 8);
-    if (c0 != 0xFF)
+    if (c0 != 0xFF) {
+      p += 1;
       continue; // Got normal byte.
+    }
 
     // Found FF -> pre-execute case of FF/00, which represents an FF data byte
-    const int c1 = prefetch[p];
-    ++p;
+    const int c1 = prefetch[p + 1];
     if (c1 == 0x00) {
       // Got FF/00, where 0x00 is a stuffing byte (that should be ignored),
       // so 0xFF is a normal byte. All good.
+      p += 2;
       continue;
     }
 


### PR DESCRIPTION
Will come in handy for restart intervals later on.