### PR TITLE
Hasselblad CFV-50c alias cleanup

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17420,16 +17420,16 @@
 		<Sensor black="256" white="62914"/>
 		<Aliases>
 			<Alias id="CFV-50c">Hasselblad CFV-50c</Alias>
-			<Alias id="CFV-50c/Flash Sync">CFV-50c/Flash Sync</Alias>
-			<Alias id="CFV-50c/SWC">CFV-50c/SWC</Alias>
-			<Alias id="CFV-50c/200">CFV-50c/200</Alias>
-			<Alias id="CFV-50c/500">CFV-50c/500</Alias>
-			<Alias id="CFV-50c/Schneider">CFV-50c/Schneider</Alias>
-			<Alias id="CFV-50c/LensCtrl S">CFV-50c/LensCtrl S</Alias>
-			<Alias id="CFV-50c/Winder CW">CFV-50c/Winder CW</Alias>
-			<Alias id="CFV-50c/ELD">CFV-50c/ELD</Alias>
-			<Alias id="CFV-50c/ELX">CFV-50c/ELX</Alias>
-			<Alias id="CFV-50c/Pinhole">CFV-50c/Pinhole</Alias>
+			<Alias id="CFV-50c">CFV-50c/Flash Sync</Alias>
+			<Alias id="CFV-50c">CFV-50c/SWC</Alias>
+			<Alias id="CFV-50c">CFV-50c/200</Alias>
+			<Alias id="CFV-50c">CFV-50c/500</Alias>
+			<Alias id="CFV-50c">CFV-50c/Schneider</Alias>
+			<Alias id="CFV-50c">CFV-50c/LensCtrl S</Alias>
+			<Alias id="CFV-50c">CFV-50c/Winder CW</Alias>
+			<Alias id="CFV-50c">CFV-50c/ELD</Alias>
+			<Alias id="CFV-50c">CFV-50c/ELX</Alias>
+			<Alias id="CFV-50c">CFV-50c/Pinhole</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -292,7 +292,7 @@
   </xs:simpleType>
   <xs:simpleType name="AliasTypeIdType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[a-zA-Z0-9 \-/]{7,21}"/>
+      <xs:pattern value="[a-zA-Z0-9 \-]{7,21}"/>
       <xs:minLength value="7"/>
       <xs:maxLength value="21"/>
     </xs:restriction>


### PR DESCRIPTION
The `id` attribute is what gets shown in dt UI (if present and different from the actual value), we only want one model for all body combos.

Hasselblad Phocus software also normalizes to just "Hasselblad CFV-50c" when converting any of these from 3FR to FFF.