### PR TITLE
oss-fuzz: do build with OpenMP

### DIFF
--- a/.ci/oss-fuzz.sh
+++ b/.ci/oss-fuzz.sh
@@ -30,7 +30,7 @@ cd build
 # https://github.com/google/oss-fuzz/pull/2781).
 ln -f -s /usr/bin/gold /usr/bin/ld
 cmake \
-  -G"Unix Makefiles" -DBINARY_PACKAGE_BUILD=ON -DWITH_OPENMP=OFF \
+  -G"Unix Makefiles" -DBINARY_PACKAGE_BUILD=ON -DWITH_OPENMP=ON \
   -DWITH_PUGIXML=OFF -DUSE_XMLLINT=OFF -DWITH_JPEG=OFF -DWITH_ZLIB=OFF \
   -DBUILD_TESTING=OFF -DBUILD_TOOLS=OFF -DBUILD_BENCHMARKING=OFF \
   -DCMAKE_BUILD_TYPE=FUZZ -DBUILD_FUZZERS=ON \


### PR DESCRIPTION
OpenMP structured blocks can't throw,
and that invariant is generally not reflected in the code (unless done manually) when compiled without OpenMP, and that hides bugs (787695f19bba53c5186cd89ee383884e69d6a285 e.g.)

`rawspeed_get_number_of_processor_cores()` returns `1` for fuzzers, so there should not be any actual multi-threading done.