### PR TITLE
Make Olympus decompressor a bit faster (-12%)

### DIFF
--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -79,6 +79,8 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
   if (numHighBits == 12) {
     bits.skipBitsNoFill(15);
     numHighBits = 15 - nbits;
+    assert(numHighBits >= 1);
+    assert(numHighBits <= 13);
     highBits = bits.getBitsNoFill(numHighBits + 1) >> 1;
   } else {
     bits.skipBitsNoFill(numHighBits + 1 + 3);

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -105,7 +105,8 @@ class OlympusDecompressorImpl final : public AbstractDecompressor {
         return std::min(12, high);
       }};
 
-  static inline int getPred(Array2DRef<uint16_t> out, int row, int col);
+  static __attribute__((always_inline)) int getPred(Array2DRef<uint16_t> out,
+                                                    int row, int col);
 
   void decompressRow(BitStreamerMSB& bits, int row) const;
 
@@ -122,8 +123,9 @@ public:
  * is based on the output of all previous pixel (bar the first four)
  */
 
-inline int OlympusDecompressorImpl::getPred(const Array2DRef<uint16_t> out,
-                                            int row, int col) {
+inline __attribute__((always_inline)) int
+OlympusDecompressorImpl::getPred(const Array2DRef<uint16_t> out, int row,
+                                 int col) {
   auto getLeft = [&]() { return out(row, col - 2); };
   auto getUp = [&]() { return out(row - 2, col); };
   auto getLeftUp = [&]() { return out(row - 2, col - 2); };

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -22,32 +22,53 @@
 
 #include "decompressors/OlympusDecompressor.h"
 #include "adt/Array2DRef.h"
+#include "adt/Bit.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
 #include "adt/Point.h"
 #include "bitstreams/BitStreamerMSB.h"
 #include "common/RawImage.h"
+#include "common/SimpleLUT.h"
 #include "decoders/RawDecoderException.h"
+#include "decompressors/AbstractDecompressor.h"
 #include "io/ByteStream.h"
+#include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <utility>
 
 namespace rawspeed {
 
-OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
-  if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
-      mRaw->getBpp() != sizeof(uint16_t))
-    ThrowRDE("Unexpected component count / data type");
+namespace {
 
-  const uint32_t w = mRaw->dim.x;
-  const uint32_t h = mRaw->dim.y;
+class OlympusDecompressorImpl final : public AbstractDecompressor {
+  RawImage mRaw;
 
-  if (w == 0 || h == 0 || w % 2 != 0 || h % 2 != 0 || w > 10400 || h > 7792)
-    ThrowRDE("Unexpected image dimensions found: (%u; %u)", w, h);
-}
+  // A table to quickly look up "high" value
+  const SimpleLUT<int8_t, 12> bittable{
+      [](size_t i, [[maybe_unused]] unsigned tableSize) {
+        int high;
+        for (high = 0; high < 12; high++)
+          if (extractHighBits(i, high, /*effectiveBitwidth=*/11) & 1)
+            break;
+        return std::min(12, high);
+      }};
+
+  inline __attribute__((always_inline)) int
+  parseCarry(BitStreamerMSB& bits, std::array<int, 3>& carry) const;
+
+  static inline int getPred(Array2DRef<uint16_t> out, int row, int col);
+
+  void decompressRow(BitStreamerMSB& bits, int row) const;
+
+public:
+  explicit OlympusDecompressorImpl(RawImage img) : mRaw(std::move(img)) {}
+
+  void decompress(ByteStream input) const;
+};
 
 /* This is probably the slowest decoder of them all.
  * I cannot see any way to effectively speed up the prediction
@@ -57,8 +78,8 @@ OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
  */
 
 inline __attribute__((always_inline)) int
-OlympusDecompressor::parseCarry(BitStreamerMSB& bits,
-                                std::array<int, 3>& carry) const {
+OlympusDecompressorImpl::parseCarry(BitStreamerMSB& bits,
+                                    std::array<int, 3>& carry) const {
   bits.fill();
   int i = 2 * (carry[2] < 3);
   int nbits;
@@ -85,8 +106,8 @@ OlympusDecompressor::parseCarry(BitStreamerMSB& bits,
   return (diff * 4) | low;
 }
 
-inline int OlympusDecompressor::getPred(const Array2DRef<uint16_t> out, int row,
-                                        int col) {
+inline int OlympusDecompressorImpl::getPred(const Array2DRef<uint16_t> out,
+                                            int row, int col) {
   auto getLeft = [&]() { return out(row, col - 2); };
   auto getUp = [&]() { return out(row - 2, col); };
   auto getLeftUp = [&]() { return out(row - 2, col - 2); };
@@ -120,7 +141,8 @@ inline int OlympusDecompressor::getPred(const Array2DRef<uint16_t> out, int row,
   return pred;
 }
 
-void OlympusDecompressor::decompressRow(BitStreamerMSB& bits, int row) const {
+void OlympusDecompressorImpl::decompressRow(BitStreamerMSB& bits,
+                                            int row) const {
   invariant(mRaw->dim.y > 0);
   invariant(mRaw->dim.x > 0);
   invariant(mRaw->dim.x % 2 == 0);
@@ -141,7 +163,7 @@ void OlympusDecompressor::decompressRow(BitStreamerMSB& bits, int row) const {
   }
 }
 
-void OlympusDecompressor::decompress(ByteStream input) const {
+void OlympusDecompressorImpl::decompress(ByteStream input) const {
   invariant(mRaw->dim.y > 0);
   invariant(mRaw->dim.x > 0);
   invariant(mRaw->dim.x % 2 == 0);
@@ -151,6 +173,24 @@ void OlympusDecompressor::decompress(ByteStream input) const {
 
   for (int y = 0; y < mRaw->dim.y; y++)
     decompressRow(bits, y);
+}
+
+} // namespace
+
+OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
+  if (mRaw->getCpp() != 1 || mRaw->getDataType() != RawImageType::UINT16 ||
+      mRaw->getBpp() != sizeof(uint16_t))
+    ThrowRDE("Unexpected component count / data type");
+
+  const uint32_t w = mRaw->dim.x;
+  const uint32_t h = mRaw->dim.y;
+
+  if (w == 0 || h == 0 || w % 2 != 0 || h % 2 != 0 || w > 10400 || h > 7792)
+    ThrowRDE("Unexpected image dimensions found: (%u; %u)", w, h);
+}
+
+void OlympusDecompressor::decompress(ByteStream input) const {
+  OlympusDecompressorImpl(mRaw).decompress(input);
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -34,6 +34,7 @@
 #include "io/ByteStream.h"
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -86,6 +87,8 @@ OlympusDecompressorImpl::parseCarry(BitStreamerMSB& bits,
   int nbits = numActiveBits(implicit_cast<uint16_t>(carry[0]));
   nbits -= nbitsBias;
   nbits = std::max(nbits, 2 + nbitsBias);
+  assert(nbits >= 2);
+  assert(nbits <= 14);
 
   int b = bits.peekBitsNoFill(15);
   int sign = (b >> 14) * -1;

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -190,7 +190,13 @@ void OlympusDecompressorImpl::decompressRow(BitStreamerMSB& bits,
   std::array<OlympusDifferenceDecoder, 2> acarry{bittable, bittable};
 
   const int numGroups = out.width() / 2;
-  for (int group = 0; group != numGroups; ++group) {
+  int group = 0;
+  {
+    // Process first group separately, allows to unswitch predictor calculation.
+    decompressGroup(acarry, bits, row, group);
+    ++group;
+  }
+  for (; group != numGroups; ++group) {
     decompressGroup(acarry, bits, row, group);
   }
 }

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -224,11 +224,10 @@ OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
       mRaw->getBpp() != sizeof(uint16_t))
     ThrowRDE("Unexpected component count / data type");
 
-  const uint32_t w = mRaw->dim.x;
-  const uint32_t h = mRaw->dim.y;
-
-  if (w == 0 || h == 0 || w % 2 != 0 || h % 2 != 0 || w > 10400 || h > 7792)
-    ThrowRDE("Unexpected image dimensions found: (%u; %u)", w, h);
+  if (!mRaw->dim.hasPositiveArea() || mRaw->dim.x % 2 != 0 ||
+      mRaw->dim.y % 2 != 0 || mRaw->dim.x > 10400 || mRaw->dim.y > 7792)
+    ThrowRDE("Unexpected image dimensions found: (%u; %u)", mRaw->dim.x,
+             mRaw->dim.y);
 }
 
 void OlympusDecompressor::decompress(ByteStream input) const {

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -45,7 +45,7 @@ OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
   const uint32_t w = mRaw->dim.x;
   const uint32_t h = mRaw->dim.y;
 
-  if (w == 0 || h == 0 || w % 2 != 0 || w > 10400 || h > 7792)
+  if (w == 0 || h == 0 || w % 2 != 0 || h % 2 != 0 || w > 10400 || h > 7792)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", w, h);
 }
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -83,10 +83,9 @@ OlympusDecompressorImpl::parseCarry(BitStreamerMSB& bits,
   bits.fill();
 
   int nbitsBias = (carry[2] < 3) ? 2 : 0;
-  int nbits;
-  for (nbits = 2 + nbitsBias;
-       static_cast<uint16_t>(carry[0]) >> (nbits + nbitsBias); nbits++)
-    ;
+  int nbits = numActiveBits(implicit_cast<uint16_t>(carry[0]));
+  nbits -= nbitsBias;
+  nbits = std::max(nbits, 2 + nbitsBias);
 
   int b = bits.peekBitsNoFill(15);
   int sign = (b >> 14) * -1;

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -72,16 +72,19 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
   int b = bits.peekBitsNoFill(15);
   int sign = (b >> 14) * -1;
   int low = (b >> 12) & 3;
-  int high = bittable[b & 4095];
+  const int numHighBits = bittable[b & 4095];
 
+  int highBits;
   // Skip bytes used above or read bits
-  if (high == 12) {
+  if (numHighBits == 12) {
     bits.skipBitsNoFill(15);
-    high = bits.getBitsNoFill(16 - nbits) >> 1;
-  } else
-    bits.skipBitsNoFill(high + 1 + 3);
+    highBits = bits.getBitsNoFill(16 - nbits) >> 1;
+  } else {
+    bits.skipBitsNoFill(numHighBits + 1 + 3);
+    highBits = numHighBits;
+  }
 
-  carry[0] = (high << nbits) | bits.getBitsNoFill(nbits);
+  carry[0] = (highBits << nbits) | bits.getBitsNoFill(nbits);
   int diff = (carry[0] ^ sign) + carry[1];
   carry[1] = (diff * 3 + carry[1]) >> 5;
   carry[2] = carry[0] > 16 ? 0 : carry[2] + 1;

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -58,12 +58,11 @@ OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
 
 inline __attribute__((always_inline)) int
 OlympusDecompressor::parseCarry(BitStreamerMSB& bits,
-                                std::array<int, 3>* carry) const {
+                                std::array<int, 3>& carry) const {
   bits.fill();
-  int i = 2 * ((*carry)[2] < 3);
+  int i = 2 * (carry[2] < 3);
   int nbits;
-  for (nbits = 2 + i; static_cast<uint16_t>((*carry)[0]) >> (nbits + i);
-       nbits++)
+  for (nbits = 2 + i; static_cast<uint16_t>(carry[0]) >> (nbits + i); nbits++)
     ;
 
   int b = bits.peekBitsNoFill(15);
@@ -78,10 +77,10 @@ OlympusDecompressor::parseCarry(BitStreamerMSB& bits,
   } else
     bits.skipBitsNoFill(high + 1 + 3);
 
-  (*carry)[0] = (high << nbits) | bits.getBitsNoFill(nbits);
-  int diff = ((*carry)[0] ^ sign) + (*carry)[1];
-  (*carry)[1] = (diff * 3 + (*carry)[1]) >> 5;
-  (*carry)[2] = (*carry)[0] > 16 ? 0 : (*carry)[2] + 1;
+  carry[0] = (high << nbits) | bits.getBitsNoFill(nbits);
+  int diff = (carry[0] ^ sign) + carry[1];
+  carry[1] = (diff * 3 + carry[1]) >> 5;
+  carry[2] = carry[0] > 16 ? 0 : carry[2] + 1;
 
   return (diff * 4) | low;
 }
@@ -135,7 +134,7 @@ void OlympusDecompressor::decompressRow(BitStreamerMSB& bits, int row) const {
 
     std::array<int, 3>& carry = acarry[c];
 
-    int diff = parseCarry(bits, &carry);
+    int diff = parseCarry(bits, carry);
     int pred = getPred(out, row, col);
 
     out(row, col) = implicit_cast<uint16_t>(pred + diff);

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -81,9 +81,11 @@ inline __attribute__((always_inline)) int
 OlympusDecompressorImpl::parseCarry(BitStreamerMSB& bits,
                                     std::array<int, 3>& carry) const {
   bits.fill();
-  int i = 2 * (carry[2] < 3);
+
+  int nbitsBias = (carry[2] < 3) ? 2 : 0;
   int nbits;
-  for (nbits = 2 + i; static_cast<uint16_t>(carry[0]) >> (nbits + i); nbits++)
+  for (nbits = 2 + nbitsBias;
+       static_cast<uint16_t>(carry[0]) >> (nbits + nbitsBias); nbits++)
     ;
 
   int b = bits.peekBitsNoFill(15);

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -62,12 +62,12 @@ inline __attribute__((always_inline)) int
 OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
   bits.fill();
 
-  int nbitsBias = (carry[2] < 3) ? 2 : 0;
-  int nbits = numActiveBits(implicit_cast<uint16_t>(carry[0]));
-  nbits -= nbitsBias;
-  nbits = std::max(nbits, 2 + nbitsBias);
-  assert(nbits >= 2);
-  assert(nbits <= 14);
+  int numLowBitsBias = (carry[2] < 3) ? 2 : 0;
+  int numLowBits = numActiveBits(implicit_cast<uint16_t>(carry[0]));
+  numLowBits -= numLowBitsBias;
+  numLowBits = std::max(numLowBits, 2 + numLowBitsBias);
+  assert(numLowBits >= 2);
+  assert(numLowBits <= 14);
 
   int b = bits.peekBitsNoFill(15);
   int sign = (b >> 14) * -1;
@@ -78,7 +78,7 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
   // Skip bytes used above or read bits
   if (numHighBits == 12) {
     bits.skipBitsNoFill(15);
-    numHighBits = 15 - nbits;
+    numHighBits = 15 - numLowBits;
     assert(numHighBits >= 1);
     assert(numHighBits <= 13);
     highBits = bits.peekBitsNoFill(numHighBits);
@@ -88,7 +88,7 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
     highBits = numHighBits;
   }
 
-  carry[0] = (highBits << nbits) | bits.getBitsNoFill(nbits);
+  carry[0] = (highBits << numLowBits) | bits.getBitsNoFill(numLowBits);
   int diff = (carry[0] ^ sign) + carry[1];
   carry[1] = (diff * 3 + carry[1]) >> 5;
   carry[2] = carry[0] > 16 ? 0 : carry[2] + 1;

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -72,13 +72,14 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
   int b = bits.peekBitsNoFill(15);
   int sign = (b >> 14) * -1;
   int low = (b >> 12) & 3;
-  const int numHighBits = bittable[b & 4095];
+  int numHighBits = bittable[b & 4095];
 
   int highBits;
   // Skip bytes used above or read bits
   if (numHighBits == 12) {
     bits.skipBitsNoFill(15);
-    highBits = bits.getBitsNoFill(16 - nbits) >> 1;
+    numHighBits = 15 - nbits;
+    highBits = bits.getBitsNoFill(numHighBits + 1) >> 1;
   } else {
     bits.skipBitsNoFill(numHighBits + 1 + 3);
     highBits = numHighBits;

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -81,7 +81,8 @@ OlympusDifferenceDecoder::getDiff(BitStreamerMSB& bits) {
     numHighBits = 15 - nbits;
     assert(numHighBits >= 1);
     assert(numHighBits <= 13);
-    highBits = bits.getBitsNoFill(numHighBits + 1) >> 1;
+    highBits = bits.peekBitsNoFill(numHighBits);
+    bits.skipBitsNoFill(1 + numHighBits);
   } else {
     bits.skipBitsNoFill(numHighBits + 1 + 3);
     highBits = numHighBits;

--- a/src/librawspeed/decompressors/OlympusDecompressor.h
+++ b/src/librawspeed/decompressors/OlympusDecompressor.h
@@ -20,40 +20,15 @@
 
 #pragma once
 
-#include "adt/Bit.h"
-#include "bitstreams/BitStreamerMSB.h"
 #include "common/RawImage.h"
-#include "common/SimpleLUT.h"
 #include "decompressors/AbstractDecompressor.h"
-#include <algorithm>
-#include <array>
-#include <cstddef>
-#include <cstdint>
 
 namespace rawspeed {
 
 class ByteStream;
-template <class T> class Array2DRef;
 
 class OlympusDecompressor final : public AbstractDecompressor {
   RawImage mRaw;
-
-  // A table to quickly look up "high" value
-  const SimpleLUT<int8_t, 12> bittable{
-      [](size_t i, [[maybe_unused]] unsigned tableSize) {
-        int high;
-        for (high = 0; high < 12; high++)
-          if (extractHighBits(i, high, /*effectiveBitwidth=*/11) & 1)
-            break;
-        return std::min(12, high);
-      }};
-
-  inline __attribute__((always_inline)) int
-  parseCarry(BitStreamerMSB& bits, std::array<int, 3>& carry) const;
-
-  static inline int getPred(Array2DRef<uint16_t> out, int row, int col);
-
-  void decompressRow(BitStreamerMSB& bits, int row) const;
 
 public:
   explicit OlympusDecompressor(RawImage img);

--- a/src/librawspeed/decompressors/OlympusDecompressor.h
+++ b/src/librawspeed/decompressors/OlympusDecompressor.h
@@ -49,7 +49,7 @@ class OlympusDecompressor final : public AbstractDecompressor {
       }};
 
   inline __attribute__((always_inline)) int
-  parseCarry(BitStreamerMSB& bits, std::array<int, 3>* carry) const;
+  parseCarry(BitStreamerMSB& bits, std::array<int, 3>& carry) const;
 
   static inline int getPred(Array2DRef<uint16_t> out, int row, int col);
 


### PR DESCRIPTION
Since it's still sees real-world use
in newly released cameras
(OM SYSTEM OM1 Mark II, e.g.),
i guess it's performance matters.

As comment notes, that predictor thingy
is really horrifying and slow,
but we can improve things somewhat...

```
raw.pixls.us-unique/Olympus/XZ-1$ /repositories/googlebenchmark/tools/compare.py -a benchmarks ~/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench{-old,} p1319978.orf --benchmark_repetitions=49
RUNNING: /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench-old p1319978.orf --benchmark_repetitions=49 --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpv0l1_ew2
2024-02-29T21:01:02+03:00
Running /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench-old
Run on (32 X 3399.15 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 0.51, 0.71, 0.80
----------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------------
p1319978.orf/threads:32/process_time/real_time_mean          108 ms          108 ms           49 CPUTime,s=0.107614 CPUTime/WallTime=0.999943 Pixels=10.1568M Pixels/CPUTime=94.3818M Pixels/WallTime=94.3764M Raws/CPUTime=9.29247 Raws/WallTime=9.29194 WallTime,s=0.10762
p1319978.orf/threads:32/process_time/real_time_median        108 ms          108 ms           49 CPUTime,s=0.107606 CPUTime/WallTime=0.999966 Pixels=10.1568M Pixels/CPUTime=94.3889M Pixels/WallTime=94.3824M Raws/CPUTime=9.29318 Raws/WallTime=9.29253 WallTime,s=0.107613
p1319978.orf/threads:32/process_time/real_time_stddev      0.077 ms        0.077 ms           49 CPUTime,s=76.5394u CPUTime/WallTime=51.4451u Pixels=0 Pixels/CPUTime=66.9659k Pixels/WallTime=67.538k Raws/CPUTime=6.59321m Raws/WallTime=6.64954m WallTime,s=77.1944u
p1319978.orf/threads:32/process_time/real_time_cv           0.07 %          0.07 %            49 CPUTime,s=0.07% CPUTime/WallTime=0.01% Pixels=0.00% Pixels/CPUTime=0.07% Pixels/WallTime=0.07% Raws/CPUTime=0.07% Raws/WallTime=0.07% WallTime,s=0.07%
RUNNING: /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench p1319978.orf --benchmark_repetitions=49 --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmp85xmyvj3
2024-02-29T21:01:33+03:00
Running /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 0.76, 0.75, 0.81
----------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------------
p1319978.orf/threads:32/process_time/real_time_mean         94.9 ms         94.9 ms           49 CPUTime,s=0.0949223 CPUTime/WallTime=0.999924 Pixels=10.1568M Pixels/CPUTime=107.001M Pixels/WallTime=106.993M Raws/CPUTime=10.5349 Raws/WallTime=10.5341 WallTime,s=0.0949295
p1319978.orf/threads:32/process_time/real_time_median       94.9 ms         94.9 ms           49 CPUTime,s=0.0949059 CPUTime/WallTime=0.999956 Pixels=10.1568M Pixels/CPUTime=107.02M Pixels/WallTime=107.005M Raws/CPUTime=10.5368 Raws/WallTime=10.5353 WallTime,s=0.0949188
p1319978.orf/threads:32/process_time/real_time_stddev      0.041 ms        0.041 ms           49 CPUTime,s=40.7811u CPUTime/WallTime=63.1188u Pixels=0 Pixels/CPUTime=45.9084k Pixels/WallTime=46.2605k Raws/CPUTime=4.51996m Raws/WallTime=4.55464m WallTime,s=41.1006u
p1319978.orf/threads:32/process_time/real_time_cv           0.04 %          0.04 %            49 CPUTime,s=0.04% CPUTime/WallTime=0.01% Pixels=0.00% Pixels/CPUTime=0.04% Pixels/WallTime=0.04% Raws/CPUTime=0.04% Raws/WallTime=0.04% WallTime,s=0.04%
Comparing /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench-old to /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench
Benchmark                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------
p1319978.orf/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 49 vs 49
p1319978.orf/threads:32/process_time/real_time_mean                  -0.1179         -0.1179           108            95           108            95
p1319978.orf/threads:32/process_time/real_time_median                -0.1180         -0.1180           108            95           108            95
p1319978.orf/threads:32/process_time/real_time_stddev                -0.4678         -0.4670             0             0             0             0
p1319978.orf/threads:32/process_time/real_time_cv                    -0.3966         -0.3957             0             0             0             0
OVERALL_GEOMEAN                                                      -0.1179         -0.1179             0             0             0             0
```