### PR TITLE
Support `.3FR` from old Hasselblad cameras

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17420,6 +17420,16 @@
 		<Sensor black="256" white="62914"/>
 		<Aliases>
 			<Alias id="CFV-50c">Hasselblad CFV-50c</Alias>
+			<Alias id="CFV-50c/Flash Sync">CFV-50c/Flash Sync</Alias>
+			<Alias id="CFV-50c/SWC">CFV-50c/SWC</Alias>
+			<Alias id="CFV-50c/200">CFV-50c/200</Alias>
+			<Alias id="CFV-50c/500">CFV-50c/500</Alias>
+			<Alias id="CFV-50c/Schneider">CFV-50c/Schneider</Alias>
+			<Alias id="CFV-50c/LensCtrl S">CFV-50c/LensCtrl S</Alias>
+			<Alias id="CFV-50c/Winder CW">CFV-50c/Winder CW</Alias>
+			<Alias id="CFV-50c/ELD">CFV-50c/ELD</Alias>
+			<Alias id="CFV-50c/ELX">CFV-50c/ELX</Alias>
+			<Alias id="CFV-50c/Pinhole">CFV-50c/Pinhole</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -292,7 +292,7 @@
   </xs:simpleType>
   <xs:simpleType name="AliasTypeIdType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[a-zA-Z0-9 \-]{7,21}"/>
+      <xs:pattern value="[a-zA-Z0-9 \-/]{7,21}"/>
       <xs:minLength value="7"/>
       <xs:maxLength value="21"/>
     </xs:restriction>
@@ -306,7 +306,7 @@
   </xs:complexType>
   <xs:complexType name="AliasesType">
     <xs:sequence>
-      <xs:element type="AliasType" name="Alias" minOccurs="1" maxOccurs="9"/>
+      <xs:element type="AliasType" name="Alias" minOccurs="1" maxOccurs="11"/>
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="HintTypeNameType">

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.cpp
@@ -104,6 +104,8 @@ void AbstractLJpegDecoder::decodeSOI() {
         ThrowRDE("Did not find SOF marker before SOS.");
       parseSOS(data);
       FoundMarkers.SOS = true;
+      if (erratumImplicitEOIMarkerAfterScan())
+        return;
       break;
     case JpegMarker::DQT:
       ThrowRDE("Not a valid RAW file.");

--- a/src/librawspeed/decompressors/AbstractLJpegDecoder.h
+++ b/src/librawspeed/decompressors/AbstractLJpegDecoder.h
@@ -95,6 +95,13 @@ protected:
   bool fixDng16Bug = false; // DNG v1.0.x compatibility
   bool fullDecodeHT = true; // FullDecode Huffman
 
+  // Certain non-standard-complaint LJpeg's (old Hasselblad cameras) might not
+  // end with an EOI marker. This erratum considers an implicit EOI marker
+  // to be present after the (first) full Scan.
+  [[nodiscard]] virtual bool erratumImplicitEOIMarkerAfterScan() const {
+    return false;
+  }
+
   void decodeSOI();
   void parseSOF(ByteStream data, SOFInfo* i);
   void parseSOS(ByteStream data);

--- a/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
+++ b/src/librawspeed/decompressors/HasselbladLJpegDecoder.h
@@ -29,6 +29,12 @@ class ByteStream;
 class RawImage;
 
 class HasselbladLJpegDecoder final : public AbstractLJpegDecoder {
+  // Old Hasselblad cameras don't end their LJpeg stream with an EOI.
+  // After fully decoding (first) Scan, just stop.
+  [[nodiscard]] bool erratumImplicitEOIMarkerAfterScan() const final {
+    return true;
+  }
+
   [[nodiscard]] ByteStream::size_type decodeScan() override;
 
 public:


### PR DESCRIPTION
Those didn't produce valid/standard-compliant LJpeg stream,
there is no `EOI` marker at the end, so just stop after decoding the `Scan`.