### PR TITLE
`compiler-versions.cmake`: 2024 edition

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
         os: [ linux ]
         compiler:
           - { distro: "debian:bookworm-slim", family: GNU,  version: 12, CC: gcc-12,   CXX: g++-12 }
-          - { distro: "debian:trixie-slim",   family: LLVM, version: 16, CC: clang-16, CXX: clang++-16 }
+          - { distro: "debian:bookworm-slim", family: LLVM, version: 16, CC: clang-16, CXX: clang++-16 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 15, CC: clang-15, CXX: clang++-15 }
           - { distro: "debian:bookworm-slim", family: LLVM, version: 14, CC: clang-14, CXX: clang++-14 }
         flavor: [ ReleaseWithAsserts, Release ]

--- a/cmake/compiler-versions.cmake
+++ b/cmake/compiler-versions.cmake
@@ -6,6 +6,7 @@
 # * oldest(*) maintained macOS release (assuming current cadence of
 #   one major macOS release per year, and 3 (three) year shelf-life,
 #   so last three releases are to be supported)
+# * oss-fuzz -provided compiler (LLVM) version
 #
 # Compiler-wise, that means that we support three compiler families:
 # * GCC, with the required version being the newest one that is available
@@ -15,24 +16,21 @@
 # * LLVM, with the required version being the oldest one between
 #    * the Xcode's underlying LLVM version
 #    * and the newest one that is available in *both* the
-#      debian stable *and* the latest ubuntu LTS
+#      debian stable *and* the latest ubuntu LTS (and on oss-fuzz)
 #
-# As of the time of writing (2023-10-22), the next (winter) darktable release
-# will happen in 2023-12 ish. By that time:
-# * debian 12 (Bookworm) will have been released,
-#   coming with gcc-12 and LLVM15
-# * Ubuntu 22.04.1 LTS (Jammy Jellyfish) will be the newest LTS,
-#   coming with gcc-12 and LLVM15
-# * macOS 12 (Big Sur) be the oldest supported macOS version,
-#   with the newest supported Xcode version being 14.2 (LLVM14-based !)
+# As of the time of writing (2024-02-14), the next (summer) darktable release
+# will happen in 2024-06 ish. By that time:
+# * debian 12 (Bookworm) is the newest debian stable,
+#   coming with gcc-12 and LLVM16
+# * Ubuntu 24.04 LTS (Noble Numbat) will have been released,
+#   coming with gcc-14 and LLVM18
+# * macOS 13 (Ventura) be the oldest supported macOS version,
+#   with the newest supported Xcode version being 15.2 (LLVM16-based !)
+# * (as of 2024-02-14) oss-fuzz provides LLVM15.
 #
-# Therefore, we require GCC12, macOS 12 + Xcode 14.2, and LLVM14.
-#
-# The next+1 (fall) darktable release will happen 2023-12 ish,
-# and by that time, macOS 11 will have EOL'd on 2023-10 ish,
-# so after the spring release, macOS 12 will become required,
-# and that will allow us to require Xcode 14.2 (LLVM14-based),
-# and that will allow us to require LLVM14,
+# Therefore, we currently require GCC12, macOS 12 + Xcode 14.2, and LLVM14.
+# but should be able to require GCC12, macOS 13 + Xcode 15.2, and LLVM15,
+# and, pending oss-fuzz roll-forward, LLVM16.
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
   message(SEND_ERROR "GNU C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")


### PR DESCRIPTION
LLVM16 migrated into debian stable.
macOS 12 will become EOL in summer.

Therefore, for the summer dt release,
we can require macOS 13 + XCode 15.2,
which means we'll be able to bump required LLVM version up to 15 or even 16.

@TurboGit @zisoft FYI ^
I'm really looking forward dropping at least the LLVM14 support.