### PR TITLE
Leica name normalization (DNG only)

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17504,6 +17504,9 @@
 	<Camera make="Leica Camera AG" model="LEICA M-D (Typ 262)" mode="dng">
 		<ID make="Leica" model="M-D (Typ 262)">LEICA M-D (Typ 262)</ID>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA X1" mode="dng">
+		<ID make="Leica" model="X1">LEICA X1</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X2" mode="dng">
 		<ID make="Leica" model="X2">LEICA X2</ID>
 		<ColorMatrices>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17498,6 +17498,12 @@
 	<Camera make="Leica Camera AG" model="LEICA M MONOCHROM (Typ 246)" mode="dng">
 		<ID make="Leica" model="M Monochrom (Typ 246)">LEICA M MONOCHROM (Typ 246)</ID>
 	</Camera>
+	<Camera make="Leica Camera AG" model="LEICA M (Typ 262)" mode="dng">
+		<ID make="Leica" model="M (Typ 262)">LEICA M (Typ 262)</ID>
+	</Camera>
+	<Camera make="Leica Camera AG" model="LEICA M-D (Typ 262)" mode="dng">
+		<ID make="Leica" model="M-D (Typ 262)">LEICA M-D (Typ 262)</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X2" mode="dng">
 		<ID make="Leica" model="X2">LEICA X2</ID>
 		<ColorMatrices>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17462,6 +17462,15 @@
 	<Camera make="PENTAX RICOH IMAGING" model="PENTAX MX-1" mode="dng">
 		<ID make="Pentax" model="MX-1">PENTAX MX-1</ID>
 	</Camera>
+	<Camera make="Leica Camera AG" model="LEICA S (Typ 007)" mode="dng">
+		<ID make="Leica" model="S (Typ 007)">LEICA S (Typ 007)</ID>
+	</Camera>
+	<Camera make="Leica Camera AG" model="S2" mode="dng">
+		<ID make="Leica" model="S2">Leica S2</ID>
+	</Camera>
+	<Camera make="Leica Camera AG" model="LEICA S3" mode="dng">
+		<ID make="Leica" model="S3">LEICA S3</ID>
+	</Camera>
 	<Camera make="Leica Camera AG" model="M8 Digital Camera" mode="dng">
 		<ID make="Leica" model="M8">M8 Digital Camera</ID>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17517,6 +17517,9 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA X VARIO (Typ 107)" mode="dng">
+		<ID make="Leica" model="X Vario (Typ 107)">LEICA X VARIO (Typ 107)</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA Q (Typ 116)" mode="dng">
 		<ID make="Leica" model="Q (Typ 116)">LEICA Q (Typ 116)</ID>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17518,13 +17518,6 @@
 	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X2" mode="dng">
 		<ID make="Leica" model="X2">LEICA X2</ID>
-		<ColorMatrices>
-			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">7158 -1911 -606</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-3603 10669 2530</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-659 1236 5530</ColorMatrixRow>
-			</ColorMatrix>
-		</ColorMatrices>
 	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X VARIO (Typ 107)" mode="dng">
 		<ID make="Leica" model="X Vario (Typ 107)">LEICA X VARIO (Typ 107)</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17504,6 +17504,15 @@
 	<Camera make="Leica Camera AG" model="LEICA M-D (Typ 262)" mode="dng">
 		<ID make="Leica" model="M-D (Typ 262)">LEICA M-D (Typ 262)</ID>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA T (Typ 701)" mode="dng">
+		<ID make="Leica" model="T (Typ 701)">LEICA T (Typ 701)</ID>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA TL" mode="dng">
+		<ID make="Leica" model="TL">LEICA TL</ID>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA TL2" mode="dng">
+		<ID make="Leica" model="TL2">LEICA TL2</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA X1" mode="dng">
 		<ID make="Leica" model="X1">LEICA X1</ID>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17520,6 +17520,12 @@
 	<Camera make="LEICA CAMERA AG" model="LEICA X VARIO (Typ 107)" mode="dng">
 		<ID make="Leica" model="X Vario (Typ 107)">LEICA X VARIO (Typ 107)</ID>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA X (Typ 113)" mode="dng">
+		<ID make="Leica" model="X (Typ 113)">LEICA X (Typ 113)</ID>
+	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA X-U (Typ 113)" mode="dng">
+		<ID make="Leica" model="X-U (Typ 113)">LEICA X-U (Typ 113)</ID>
+	</Camera>
 	<Camera make="LEICA CAMERA AG" model="LEICA Q (Typ 116)" mode="dng">
 		<ID make="Leica" model="Q (Typ 116)">LEICA Q (Typ 116)</ID>
 	</Camera>


### PR DESCRIPTION
AFAICT, these cameras output only DNG, so this is just to normalize the make and model strings.

Leica M (Typ 262)
Leica M-D (Typ 262)
Leica S (Typ 007)
Leica S2
Leica S3
Leica T (Typ 701)
Leica TL
Leica TL2
Leica X1
Leica X Vario (Typ 107)
Leica X (Typ 113)
Leica X-U (Typ 113)