### PR TITLE
numActiveBits(): explicitly widen to at least 32 bits (OlympusDecompressor -1%)

### DIFF
--- a/src/librawspeed/adt/Bit.h
+++ b/src/librawspeed/adt/Bit.h
@@ -49,9 +49,15 @@ unsigned numSignBits(const T v) {
 }
 
 template <class T>
-  requires std::unsigned_integral<T>
+  requires(std::unsigned_integral<T> && bitwidth<T>() >= bitwidth<uint32_t>())
 unsigned numActiveBits(const T v) {
   return bitwidth(v) - std::countl_zero(v);
+}
+
+template <class T>
+  requires(std::unsigned_integral<T> && bitwidth<T>() < bitwidth<uint32_t>())
+unsigned numActiveBits(const T v) {
+  return numActiveBits(static_cast<uint32_t>(v));
 }
 
 template <class T>


### PR DESCRIPTION
https://godbolt.org/z/7ajqhhvq7
https://alive2.llvm.org/ce/z/vBhFBk

```
raw.pixls.us-unique/Olympus/XZ-1$ /repositories/googlebenchmark/tools/compare.py -a benchmarks ~/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench{-old,} p1319978.orf --benchmark_repetitions=49
<...>
Comparing /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench-old to /home/lebedevri/rawspeed/build-Clang17-release/src/utilities/rsbench/rsbench
Benchmark                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------
p1319978.orf/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 49 vs 49
p1319978.orf/threads:32/process_time/real_time_mean                  -0.0114         -0.0114            95            94            95            94
p1319978.orf/threads:32/process_time/real_time_median                -0.0110         -0.0110            95            94            95            94
p1319978.orf/threads:32/process_time/real_time_stddev                -0.6550         -0.6415             0             0             0             0
p1319978.orf/threads:32/process_time/real_time_cv                    -0.6510         -0.6374             0             0             0             0
OVERALL_GEOMEAN                                                      -0.0114         -0.0114             0             0             0             0
```