### PR TITLE
Fujifilm X100VI support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -15689,8 +15689,45 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="X100VI" supported="unknown-no-samples">
+	<Camera make="FUJIFILM" model="X100VI">
 		<ID make="Fujifilm" model="X100VI">Fujifilm X100VI</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="12" width="-120" height="-12"/>
+		<Sensor black="1023" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11809 -5358 -1141</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4248 12164 2343</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-514 1097 5848</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="X100VI" mode="compressed">
+		<ID make="Fujifilm" model="X100VI">Fujifilm X100VI</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="12" width="-120" height="-12"/>
+		<Sensor black="1023" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11809 -5358 -1141</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4248 12164 2343</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-514 1097 5848</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-H1">
 		<ID make="Fujifilm" model="X-H1">Fujifilm X-H1</ID>


### PR DESCRIPTION
Resolves https://github.com/darktable-org/darktable/issues/16393

The premise is that this is [identical to X-T5 and X-H2](https://www.dpreview.com/reviews/fujifilm-x100vi-initial-review#WN), and ADC 16.2 also converts it as such. However, it is not (yet) announced in the 16.2 supported list...

[No support for the lossy compressed mode yet](https://github.com/darktable-org/rawspeed/issues/232).