### PR TITLE
LJpeg: [full] LJpeg frame matches normal DNG tile size

### DIFF
--- a/fuzz/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecoder.cpp
@@ -47,11 +47,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const auto offsetY = bs.getU32();
     const auto width = bs.getU32();
     const auto height = bs.getU32();
+    const auto maxWidth = bs.getU32();
+    const auto maxHeight = bs.getU32();
     const auto fixDng16Bug = bs.getU32();
 
     rawspeed::LJpegDecoder j(bs, mRaw);
     mRaw->createData();
-    j.decode(offsetX, offsetY, width, height, fixDng16Bug);
+    j.decode(offsetX, offsetY, width, height,
+             rawspeed::iPoint2D(maxWidth, maxHeight), fixDng16Bug);
 
     // we can not check that all the image was initialized, because normally
     // LJpegDecoder decodes just some one tile/slice.

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -385,8 +385,14 @@ void ArwDecoder::DecodeLJpeg(const TiffIFD* raw) {
           ByteStream(
               DataBuffer(mFile.getSubView(offset, length), Endianness::little)),
           mRaw);
-      decoder.decode(implicit_cast<uint32_t>(tileX * tilew), tileY * tileh,
-                     implicit_cast<uint32_t>(tilew), tileh, false);
+      auto offsetX = implicit_cast<uint32_t>(tileX * tilew);
+      auto offsetY = tileY * tileh;
+      auto tileWidth = implicit_cast<uint32_t>(tilew);
+      auto tileHeight = tileh;
+      auto maxDim = iPoint2D{implicit_cast<int>(tileWidth),
+                             implicit_cast<int>(tileHeight)};
+      decoder.decode(offsetX, offsetY, tileWidth, tileHeight, maxDim,
+                     /*fixDng16Bug=*/false);
     } catch (const RawDecoderException& err) {
       mRaw->setError(err.what());
     } catch (const IOException& err) {

--- a/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
@@ -116,7 +116,8 @@ template <> void AbstractDngDecompressor::decompressThread<7>() const noexcept {
        Array1DRef(slices.data(), implicit_cast<int>(slices.size()))) {
     try {
       LJpegDecoder d(e.bs, mRaw);
-      d.decode(e.offX, e.offY, e.width, e.height, mFixLjpeg);
+      d.decode(e.offX, e.offY, e.width, e.height,
+               iPoint2D(e.dsc.tileW, e.dsc.tileH), mFixLjpeg);
     } catch (const RawDecoderException& err) {
       mRaw->setError(err.what());
     } catch (const IOException& err) {

--- a/src/librawspeed/decompressors/LJpegDecoder.h
+++ b/src/librawspeed/decompressors/LJpegDecoder.h
@@ -38,11 +38,13 @@ class LJpegDecoder final : public AbstractLJpegDecoder {
   uint32_t w = 0;
   uint32_t h = 0;
 
+  iPoint2D maxDim;
+
 public:
   LJpegDecoder(ByteStream bs, const RawImage& img);
 
   void decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
-              uint32_t height, bool fixDng16Bug_);
+              uint32_t height, iPoint2D maxDim, bool fixDng16Bug_);
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
This is true for all RPU samples at least, even weird 3-component ones.

This seems like the missing info trivia which allows support for different LJpeg CPS layouts (e.g. the square one)