### PR TITLE
Split prep changes from PR666

### DIFF
--- a/.ci/oss-fuzz.sh
+++ b/.ci/oss-fuzz.sh
@@ -17,6 +17,9 @@
 
 set -ex
 
+apt-get install -y ninja-build
+export CMAKE_GENERATOR=Ninja
+
 ln -f -s /usr/local/bin/lld /usr/bin/ld
 
 if [[ $SANITIZER = *undefined* ]]; then
@@ -34,7 +37,7 @@ mkdir build
 cd build
 
 cmake \
-  -G"Unix Makefiles" -DBINARY_PACKAGE_BUILD=ON -DWITH_OPENMP=$WITH_OPENMP \
+  -DBINARY_PACKAGE_BUILD=ON -DWITH_OPENMP=$WITH_OPENMP \
   -DUSE_BUNDLED_LLVMOPENMP=ON -DALLOW_DOWNLOADING_LLVMOPENMP=ON \
   -DWITH_PUGIXML=OFF -DUSE_XMLLINT=OFF -DWITH_JPEG=OFF -DWITH_ZLIB=OFF \
   -DBUILD_TESTING=OFF -DBUILD_TOOLS=OFF -DBUILD_BENCHMARKING=OFF \

--- a/.ci/oss-fuzz.sh
+++ b/.ci/oss-fuzz.sh
@@ -43,4 +43,4 @@ cmake \
   -DCMAKE_INSTALL_PREFIX:PATH="$OUT" -DCMAKE_INSTALL_BINDIR:PATH="$OUT" \
   "$SRC/librawspeed/"
 
-make -j$(nproc) all && make -j$(nproc) install
+cmake --build . -- -j$(nproc) all && cmake --build . -- -j$(nproc) install

--- a/.ci/oss-fuzz.sh
+++ b/.ci/oss-fuzz.sh
@@ -67,3 +67,6 @@ cmake \
   "$SRC/librawspeed/"
 
 cmake --build . -- -j$(nproc) all && cmake --build . -- -j$(nproc) install
+
+du -hcs .
+du -hcs "$OUT"

--- a/.ci/oss-fuzz.sh
+++ b/.ci/oss-fuzz.sh
@@ -15,7 +15,9 @@
 #
 ################################################################################
 
-set -e
+set -ex
+
+ln -f -s /usr/local/bin/lld /usr/bin/ld
 
 if [[ $SANITIZER = *undefined* ]]; then
   CFLAGS="$CFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"
@@ -31,9 +33,6 @@ cd "$WORK"
 mkdir build
 cd build
 
-# Temporarily use gold for linking because of BFD breakage (see
-# https://github.com/google/oss-fuzz/pull/2781).
-ln -f -s /usr/bin/gold /usr/bin/ld
 cmake \
   -G"Unix Makefiles" -DBINARY_PACKAGE_BUILD=ON -DWITH_OPENMP=$WITH_OPENMP \
   -DUSE_BUNDLED_LLVMOPENMP=ON -DALLOW_DOWNLOADING_LLVMOPENMP=ON \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,8 +195,9 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # LLVM16, native
-          - { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM14, native
+          - { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # AArch64, LLVM16, native
+          - { os: macos-13, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # x86_64,  LLVM16, native
+          - { os: macos-12, family: XCode, version: 14.2, deployment_target: 12.5, CC: cc, CXX: c++ } # x86_64,  LLVM14, native
         flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -212,9 +213,9 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-14, family: XCode, version: 15.2, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM16, "backdeploy"
-          - { os: macos-14, family: XCode, version: 14.3, deployment_target: 13.0, CC: cc, CXX: c++ } # LLVM15, native
-          # - { os: macos-14, family: XCode, version: 14.3, deployment_target: 12.5, CC: cc, CXX: c++ } # LLVM15, "backdeploy"
+          - { os: macos-14, family: XCode, version: 15.2, deployment_target: 12.5, CC: cc, CXX: c++ } # x86_64, LLVM16, "backdeploy"
+          - { os: macos-14, family: XCode, version: 14.3, deployment_target: 13.0, CC: cc, CXX: c++ } # x86_64, LLVM15, native
+          # - { os: macos-14, family: XCode, version: 14.3, deployment_target: 12.5, CC: cc, CXX: c++ } # x86_64, LLVM15, "backdeploy"
         flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0025 NEW)

--- a/cmake/Modules/GoogleBenchmark.cmake.in
+++ b/cmake/Modules/GoogleBenchmark.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 project(googlebenchmark-download NONE)
 

--- a/cmake/Modules/GoogleTest.cmake.in
+++ b/cmake/Modules/GoogleTest.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 project(googletest-download NONE)
 

--- a/cmake/Modules/LLVMOpenMP.cmake.in
+++ b/cmake/Modules/LLVMOpenMP.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 project(llvm-openmp-download NONE)
 

--- a/cmake/Modules/Pugixml.cmake.in
+++ b/cmake/Modules/Pugixml.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 project(pugixml-download NONE)
 

--- a/cmake/Modules/Zlib.cmake.in
+++ b/cmake/Modules/Zlib.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22) # FIXME: 3.24.2 / 3.25
 
 project(zlib-download NONE)
 

--- a/cmake/compiler-versions.cmake
+++ b/cmake/compiler-versions.cmake
@@ -57,3 +57,60 @@ endif()
 if(CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 12.5)
   message(SEND_ERROR "Targeting OSX version ${CMAKE_OSX_DEPLOYMENT_TARGET} older than 12.5 is unsupported.")
 endif()
+
+include(CheckCXXSourceCompiles)
+
+if(NOT DEFINED RAWSPEED_LIBSTDCXX_MIN)
+  set(LIBSTDCXX_MIN 12)
+  message(STATUS "Performing libstdc++ version check")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libstdcxx_version_check.cpp"
+  "#include <version>
+  #define STR_HELPER(x) #x
+  #define STR(x) STR_HELPER(x)
+  #if defined(__GLIBCXX__)
+  #if !defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE < ${LIBSTDCXX_MIN}
+  #pragma message(\"Unsupported libstdc++ version: \" STR(_GLIBCXX_RELEASE))
+  #error
+  #endif
+  #endif
+  int main() { return 0; }
+  ")
+  try_compile(RAWSPEED_LIBSTDCXX_MIN
+  "${CMAKE_CURRENT_BINARY_DIR}/libstdcxx_version_check"
+  "${CMAKE_CURRENT_BINARY_DIR}/libstdcxx_version_check.cpp"
+  OUTPUT_VARIABLE MSG)
+  if(NOT RAWSPEED_LIBSTDCXX_MIN)
+    message(SEND_ERROR ${MSG})
+  else()
+    message(STATUS "Performing libstdc++ version check - Success")
+  endif()
+endif()
+
+if(NOT DEFINED RAWSPEED_LIBCXX_MIN)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(LIBCXX_MIN 13000)
+    # NOTE: with libc++-16, version gains extra tailing zero
+  else()
+    set(LIBCXX_MIN 14000)
+  endif()
+  message(STATUS "Performing libc++ version check")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libcpp_version_check.cpp"
+  "#include <version>
+  #define STR_HELPER(x) #x
+  #define STR(x) STR_HELPER(x)
+  #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < ${LIBCXX_MIN}
+  #pragma message(\"Unsupported libc++ version: \" STR(_LIBCPP_VERSION))
+  #error
+  #endif
+  int main() { return 0; }
+  ")
+  try_compile(RAWSPEED_LIBCXX_MIN
+  "${CMAKE_CURRENT_BINARY_DIR}/libcpp_version_check"
+  "${CMAKE_CURRENT_BINARY_DIR}/libcpp_version_check.cpp"
+  OUTPUT_VARIABLE MSG)
+  if(NOT RAWSPEED_LIBCXX_MIN)
+    message(SEND_ERROR ${MSG})
+  else()
+    message(STATUS "Performing libc++ version check - Success")
+  endif()
+endif()

--- a/fuzz/librawspeed/decompressors/CMakeLists.txt
+++ b/fuzz/librawspeed/decompressors/CMakeLists.txt
@@ -39,7 +39,7 @@ foreach(decompressor ${DECOMPRESSORS})
 endforeach()
 
 
-function(add_specialized_fuzzer Name PrefixCodeDecoderImpl)
+macro(add_specialized_fuzzer Name PrefixCodeDecoderImpl)
   set(fuzzer "${Name}Fuzzer-${PrefixCodeDecoderImpl}")
 
   rawspeed_add_executable(${fuzzer} ${Name}.cpp)
@@ -52,7 +52,7 @@ function(add_specialized_fuzzer Name PrefixCodeDecoderImpl)
   add_fuzz_target(${fuzzer})
 
   add_dependencies(PrefixCodeDecoderFuzzers ${fuzzer})
-endfunction()
+endmacro()
 
 add_specialized_fuzzer("Cr2Decompressor" PrefixCodeDecoder)
 add_specialized_fuzzer("Cr2Decompressor" DummyPrefixCodeDecoder)


### PR DESCRIPTION
See https://github.com/darktable-org/rawspeed/pull/663

> LLVM16 migrated into debian stable. macOS 12 will become EOL in summer.
> 
> Therefore, for the summer dt release, we can require macOS 13 + XCode 15.2, which means we'll be able to bump required LLVM version up to 15 or even 16.

... but here let's just prepare for the bump. It's best to discover issues before that.