### PR TITLE
Implement `CoalescingOutputIterator`

### DIFF
--- a/bench/librawspeed/adt/CMakeLists.txt
+++ b/bench/librawspeed/adt/CMakeLists.txt
@@ -1,4 +1,5 @@
 FILE(GLOB RAWSPEED_BENCHS_SOURCES
+  "CoalescingOutputIteratorBenchmark.cpp"
   "DefaultInitAllocatorAdaptorBenchmark.cpp"
   "VariableLengthLoadBenchmark.cpp"
 )

--- a/bench/librawspeed/adt/CoalescingOutputIteratorBenchmark.cpp
+++ b/bench/librawspeed/adt/CoalescingOutputIteratorBenchmark.cpp
@@ -1,0 +1,177 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "adt/CoalescingOutputIterator.h"
+#include "adt/Array1DRef.h"
+#include "adt/Casts.h"
+#include "adt/DefaultInitAllocatorAdaptor.h"
+#include "bench/Common.h"
+#include "common/Common.h"
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <benchmark/benchmark.h>
+
+namespace rawspeed {
+
+namespace {
+
+template <typename T, typename UnderlyingOutputIterator>
+auto getMaybeCoalescingOutputIterator(UnderlyingOutputIterator e) {
+  return CoalescingOutputIterator(e);
+}
+
+template <typename T, typename UnderlyingOutputIterator>
+  requires std::same_as<T, uint8_t>
+auto getMaybeCoalescingOutputIterator(UnderlyingOutputIterator e) {
+  return e;
+}
+
+template <typename T> void BM_Broadcast(benchmark::State& state) {
+  int64_t numBytes = state.range(0);
+  const int bytesPerChunk = sizeof(T);
+  const auto numChunks =
+      implicit_cast<int>(roundUpDivision(numBytes, bytesPerChunk));
+  numBytes = bytesPerChunk * numChunks;
+
+  std::vector<T, DefaultInitAllocatorAdaptor<T, std::allocator<T>>> output;
+  output.reserve(implicit_cast<size_t>(numChunks));
+
+  for (auto _ : state) {
+    output.clear();
+
+    auto iter = getMaybeCoalescingOutputIterator<T>(std::back_inserter(output));
+    uint8_t value = 0;
+    for (int chunkIndex = 0; chunkIndex != numChunks; ++chunkIndex) {
+#if defined(__clang__)
+#pragma clang loop unroll(full)
+#endif
+      for (int byteOfChunk = 0; byteOfChunk != bytesPerChunk; ++byteOfChunk) {
+        benchmark::DoNotOptimize(value);
+        *iter = value;
+      }
+    }
+  }
+  assert(implicit_cast<int64_t>(output.size()) == numChunks);
+
+  state.SetComplexityN(numBytes);
+  state.counters.insert({
+      {"Throughput",
+       benchmark::Counter(sizeof(std::byte) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate,
+                          benchmark::Counter::kIs1024)},
+      {"Latency",
+       benchmark::Counter(sizeof(std::byte) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate |
+                              benchmark::Counter::Flags::kInvert,
+                          benchmark::Counter::kIs1000)},
+  });
+}
+
+template <typename T> void BM_Copy(benchmark::State& state) {
+  int64_t numBytes = state.range(0);
+  const int bytesPerChunk = sizeof(T);
+  const auto numChunks =
+      implicit_cast<int>(roundUpDivision(numBytes, bytesPerChunk));
+  numBytes = bytesPerChunk * numChunks;
+
+  std::vector<uint8_t,
+              DefaultInitAllocatorAdaptor<uint8_t, std::allocator<uint8_t>>>
+      inputStorage(implicit_cast<size_t>(numBytes), uint8_t{0});
+  const auto input = Array1DRef(
+      inputStorage.data(), rawspeed::implicit_cast<int>(inputStorage.size()));
+  benchmark::DoNotOptimize(input.begin());
+
+  std::vector<T, DefaultInitAllocatorAdaptor<T, std::allocator<T>>> output;
+  output.reserve(implicit_cast<size_t>(numChunks));
+
+  for (auto _ : state) {
+    output.clear();
+
+    auto iter = getMaybeCoalescingOutputIterator<T>(std::back_inserter(output));
+    for (int chunkIndex = 0; chunkIndex != numChunks; ++chunkIndex) {
+      const auto chunk =
+          input.getBlock(bytesPerChunk, chunkIndex).getAsArray1DRef();
+#if defined(__clang__)
+#pragma clang loop unroll(full)
+#endif
+      for (int byteOfChunk = 0; byteOfChunk != bytesPerChunk; ++byteOfChunk) {
+        *iter = chunk(byteOfChunk);
+      }
+    }
+  }
+  assert(implicit_cast<int64_t>(output.size()) == numChunks);
+
+  state.SetComplexityN(numBytes);
+  state.counters.insert({
+      {"Throughput",
+       benchmark::Counter(sizeof(std::byte) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate,
+                          benchmark::Counter::kIs1024)},
+      {"Latency",
+       benchmark::Counter(sizeof(std::byte) * state.complexity_length_n(),
+                          benchmark::Counter::Flags::kIsIterationInvariantRate |
+                              benchmark::Counter::Flags::kInvert,
+                          benchmark::Counter::kIs1000)},
+  });
+}
+
+void CustomArguments(benchmark::internal::Benchmark* b) {
+  b->Unit(benchmark::kMicrosecond);
+
+  static constexpr int L1dByteSize = 32U * (1U << 10U);
+  static constexpr int L2dByteSize = 512U * (1U << 10U);
+  static constexpr int MaxBytesOptimal = L2dByteSize * (1U << 5);
+
+  if (benchmarkDryRun()) {
+    b->Arg(L1dByteSize);
+    return;
+  }
+
+  b->RangeMultiplier(2);
+  if constexpr ((true))
+    b->Arg(MaxBytesOptimal);
+  else
+    b->Range(1, 2048UL << 20)->Complexity(benchmark::oN);
+}
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
+#define GEN(I, T) BENCHMARK(I<T>)->Apply(CustomArguments)
+
+#define GEN_T(I)                                                               \
+  GEN(I, uint8_t);                                                             \
+  GEN(I, uint16_t);                                                            \
+  GEN(I, uint32_t);                                                            \
+  GEN(I, uint64_t)
+
+GEN_T(BM_Broadcast);
+GEN_T(BM_Copy);
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+} // namespace
+
+} // namespace rawspeed
+
+BENCHMARK_MAIN();

--- a/src/librawspeed/adt/CMakeLists.txt
+++ b/src/librawspeed/adt/CMakeLists.txt
@@ -8,6 +8,7 @@ FILE(GLOB SOURCES
   "Bit.h"
   "BitIterator.h"
   "Casts.h"
+  "CoalescingOutputIterator.h"
   "CroppedArray1DRef.h"
   "CroppedArray2DRef.h"
   "DefaultInitAllocatorAdaptor.h"

--- a/src/librawspeed/adt/CoalescingOutputIterator.h
+++ b/src/librawspeed/adt/CoalescingOutputIterator.h
@@ -1,0 +1,125 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "adt/Bit.h"
+#include "adt/Invariant.h"
+#include "io/Endianness.h"
+#include <concepts>
+#include <cstdint>
+#include <iterator>
+
+namespace rawspeed {
+
+template <typename UnderlyingOutputIterator,
+          typename CoalescedType =
+              typename UnderlyingOutputIterator::container_type::value_type,
+          typename PartType = uint8_t>
+  requires(std::output_iterator<UnderlyingOutputIterator, CoalescedType> &&
+           std::unsigned_integral<CoalescedType> &&
+           std::unsigned_integral<PartType> &&
+           std::same_as<PartType, uint8_t> &&
+           sizeof(PartType) < sizeof(CoalescedType) &&
+           sizeof(CoalescedType) % sizeof(PartType) == 0)
+class CoalescingOutputIterator {
+  UnderlyingOutputIterator it;
+
+  CoalescedType cache = 0;
+  int occupancy = 0;
+
+  static constexpr int MaxOccupancy = bitwidth<CoalescedType>();
+
+  inline void establishClassInvariants() const {
+    invariant(occupancy >= 0);
+    invariant(occupancy <= MaxOccupancy);
+  }
+
+  inline void maybeOutputCoalescedParts() {
+    establishClassInvariants();
+    if (occupancy != MaxOccupancy)
+      return;
+    *it = getLE<CoalescedType>(&cache);
+    cache = 0;
+    occupancy = 0;
+  }
+
+public:
+  using iterator_concept = std::output_iterator_tag;
+  using value_type = void;
+  using difference_type = void;
+  using pointer = void;
+  using reference = void;
+
+  CoalescingOutputIterator() = delete;
+
+  template <typename U>
+    requires std::same_as<U, UnderlyingOutputIterator>
+  inline explicit CoalescingOutputIterator(U it_) : it(it_) {}
+
+  inline ~CoalescingOutputIterator() {
+    establishClassInvariants();
+    if (occupancy == 0)
+      return;
+    int numPaddingBits = MaxOccupancy - occupancy;
+    invariant(numPaddingBits > 0);
+    invariant(numPaddingBits < MaxOccupancy);
+    occupancy += numPaddingBits;
+    invariant(occupancy == MaxOccupancy);
+    maybeOutputCoalescedParts();
+    invariant(occupancy == 0);
+  }
+
+  [[nodiscard]] inline CoalescingOutputIterator& operator*() {
+    establishClassInvariants();
+    return *this;
+  }
+
+  inline const CoalescingOutputIterator& operator++() const {
+    establishClassInvariants();
+    return *this;
+  }
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp)
+  inline CoalescingOutputIterator operator++(int) const {
+    establishClassInvariants();
+    return *this;
+  }
+
+  template <typename U>
+    requires std::same_as<U, PartType>
+  inline CoalescingOutputIterator& operator=(U part) {
+    establishClassInvariants();
+    invariant(occupancy < MaxOccupancy);
+    invariant(occupancy + bitwidth<U>() <= MaxOccupancy);
+    static_assert(bitwidth<U>() < MaxOccupancy);
+    cache |= static_cast<CoalescedType>(part) << occupancy;
+    occupancy += bitwidth<U>();
+    invariant(occupancy <= MaxOccupancy);
+    maybeOutputCoalescedParts();
+    return *this;
+  }
+};
+
+// CTAD deduction guide
+template <typename T>
+CoalescingOutputIterator(T) -> CoalescingOutputIterator<T>;
+
+} // namespace rawspeed

--- a/test/librawspeed/adt/CMakeLists.txt
+++ b/test/librawspeed/adt/CMakeLists.txt
@@ -1,5 +1,6 @@
 FILE(GLOB RAWSPEED_TEST_SOURCES
   "BitTest.cpp"
+  "CoalescingOutputIteratorTest.cpp"
   "NORangesSetTest.cpp"
   "PointTest.cpp"
   "RangeTest.cpp"

--- a/test/librawspeed/adt/CoalescingOutputIteratorTest.cpp
+++ b/test/librawspeed/adt/CoalescingOutputIteratorTest.cpp
@@ -1,0 +1,104 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; withexpected even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "adt/CoalescingOutputIterator.h"
+#include "adt/Array1DRef.h"
+#include "common/Common.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <ostream>
+#include <vector>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace rawspeed {
+
+template <typename T>
+bool operator==(const Array1DRef<T> a, const Array1DRef<T> b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+
+template <typename T>
+  requires std::same_as<T, std::byte>
+inline ::std::ostream& operator<<(::std::ostream& os, const T& b) {
+  os << std::to_integer<uint8_t>(b);
+  return os;
+}
+
+template <typename T>
+::std::ostream& operator<<(::std::ostream& os, const Array1DRef<T>& r) {
+  os << "{";
+  for (int i = 0; i != r.size(); ++i) {
+    if (i != 0)
+      os << ", ";
+    os << r(i);
+  }
+  os << "}";
+  return os;
+}
+
+namespace rawpeed_test {
+
+namespace {
+
+template <typename T>
+class CoalescingOutputIteratorTest : public testing::Test {};
+
+TYPED_TEST_SUITE_P(CoalescingOutputIteratorTest);
+
+TYPED_TEST_P(CoalescingOutputIteratorTest, Exhaustive) {
+  static constexpr int MaxBytes = 256;
+
+  for (int numInputBytes = 1; numInputBytes <= MaxBytes; ++numInputBytes) {
+    std::vector<uint8_t> inputStorage(numInputBytes);
+    auto input = Array1DRef(inputStorage.data(), numInputBytes);
+    std::iota(input.begin(), input.end(), 0);
+
+    std::vector<TypeParam> outputStorage;
+    {
+      outputStorage.reserve(implicit_cast<size_t>(
+          roundUpDivision(numInputBytes, sizeof(TypeParam))));
+      auto iter = CoalescingOutputIterator(std::back_inserter(outputStorage));
+      for (const auto& e : input)
+        *iter = e;
+    }
+
+    auto output = Array1DRef<std::byte>(Array1DRef(
+        outputStorage.data(), implicit_cast<int>(outputStorage.size())));
+    ASSERT_THAT(output, testing::SizeIs(testing::Ge(input.size())));
+    output = output.getBlock(input.size(), /*index=*/0).getAsArray1DRef();
+    ASSERT_THAT(output, testing::ContainerEq(Array1DRef<std::byte>(input)));
+  }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(CoalescingOutputIteratorTest, Exhaustive);
+
+using CoalescedTypes = ::testing::Types<uint16_t, uint32_t, uint64_t>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(CoalescedTo, CoalescingOutputIteratorTest,
+                               CoalescedTypes);
+
+} // namespace
+
+} // namespace rawpeed_test
+
+} // namespace rawspeed


### PR DESCRIPTION
Will be rather useful for `BitVacuumer` perf work.

```
$ bench/librawspeed/adt/CoalescingOutputIteratorBenchmark
2024-02-20T02:27:50+03:00
Running bench/librawspeed/adt/CoalescingOutputIteratorBenchmark
Run on (32 X 3397.05 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 1.16, 1.08, 1.12
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
BM_Broadcast<uint8_t>/16777216        9893 us         9893 us           70 Latency=589.649ps Throughput=1.57945Gi/s
BM_Broadcast<uint16_t>/16777216       4948 us         4948 us          141 Latency=294.908ps Throughput=3.15801Gi/s
BM_Broadcast<uint32_t>/16777216       3711 us         3710 us          189 Latency=221.16ps Throughput=4.21109Gi/s
BM_Broadcast<uint64_t>/16777216       3708 us         3708 us          189 Latency=220.986ps Throughput=4.21439Gi/s
BM_Copy<uint8_t>/16777216             8115 us         8114 us           85 Latency=483.656ps Throughput=1.92559Gi/s
BM_Copy<uint16_t>/16777216            3533 us         3533 us          198 Latency=210.609ps Throughput=4.42204Gi/s
BM_Copy<uint32_t>/16777216            1730 us         1730 us          402 Latency=103.111ps Throughput=9.03223Gi/s
BM_Copy<uint64_t>/16777216            1301 us         1301 us          536 Latency=77.538ps Throughput=12.0112Gi/s
```