### PR TITLE
Pentax Q-S1 normalization

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17589,8 +17589,11 @@
 	<Camera make="PENTAX" model="PENTAX Q7" mode="dng">
 		<ID make="Pentax" model="Q7">PENTAX Q7</ID>
 	</Camera>
-	<Camera make="PENTAX" model="PENTAX Q10" mode="dng" supported="no-samples">
+	<Camera make="PENTAX" model="PENTAX Q10" mode="dng">
 		<ID make="Pentax" model="Q10">PENTAX Q10</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX Q-S1" mode="dng">
+		<ID make="Pentax" model="Q-S1">PENTAX Q-S1</ID>
 	</Camera>
 	<Camera make="PENTAX RICOH IMAGING" model="PENTAX MX-1" mode="dng">
 		<ID make="Pentax" model="MX-1">PENTAX MX-1</ID>


### PR DESCRIPTION
We could drop "no-samples" on both this one and the Q10, as this is only about naming scheme for regular DNGs...

Alternatively, if we really want to solicit even more OOC DNG samples, we might want to add "no-samples" to the Leicas added recently?