### PR TITLE
Cr2Decompressor: make whole-image decoding -10% faster. Wow?

### DIFF
--- a/fuzz/librawspeed/decompressors/Cr2Decompressor.cpp
+++ b/fuzz/librawspeed/decompressors/Cr2Decompressor.cpp
@@ -122,7 +122,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
         mRaw, format, frame, slicing, rec,
         bs.getSubStream(/*offset=*/0).peekRemainingBuffer().getAsArray1DRef());
     mRaw->createData();
-    d.decompress();
+    (void)d.decompress();
 
     rawspeed::MSan::CheckMemIsInitialized(
         mRaw->getByteDataAsUncroppedArray2DRef());

--- a/src/librawspeed/decompressors/Cr2Decompressor.h
+++ b/src/librawspeed/decompressors/Cr2Decompressor.h
@@ -28,6 +28,7 @@
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
+#include "io/ByteStream.h"
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -153,7 +154,8 @@ private:
   template <int N_COMP>
   [[nodiscard]] std::array<uint16_t, N_COMP> getInitialPreds() const;
 
-  template <int N_COMP, int X_S_F, int Y_S_F> void decompressN_X_Y() const;
+  template <int N_COMP, int X_S_F, int Y_S_F>
+  [[nodiscard]] ByteStream::size_type decompressN_X_Y() const;
 
   [[nodiscard]] iterator_range<Cr2SliceIterator> getSlices() const;
   [[nodiscard]] iterator_range<Cr2OutputTileIterator> getAllOutputTiles() const;
@@ -168,7 +170,7 @@ public:
       iPoint2D frame, Cr2SliceWidths slicing,
       std::vector<PerComponentRecipe> rec, Array1DRef<const uint8_t> input);
 
-  void decompress() const;
+  [[nodiscard]] ByteStream::size_type decompress() const;
 };
 
 extern template class Cr2Decompressor<PrefixCodeDecoder<>>;

--- a/src/librawspeed/decompressors/Cr2DecompressorImpl.h
+++ b/src/librawspeed/decompressors/Cr2DecompressorImpl.h
@@ -390,7 +390,8 @@ Cr2Decompressor<PrefixCodeDecoder>::getInitialPreds() const {
 
 template <typename PrefixCodeDecoder>
 template <int N_COMP, int X_S_F, int Y_S_F>
-void Cr2Decompressor<PrefixCodeDecoder>::decompressN_X_Y() const {
+ByteStream::size_type
+Cr2Decompressor<PrefixCodeDecoder>::decompressN_X_Y() const {
   const Array2DRef<uint16_t> out(mRaw->getU16DataAsUncroppedArray2DRef());
 
   // To understand the CR2 slice handling and sampling factor behavior, see
@@ -458,25 +459,22 @@ void Cr2Decompressor<PrefixCodeDecoder>::decompressN_X_Y() const {
       }
     }
   }
+  return bs.getStreamPosition();
 }
 
 template <typename PrefixCodeDecoder>
-void Cr2Decompressor<PrefixCodeDecoder>::decompress() const {
+ByteStream::size_type Cr2Decompressor<PrefixCodeDecoder>::decompress() const {
   if (std::make_tuple(3, 2, 2) == format) {
-    decompressN_X_Y<3, 2, 2>(); // Cr2 sRaw1/mRaw
-    return;
+    return decompressN_X_Y<3, 2, 2>(); // Cr2 sRaw1/mRaw
   }
   if (std::make_tuple(3, 2, 1) == format) {
-    decompressN_X_Y<3, 2, 1>(); // Cr2 sRaw2/sRaw
-    return;
+    return decompressN_X_Y<3, 2, 1>(); // Cr2 sRaw2/sRaw
   }
   if (std::make_tuple(2, 1, 1) == format) {
-    decompressN_X_Y<2, 1, 1>();
-    return;
+    return decompressN_X_Y<2, 1, 1>();
   }
   if (std::make_tuple(4, 1, 1) == format) {
-    decompressN_X_Y<4, 1, 1>();
-    return;
+    return decompressN_X_Y<4, 1, 1>();
   }
   __builtin_unreachable();
 }

--- a/src/librawspeed/decompressors/Cr2LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/Cr2LJpegDecoder.cpp
@@ -146,7 +146,7 @@ void Cr2LJpegDecoder::decodeScan() {
   Cr2Decompressor<PrefixCodeDecoder<>> d(
       mRaw, format, iPoint2D(frame.w, frame.h), slicing, rec,
       input.peekRemainingBuffer().getAsArray1DRef());
-  d.decompress();
+  input.skipBytes(d.decompress());
 }
 
 void Cr2LJpegDecoder::decode(const Cr2SliceWidths& slicing_) {


### PR DESCRIPTION
```
Comparing src/utilities/rsbench/rsbench-old to src/utilities/rsbench/rsbench
Benchmark                                                                                                              Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
raw.pixls.us-unique/Canon/EOS 40D/_MG_0154.CR2/threads:32/process_time/real_time_pvalue                              0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 40D/_MG_0154.CR2/threads:32/process_time/real_time_mean                               -0.0796         -0.0796            27            25            27            25
raw.pixls.us-unique/Canon/EOS 40D/_MG_0154.CR2/threads:32/process_time/real_time_median                             -0.0796         -0.0796            27            25            27            25
raw.pixls.us-unique/Canon/EOS 40D/_MG_0154.CR2/threads:32/process_time/real_time_stddev                             +0.4248         +0.4262             0             0             0             0
raw.pixls.us-unique/Canon/EOS 40D/_MG_0154.CR2/threads:32/process_time/real_time_cv                                 +0.5481         +0.5496             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5D Mark II/09.canon.sraw1.cr2/threads:32/process_time/real_time_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 5D Mark II/09.canon.sraw1.cr2/threads:32/process_time/real_time_mean                  -0.1362         -0.1359           105            91          3354          2898
raw.pixls.us-unique/Canon/EOS 5D Mark II/09.canon.sraw1.cr2/threads:32/process_time/real_time_median                -0.1392         -0.1386           105            91          3354          2890
raw.pixls.us-unique/Canon/EOS 5D Mark II/09.canon.sraw1.cr2/threads:32/process_time/real_time_stddev                +0.7775         +0.4946             1             1            19            29
raw.pixls.us-unique/Canon/EOS 5D Mark II/09.canon.sraw1.cr2/threads:32/process_time/real_time_cv                    +1.0577         +0.7297             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5D Mark II/10.canon.sraw2.cr2/threads:32/process_time/real_time_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 5D Mark II/10.canon.sraw2.cr2/threads:32/process_time/real_time_mean                  -0.0665         -0.0665            55            52            55            52
raw.pixls.us-unique/Canon/EOS 5D Mark II/10.canon.sraw2.cr2/threads:32/process_time/real_time_median                -0.0665         -0.0665            55            52            55            52
raw.pixls.us-unique/Canon/EOS 5D Mark II/10.canon.sraw2.cr2/threads:32/process_time/real_time_stddev                -0.9041         -0.9014             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5D Mark II/10.canon.sraw2.cr2/threads:32/process_time/real_time_cv                    -0.8972         -0.8943             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9927.CR2/threads:32/process_time/real_time_pvalue                              0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9927.CR2/threads:32/process_time/real_time_mean                               -0.1502         -0.1502           225           191           225           191
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9927.CR2/threads:32/process_time/real_time_median                             -0.1496         -0.1496           225           192           225           192
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9927.CR2/threads:32/process_time/real_time_stddev                             +3.8736         +3.9278             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9927.CR2/threads:32/process_time/real_time_cv                                 +4.7349         +4.7987             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9928.CR2/threads:32/process_time/real_time_pvalue                              0.0004          0.6588      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9928.CR2/threads:32/process_time/real_time_mean                               -0.0764         +0.0020           267           247          6984          6998
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9928.CR2/threads:32/process_time/real_time_median                             -0.0756         -0.0010           267           247          6992          6984
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9928.CR2/threads:32/process_time/real_time_stddev                             +0.8443         +0.0099             1             1            38            38
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9928.CR2/threads:32/process_time/real_time_cv                                 +0.9967         +0.0080             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9929.CR2/threads:32/process_time/real_time_pvalue                              0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9929.CR2/threads:32/process_time/real_time_mean                               -0.0689         -0.0689           154           144           154           144
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9929.CR2/threads:32/process_time/real_time_median                             -0.0682         -0.0682           154           144           154           144
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9929.CR2/threads:32/process_time/real_time_stddev                             +6.6731         +6.8931             0             0             0             0
raw.pixls.us-unique/Canon/EOS 5DS/2K4A9929.CR2/threads:32/process_time/real_time_cv                                 +7.2405         +7.4768             0             0             0             0
raw.pixls.us-unique/Canon/EOS 77D/IMG_4049.CR2/threads:32/process_time/real_time_pvalue                              0.0004          0.0004      U Test, Repetitions: 9 vs 9
raw.pixls.us-unique/Canon/EOS 77D/IMG_4049.CR2/threads:32/process_time/real_time_mean                               -0.1334         -0.1334           151           131           151           131
raw.pixls.us-unique/Canon/EOS 77D/IMG_4049.CR2/threads:32/process_time/real_time_median                             -0.1333         -0.1333           151           131           151           131
raw.pixls.us-unique/Canon/EOS 77D/IMG_4049.CR2/threads:32/process_time/real_time_stddev                             +0.1553         +0.1940             0             0             0             0
raw.pixls.us-unique/Canon/EOS 77D/IMG_4049.CR2/threads:32/process_time/real_time_cv                                 +0.3331         +0.3777             0             0             0             0
OVERALL_GEOMEAN                                                                                                     -0.1022         -0.0917             0             0             0             0
```