### PR TITLE
DngDecoder: default white level for floats is simply 1

### DIFF
--- a/src/librawspeed/common/RawImage.h
+++ b/src/librawspeed/common/RawImage.h
@@ -163,6 +163,11 @@ public:
   int blackLevel = -1;
   std::array<int, 4> blackLevelSeparateStorage;
   Optional<Array2DRef<int>> blackLevelSeparate;
+  // A white level of the image, if known.
+  // NOTE: it is always correct to divide the pixel by float(whiteLevel) to
+  // normalize the image.
+  // NOTE: for floating-point images, the white level is never non-integral, and
+  // thus >= 1.0f
   Optional<int> whitePoint;
   std::vector<BlackArea> blackAreas;
 

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -602,9 +602,23 @@ void DngDecoder::handleMetadata(const TiffIFD* raw) {
     // Default white level is (2 ** BitsPerSample) - 1
     mRaw->whitePoint = implicit_cast<int>((1UL << bps) - 1UL);
   } else if (mRaw->getDataType() == RawImageType::F32) {
-    // Default white level is 1.0f. But we can't represent that here,
-    // so just claim that we don't know it, and users shall default to 1.0F.
-    mRaw->whitePoint.reset();
+    // 1. We divide by white level to normalize the image s.t. the 1.0 becomes
+    // the white level.
+    // 2. In DNG spec, white level is always an integer, there can not be a
+    // non-integral white level.
+    // 3. Additionally, no white level for FP DNG's means that it is
+    // pre-normalized (default is 1.0).
+    //
+    // Therefore, we can surmise that:
+    // a) FP DNG's never have white level of <1.0
+    // b) FP DNG's always have integral white level
+    // c) if FP DNG has a white level of `w`, it is always correct to divide by
+    // float(w) to normalize the image
+    // ... therefore, we can, as an optimization, store FP DNG white level as an
+    // integer.
+    //
+    // This matches DNG SDK behavior.
+    mRaw->whitePoint = 1;
   }
 
   if (raw->hasEntry(TiffTag::WHITELEVEL)) {


### PR DESCRIPTION
1. We divide by white level to normalize the image s.t. the 1.0 becomes the white level.
2. In DNG spec, white level is always an integer, there can not be a non-integral white level.
3. Additionally, no white level for FP DNG's means that it is pre-normalized (default is 1.0).

Therefore, we can surmise that
a) FP DNG's never have white level of <1.0
b) FP DNG's always have integral white level
c) if FP DNG has a white level of `w`, it is always correct to divide by `float(w)` to normalize the image
... therefore, we can, as an optimization, store FP DNG white level as an integer.

This matches DNG SDK behavior.