### PR TITLE
DngDecoder: use uninitialized white point value for float DNGs

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -603,7 +603,8 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
     mRaw->whitePoint = implicit_cast<int>((1UL << bps) - 1UL);
   } else if (mRaw->getDataType() == RawImageType::F32) {
     // Default white level is 1.0f. But we can't represent that here.
-    mRaw->whitePoint = 65535;
+    // Fall back to uninitialized value instead.
+    mRaw->whitePoint = 65536;
   }
 
   if (raw->hasEntry(TiffTag::WHITELEVEL)) {


### PR DESCRIPTION
E.g. HDRMerge will use 65535 for real 16b cameras, don't hijack it.

This is to go w/ https://github.com/darktable-org/darktable/pull/16206

~~TODO: WhiteLevel should probably become float to support RATIONAL type and default value 1.0 (same goes for BlackLevel).~~