### PR TITLE
CMake: `RelWithDebInfo` is pointless, replace it with `ReleaseWithAsserts`

### DIFF
--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# it is supposed to be run by travis-ci
+# it is supposed to be run by ci
 # expects a few env variables to be set:
 #   BUILD_DIR - the working directory, where to build
 #   INSTALL_DIR - the installation prefix.
@@ -11,16 +11,23 @@
 
 set -ex
 
-CMAKE_BUILD_TYPE="RelWithDebInfo"
+CMAKE_BUILD_TYPE="ReleaseWithAsserts"
 GENERATOR="Ninja"
 VERBOSE="-v"
 KEEPGOING="-k0"
 
 case "$FLAVOR" in
+  "Release")
+    CMAKE_BUILD_TYPE="Release"
+    ;;
+  "ReleaseWithAsserts" | "ClangTidy" | "ClangStaticAnalysis" | "CodeQLAnalysis" | "SonarCloudStaticAnalysis")
+    CMAKE_BUILD_TYPE="ReleaseWithAsserts"
+    ;;
   "Coverage")
     CMAKE_BUILD_TYPE="Coverage"
     ;;
   *)
+    exit 1
     ;;
 esac
 

--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -278,7 +278,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
           RPUU_DST: ${{ env.RPUU_DST }}
-          ECO: ${{ inputs.ECO }} -DALLOW_DOWNLOADING_GOOGLETEST=ON -DALLOW_DOWNLOADING_GOOGLEBENCHMARK=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=${{ inputs.flavor == 'ClangStaticAnalysis' || inputs.flavor == 'SonarCloudStaticAnalysis' }} -DUSE_CLANG_TIDY=${{ inputs.flavor == 'ClangTidy' }} -DRAWSPEED_ENABLE_SAMPLE_BASED_TESTING=${{ inputs.flavor == 'Coverage' }}
+          ECO: ${{ inputs.ECO }} -DALLOW_DOWNLOADING_GOOGLETEST=ON -DALLOW_DOWNLOADING_GOOGLEBENCHMARK=ON -DUSE_CLANG_TIDY=${{ inputs.flavor == 'ClangTidy' }} -DRAWSPEED_ENABLE_SAMPLE_BASED_TESTING=${{ inputs.flavor == 'Coverage' }}
           FLAVOR: ${{ inputs.flavor }}
           TARGET: configure
         run: |
@@ -286,9 +286,6 @@ jobs:
           cmake -E make_directory "${BUILD_DIR}"
           cmake -E make_directory "${INSTALL_PREFIX}"
           export ECO="${ECO} -DRAWSPEED_REFERENCE_SAMPLE_ARCHIVE=${RPUU_DST}"
-          if [ "$FLAVOR" = "ClangTidy" -o "$FLAVOR" = "ClangStaticAnalysis" -o "$FLAVOR" = "CodeQLAnalysis" -o "$FLAVOR" = "SonarCloudStaticAnalysis" ]; then
-            export ECO="${ECO} -DCMAKE_C_FLAGS_RELWITHDEBINFO=-UNDEBUG -DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-UNDEBUG"
-          fi
           "${SRC_DIR}/.ci/ci-script.sh"
       - name: Build
         timeout-minutes: ${{ inputs.flavor != 'ClangTidy' && (inputs.flavor != 'CodeQLAnalysis' && 7 || 12) || 25 }}
@@ -296,6 +293,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: build
         run: |
           set -xe
@@ -306,6 +304,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test
         run: |
           set -xe
@@ -318,6 +317,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/linux
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage
         run: |
           set -xe
@@ -330,6 +330,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test_benchmarks
         run: |
           set -xe
@@ -342,6 +343,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/linux
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage_benchmarks
         run: |
           set -xe
@@ -355,6 +357,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test_integration
           OMP_NUM_THREADS: 1
         run: |
@@ -368,6 +371,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/linux
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage_integration
         run: |
           set -xe
@@ -388,6 +392,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: install
         run: |
           set -xe

--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -85,6 +85,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: build
         run: |
           set -xe
@@ -95,6 +96,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test
         run: |
           set -xe
@@ -107,6 +109,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/macOS
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage
         run: |
           set -xe
@@ -119,6 +122,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test_benchmarks
         run: |
           set -xe
@@ -131,6 +135,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/macOS
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage_benchmarks
         run: |
           set -xe
@@ -151,6 +156,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: install
         run: |
           set -xe

--- a/.github/workflows/CI-windows-msys2.yml
+++ b/.github/workflows/CI-windows-msys2.yml
@@ -95,6 +95,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: build
         run: |
           set -xe
@@ -105,6 +106,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test
         run: |
           set -xe
@@ -117,6 +119,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/windows
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage
         run: |
           set -xe
@@ -129,6 +132,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: test_benchmarks
         run: |
           set -xe
@@ -141,6 +145,7 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           COVERAGE_REPORT_PREFIX: ${{ github.workspace }}/${{ env.COVERAGE_REPORT_PREFIX }}/windows
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: coverage_benchmarks
         run: |
           set -xe
@@ -161,6 +166,7 @@ jobs:
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
+          FLAVOR: ${{ inputs.flavor }}
           TARGET: install
         run: |
           set -xe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
         compiler:
           - { distro: "debian:trixie-slim", family: GNU,  version: 13, CC: gcc-13,   CXX: g++-13 }
           - { distro: "debian:trixie-slim", family: LLVM, version: 17, CC: clang-17, CXX: clang++-17 }
-        flavor: [ RelWithDebInfo, Release ]
+        flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-linux.yml
     with:
       os: ${{ matrix.os }}
@@ -44,7 +44,7 @@ jobs:
           - { distro: "debian:trixie-slim",   family: LLVM, version: 16, CC: clang-16, CXX: clang++-16 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 15, CC: clang-15, CXX: clang++-15 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 14, CC: clang-14, CXX: clang++-14 }
-        flavor: [ RelWithDebInfo, Release ]
+        flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-linux.yml
     with:
       os: ${{ matrix.os }}
@@ -144,7 +144,7 @@ jobs:
           - { msystem: CLANG64,    arch: x86_64,  family: LLVM, CC: clang, CXX: clang++ }
           - { msystem: CLANG32,    arch: i686,    family: LLVM, CC: clang, CXX: clang++ }
           - { msystem: UCRT64,     arch: x86_64,  family: GNU,  CC: gcc,   CXX: g++ }
-        flavor: [ RelWithDebInfo, Release ]
+        flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-windows-msys2.yml
     with:
       os: ${{ matrix.os }}
@@ -178,7 +178,7 @@ jobs:
         compiler:
           - { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # LLVM16, native
           - { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
-        flavor: [ RelWithDebInfo, Release ]
+        flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
       os: ${{ matrix.compiler.os }}
@@ -196,7 +196,7 @@ jobs:
           - { os: macos-14, family: XCode, version: 15.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM16, "backdeploy"
           - { os: macos-14, family: XCode, version: 14.3, deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15, native
           # - { os: macos-14, family: XCode, version: 14.3, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM15, "backdeploy"
-        flavor: [ RelWithDebInfo, Release ]
+        flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
       os: ${{ matrix.compiler.os }}

--- a/cmake/build-type.cmake
+++ b/cmake/build-type.cmake
@@ -2,22 +2,14 @@
 if(NOT CMAKE_BUILD_TYPE)
   message(WARNING "CMAKE_BUILD_TYPE is not defined!")
 
-  set(default_build_type "RelWithDebInfo")
-
-  if(BUILD_TESTING)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(default_build_type "Coverage")
-    else()
-      set(default_build_type "Sanitize")
-    endif()
-  endif()
+  set(default_build_type "ReleaseWithAsserts")
 
   message("WARNING: Defaulting to CMAKE_BUILD_TYPE=${default_build_type}. Use ccmake to set a proper value.")
 
   SET(CMAKE_BUILD_TYPE ${default_build_type} CACHE STRING "" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(RAWSPEED_STANDARD_BUILD_TYPES Debug RelWithDebInfo Release)
+set(RAWSPEED_STANDARD_BUILD_TYPES Debug ReleaseWithAsserts Release)
 set(RAWSPEED_SPECIAL_BUILD_TYPES Coverage Sanitize TSan Fuzz)
 set(CMAKE_CONFIGURATION_TYPES ${RAWSPEED_STANDARD_BUILD_TYPES} ${RAWSPEED_SPECIAL_BUILD_TYPES} CACHE STRING "All the available build types" FORCE)
 

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -12,10 +12,14 @@ set(CMAKE_CXX_MODULE_MAP_FORMAT "")
 include(debug-info)
 
 if(RAWSPEED_RELEASE_BUILD)
-  # want assertions in all but Release build type.
+  # No assertions in Release build type.
   add_definitions(-DNDEBUG)
-elseif(NOT (RAWSPEED_RELWITHDEBINFO_BUILD OR RAWSPEED_FUZZ_BUILD))
-  # if not Release/RelWithDebInfo/Fuzz build, enable extra debug mode
+elseif(RAWSPEED_RELEASEWITHASSERTS_BUILD)
+  # Assertions in ReleaseWithAsserts build type.
+  add_definitions(-UNDEBUG)
+elseif(NOT (RAWSPEED_FUZZ_BUILD))
+  # if not Release/ReleaseWithAsserts/Fuzz build, enable extra debug mode
+  add_definitions(-UNDEBUG)
   add_definitions(-DDEBUG)
 
   # all this does not work with integer sanitizer
@@ -210,8 +214,8 @@ MARK_AS_ADVANCED(
     CMAKE_SHARED_LINKER_FLAGS_TSAN
     CMAKE_SHARED_MODULE_FLAGS_TSAN )
 
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O2")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2")
+set(CMAKE_C_FLAGS_RELEASEWITHASSERTS "${CMAKE_C_FLAGS_RELEASEWITHASSERTS} -O3")
+set(CMAKE_CXX_FLAGS_RELEASEWITHASSERTS "${CMAKE_CXX_FLAGS_RELEASEWITHASSERTS} -O3")
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")


### PR DESCRIPTION
We always enable debug info.

And actually i though assertions were enabled
in `RelWithDebInfo` but they are not.

So `ReleaseWithAsserts` is more interesting.