### PR TITLE
Re-add `BitStreamerJPEG` forward progress guarantee

### DIFF
--- a/.github/workflows/CI-codecov.yml
+++ b/.github/workflows/CI-codecov.yml
@@ -99,7 +99,7 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           OS: macOS
-          ARCH: x86_64
+          ARCH: aarch64
           CXX: XCode
           JOB_NAME: macOS.XCode.Coverage
         with:
@@ -115,7 +115,7 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           OS: macOS
-          ARCH: x86_64
+          ARCH: aarch64
           CXX: XCode
           JOB_NAME: macOS.XCode.Coverage
         with:

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
@@ -221,7 +221,7 @@ void AbstractLJpegDecoder::parseSOS(ByteStream sos) {
     ThrowRDE("Point transform not supported.");
 
   const auto scanLength = decodeScan();
-  invariant(scanLength != 0);
+  // FIXME: invariant(scanLength != 0);
   input.skipBytes(scanLength);
 }
 

--- a/src/librawspeed/decompressors/Cr2DecompressorImpl.h
+++ b/src/librawspeed/decompressors/Cr2DecompressorImpl.h
@@ -459,7 +459,8 @@ Cr2Decompressor<PrefixCodeDecoder>::decompressN_X_Y() const {
       }
     }
   }
-  return bs.getStreamPosition();
+  // FIXME: return bs.getStreamPosition();
+  return 0; // We don't know how far we've advanced.
 }
 
 template <typename PrefixCodeDecoder>

--- a/src/librawspeed/decompressors/JpegMarkers.h
+++ b/src/librawspeed/decompressors/JpegMarkers.h
@@ -116,6 +116,23 @@ inline Optional<JpegMarker> peekMarker(ByteStream input) {
   return {};
 }
 
+inline Optional<ByteStream> advanceToNextMarker(ByteStream input,
+                                                bool skipPadding) {
+  while (input.getRemainSize() >= 2) {
+    if (Optional<JpegMarker> m = peekMarker(input))
+      return input;
+
+    // Marker not found. Might there be leading padding bytes?
+    if (!skipPadding)
+      break; // Nope, give up.
+
+    // Advance by a single(!) byte and try again.
+    input.skipBytes(1);
+  }
+
+  return std::nullopt;
+}
+
 // Get the number of this restart marker (modulo 8).
 inline Optional<int> getRestartMarkerNumber(JpegMarker m) {
   switch (m) {

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -296,7 +296,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
       decodeRowN<N_COMP, WeirdWidth>(outRow, pred, ht, bs);
     }
 
-    inputStream.skipBytes(bs.getStreamPosition());
+    // FIXME: inputStream.skipBytes(bs.getStreamPosition());
   }
 
   return inputStream.getPosition();

--- a/src/librawspeed/io/BitStreamer.h
+++ b/src/librawspeed/io/BitStreamer.h
@@ -199,6 +199,7 @@ struct BitStreamerForwardSequentialReplenisher final
   inline void markNumBytesAsConsumed(typename Base::size_type numBytes) {
     Base::establishClassInvariants();
     invariant(numBytes >= 0);
+    invariant(numBytes != 0);
     Base::pos += numBytes;
   }
 

--- a/src/librawspeed/io/BitStreamerJPEG.h
+++ b/src/librawspeed/io/BitStreamerJPEG.h
@@ -113,17 +113,10 @@ BitStreamerJPEG::fillCache(Array1DRef<const uint8_t> input) {
     cache.cache &= ~((~0ULL) >> cache.fillLevel);
     cache.fillLevel = 64;
 
-    // This buffer has been exhausted. While it is incredibly tempting to
-    // signal *that* by claiming that we have consumed all the remaining bytes
-    // of the buffer, we can't actually do that, because the caller code
-    // may depend on the position of the end-of-stream marker / marker itself.
-    break;
+    // No further reading from this buffer shall happen. Do signal that by
+    // claiming that we have consumed all the remaining bytes of the buffer.
+    return getRemainingSize();
   }
-
-  invariant(p >= 0);
-  invariant(p <= 8);
-  // NOTE: `p` may be `0`!
-
   return p;
 }
 


### PR DESCRIPTION
As expected, f47140a7a94d756deb4de411ce8f2df9f8b5422a broke nearly all fuzzers.
Performance is nice, but not at that cost.
For now, just go back to the known-correct implementation,
without reverting JPEG restart interval handling.