### PR TITLE
Add Panasonic DC-TZ95D alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11520,6 +11520,7 @@
 		<Sensor black="142" white="4095"/>
 		<Aliases>
 			<Alias>DC-TZ95</Alias>
+			<Alias>DC-TZ95D</Alias>
 			<Alias>DC-ZS80</Alias>
 		</Aliases>
 		<ColorMatrices>
@@ -11536,6 +11537,7 @@
 		<Sensor black="142" white="4095"/>
 		<Aliases>
 			<Alias>DC-TZ95</Alias>
+			<Alias>DC-TZ95D</Alias>
 			<Alias>DC-ZS80</Alias>
 		</Aliases>
 		<ColorMatrices>


### PR DESCRIPTION
In keeping w/ the tradition, the "D" seems to denote just the [back LCD panel refresh](https://www.photospecialist.fr/panasonic-dc-tz95d-argent).

Resolves https://github.com/darktable-org/darktable/issues/16353