### PR TITLE
(DNG/Sony) LJpeg decompressor: make it -10% faster. WOW?

### DIFF
--- a/fuzz/librawspeed/decompressors/DummyLJpegDecoder.cpp
+++ b/fuzz/librawspeed/decompressors/DummyLJpegDecoder.cpp
@@ -21,6 +21,7 @@
 #include "adt/Casts.h"
 #include "common/RawImage.h"
 #include "common/RawspeedException.h"
+#include "decoders/RawDecoderException.h"
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "fuzz/Common.h"
 #include "io/Buffer.h"
@@ -35,7 +36,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size);
 namespace {
 
 class DummyLJpegDecoder final : public rawspeed::AbstractLJpegDecoder {
-  void decodeScan() final {}
+  [[nodiscard]] rawspeed::ByteStream::size_type decodeScan() final {
+    ThrowRDE("Success!");
+  }
 
 public:
   DummyLJpegDecoder(const rawspeed::ByteStream& bs,

--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -90,7 +90,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
         mRaw, rawspeed::iRectangle2D(mRaw->dim.x, mRaw->dim.y), frame, rec,
         bs.getSubStream(/*offset=*/0).peekRemainingBuffer().getAsArray1DRef());
     mRaw->createData();
-    d.decode();
+    (void)d.decode();
 
     rawspeed::MSan::CheckMemIsInitialized(
         mRaw->getByteDataAsUncroppedArray2DRef());

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
@@ -219,7 +219,9 @@ void AbstractLJpegDecoder::parseSOS(ByteStream sos) {
   if (Pt != 0)
     ThrowRDE("Point transform not supported.");
 
-  decodeScan();
+  const auto scanLength = decodeScan();
+  invariant(scanLength != 0);
+  input.skipBytes(scanLength);
 }
 
 void AbstractLJpegDecoder::parseDHT(ByteStream dht) {

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.h
@@ -206,7 +206,7 @@ protected:
     return pred;
   }
 
-  virtual void decodeScan() = 0;
+  [[nodiscard]] virtual ByteStream::size_type decodeScan() = 0;
 
   ByteStream input;
   RawImage mRaw;

--- a/src/librawspeed/decompressors/Cr2LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/Cr2LJpegDecoder.cpp
@@ -28,6 +28,7 @@
 #include "decoders/RawDecoderException.h"
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "decompressors/Cr2Decompressor.h"
+#include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include <algorithm>
 #include <array>
@@ -54,7 +55,7 @@ Cr2LJpegDecoder::Cr2LJpegDecoder(ByteStream bs, const RawImage& img)
   }
 }
 
-void Cr2LJpegDecoder::decodeScan() {
+Buffer::size_type Cr2LJpegDecoder::decodeScan() {
   if (predictorMode != 1)
     ThrowRDE("Unsupported predictor mode.");
 
@@ -146,7 +147,7 @@ void Cr2LJpegDecoder::decodeScan() {
   Cr2Decompressor<PrefixCodeDecoder<>> d(
       mRaw, format, iPoint2D(frame.w, frame.h), slicing, rec,
       input.peekRemainingBuffer().getAsArray1DRef());
-  input.skipBytes(d.decompress());
+  return d.decompress();
 }
 
 void Cr2LJpegDecoder::decode(const Cr2SliceWidths& slicing_) {

--- a/src/librawspeed/decompressors/Cr2LJpegDecoder.h
+++ b/src/librawspeed/decompressors/Cr2LJpegDecoder.h
@@ -32,7 +32,7 @@ class RawImage;
 class Cr2LJpegDecoder final : public AbstractLJpegDecoder {
   Cr2SliceWidths slicing;
 
-  void decodeScan() override;
+  [[nodiscard]] ByteStream::size_type decodeScan() override;
 
 public:
   Cr2LJpegDecoder(ByteStream bs, const RawImage& img);

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.cpp
@@ -25,6 +25,7 @@
 #include "decoders/RawDecoderException.h"
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "decompressors/HasselbladDecompressor.h"
+#include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include <cstdint>
 #include <vector>
@@ -46,7 +47,7 @@ HasselbladLJpegDecoder::HasselbladLJpegDecoder(ByteStream bs,
   }
 }
 
-void HasselbladLJpegDecoder::decodeScan() {
+Buffer::size_type HasselbladLJpegDecoder::decodeScan() {
   if (frame.w != static_cast<unsigned>(mRaw->dim.x) ||
       frame.h != static_cast<unsigned>(mRaw->dim.y)) {
     ThrowRDE("LJPEG frame does not match EXIF dimensions: (%u; %u) vs (%i; %i)",
@@ -58,7 +59,7 @@ void HasselbladLJpegDecoder::decodeScan() {
 
   HasselbladDecompressor d(mRaw, rec,
                            input.peekRemainingBuffer().getAsArray1DRef());
-  input.skipBytes(d.decompress());
+  return d.decompress();
 }
 
 void HasselbladLJpegDecoder::decode() {

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
@@ -29,7 +29,7 @@ class ByteStream;
 class RawImage;
 
 class HasselbladLJpegDecoder final : public AbstractLJpegDecoder {
-  void decodeScan() override;
+  [[nodiscard]] ByteStream::size_type decodeScan() override;
 
 public:
   HasselbladLJpegDecoder(ByteStream bs, const RawImage& img);

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -119,7 +119,7 @@ void LJpegDecoder::decodeScan() {
                    {static_cast<int>(w), static_cast<int>(h)}),
       LJpegDecompressor::Frame{N_COMP, iPoint2D(frame.w, frame.h)}, rec,
       input.peekRemainingBuffer().getAsArray1DRef());
-  d.decode();
+  input.skipBytes(d.decode());
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -27,6 +27,7 @@
 #include "decoders/RawDecoderException.h"
 #include "decompressors/AbstractLJpegDecoder.h"
 #include "decompressors/LJpegDecompressor.h"
+#include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include <algorithm>
 #include <array>
@@ -91,7 +92,7 @@ void LJpegDecoder::decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
   AbstractLJpegDecoder::decodeSOI();
 }
 
-void LJpegDecoder::decodeScan() {
+Buffer::size_type LJpegDecoder::decodeScan() {
   invariant(frame.cps > 0);
 
   if (predictorMode != 1)
@@ -119,7 +120,7 @@ void LJpegDecoder::decodeScan() {
                    {static_cast<int>(w), static_cast<int>(h)}),
       LJpegDecompressor::Frame{N_COMP, iPoint2D(frame.w, frame.h)}, rec,
       input.peekRemainingBuffer().getAsArray1DRef());
-  input.skipBytes(d.decode());
+  return d.decode();
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/LJpegDecoder.h
+++ b/src/librawspeed/decompressors/LJpegDecoder.h
@@ -31,7 +31,7 @@ class RawImage;
 // Decompresses Lossless JPEGs, with 2-4 components
 
 class LJpegDecoder final : public AbstractLJpegDecoder {
-  void decodeScan() override;
+  [[nodiscard]] ByteStream::size_type decodeScan() override;
 
   uint32_t offX = 0;
   uint32_t offY = 0;

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -30,6 +30,7 @@
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "io/BitStreamerJPEG.h"
+#include "io/ByteStream.h"
 #include <algorithm>
 #include <array>
 #include <cinttypes>
@@ -159,7 +160,8 @@ std::array<uint16_t, N_COMP> LJpegDecompressor::getInitialPreds() const {
 
 // N_COMP == number of components (2, 3 or 4)
 
-template <int N_COMP, bool WeirdWidth> void LJpegDecompressor::decodeN() {
+template <int N_COMP, bool WeirdWidth>
+ByteStream::size_type LJpegDecompressor::decodeN() {
   invariant(mRaw->getCpp() > 0);
   invariant(N_COMP > 0);
 
@@ -240,23 +242,20 @@ template <int N_COMP, bool WeirdWidth> void LJpegDecompressor::decodeN() {
             .decodeDifference(bitStreamer);
     }
   }
+  return bitStreamer.getStreamPosition();
 }
 
-void LJpegDecompressor::decode() {
+ByteStream::size_type LJpegDecompressor::decode() {
   if (trailingPixels == 0) {
     switch (frame.cps) {
     case 1:
-      decodeN<1>();
-      break;
+      return decodeN<1>();
     case 2:
-      decodeN<2>();
-      break;
+      return decodeN<2>();
     case 3:
-      decodeN<3>();
-      break;
+      return decodeN<3>();
     case 4:
-      decodeN<4>();
-      break;
+      return decodeN<4>();
     default:
       __builtin_unreachable();
     }
@@ -267,14 +266,11 @@ void LJpegDecompressor::decode() {
     switch (frame.cps) {
     // Naturally can't happen for CPS=1.
     case 2:
-      decodeN<2, /*WeirdWidth=*/true>();
-      break;
+      return decodeN<2, /*WeirdWidth=*/true>();
     case 3:
-      decodeN<3, /*WeirdWidth=*/true>();
-      break;
+      return decodeN<3, /*WeirdWidth=*/true>();
     case 4:
-      decodeN<4, /*WeirdWidth=*/true>();
-      break;
+      return decodeN<4, /*WeirdWidth=*/true>();
     default:
       __builtin_unreachable();
     }

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -25,6 +25,7 @@
 #include "adt/Point.h"
 #include "codes/PrefixCodeDecoder.h"
 #include "common/RawImage.h"
+#include "io/ByteStream.h"
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -72,14 +73,15 @@ private:
   template <int N_COMP>
   [[nodiscard]] std::array<uint16_t, N_COMP> getInitialPreds() const;
 
-  template <int N_COMP, bool WeirdWidth = false> void decodeN();
+  template <int N_COMP, bool WeirdWidth = false>
+  [[nodiscard]] ByteStream::size_type decodeN();
 
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,
                     std::vector<PerComponentRecipe> rec,
                     Array1DRef<const uint8_t> input);
 
-  void decode();
+  [[nodiscard]] ByteStream::size_type decode();
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
```
Comparing /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench-old to /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench
Benchmark                                                                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_mean                  -0.0615         -0.0619            12            11           377           354
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_median                -0.0498         -0.0507            12            11           373           354
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_stddev                -0.2116         -0.2142             0             0            10             8
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_cv                    -0.1600         -0.1623             0             0             0             0
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_mean                  -0.1044         -0.1049            16            15           517           463
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_median                -0.1108         -0.1110            16            14           515           458
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_stddev                -0.0016         -0.0047             0             0            12            12
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_cv                    +0.1147         +0.1119             0             0             0             0
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_pvalue                                        0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_mean                                         -0.2185         -0.2185             5             4           163           128
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_median                                       -0.2150         -0.2147             5             4           161           126
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_stddev                                       -0.4047         -0.4066             0             0             5             3
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_cv                                           -0.2382         -0.2407             0             0             0             0
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_pvalue                                      0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_mean                                       -0.0791         -0.0801            31            29          1000           920
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_median                                     -0.0877         -0.0884            31            29           995           907
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_stddev                                     -0.0990         -0.1090             1             1            23            21
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_cv                                         -0.0215         -0.0314             0             0             0             0
Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_pvalue                                         0.4781          0.4363      U Test, Repetitions: 27 vs 27
Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_mean                                          -0.0048         -0.0048            29            29           930           925
Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_median                                        +0.0029         +0.0059            29            29           922           927
Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_stddev                                        -0.0006         -0.0040             1             1            25            25
Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_cv                                            +0.0042         +0.0009             0             0             0             0
OVERALL_GEOMEAN                                                                                                                      -0.0965         -0.0968             0             0             0             0

```
