### PR TITLE
LJpeg: support square MCU layout (Sony LJpeg, -32%)

### DIFF
--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -87,11 +87,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
                       return {*hts[i], initPred[i]};
                     });
 
-    const int numRowsPerRestartInterval = bs.getI32();
+    const int numLJpegRowsPerRestartInterval = bs.getI32();
 
     rawspeed::LJpegDecompressor d(
         mRaw, rawspeed::iRectangle2D(mRaw->dim.x, mRaw->dim.y), frame, rec,
-        numRowsPerRestartInterval,
+        numLJpegRowsPerRestartInterval,
         bs.getSubStream(/*offset=*/0).peekRemainingBuffer().getAsArray1DRef());
     mRaw->createData();
     (void)d.decode();

--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -50,11 +50,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
 
     rawspeed::RawImage mRaw(CreateRawImage(bs));
 
-    const int N_COMP = bs.getI32();
+    const int MCU_w = bs.getI32();
+    const int MCU_h = bs.getI32();
     const int frame_w = bs.getI32();
     const int frame_h = bs.getI32();
     const rawspeed::LJpegDecompressor::Frame frame{
-        N_COMP, rawspeed::iPoint2D(frame_w, frame_h)};
+        rawspeed::iPoint2D(MCU_w, MCU_h), rawspeed::iPoint2D(frame_w, frame_h)};
 
     const unsigned num_recips = bs.getU32();
 

--- a/src/librawspeed/adt/Point.h
+++ b/src/librawspeed/adt/Point.h
@@ -56,7 +56,7 @@ public:
     return *this;
   }
 
-  constexpr bool operator==(const iPoint2D& rhs) const {
+  constexpr bool RAWSPEED_READONLY operator==(const iPoint2D& rhs) const {
     return x == rhs.x && y == rhs.y;
   }
 

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -20,7 +20,6 @@
 */
 
 #include "decoders/ArwDecoder.h"
-#include "MemorySanitizer.h"
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
@@ -318,16 +317,13 @@ void ArwDecoder::DecodeLJpeg(const TiffIFD* raw) {
       width > 9728 || height > 6656)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
-  mRaw->dim = iPoint2D(2 * width, height / 2);
+  mRaw->dim = iPoint2D(width, height);
 
   auto tilew = uint64_t(raw->getEntry(TiffTag::TILEWIDTH)->getU32());
   uint32_t tileh = raw->getEntry(TiffTag::TILELENGTH)->getU32();
 
   if (tilew <= 0 || tileh <= 0 || tileh % 2 != 0)
     ThrowRDE("Invalid tile size: (%" PRIu64 ", %u)", tilew, tileh);
-
-  tileh /= 2;
-  tilew *= 2;
 
   assert(tilew > 0);
   const auto tilesX =
@@ -409,46 +405,9 @@ void ArwDecoder::DecodeLJpeg(const TiffIFD* raw) {
              firstErr.c_str());
   }
 
-  PostProcessLJpeg();
-
   const TiffEntry* size_entry = raw->getEntry(TiffTag::SONYRAWIMAGESIZE);
   iRectangle2D crop(0, 0, size_entry->getU32(0), size_entry->getU32(1));
   mRaw->subFrame(crop);
-}
-
-void ArwDecoder::PostProcessLJpeg() {
-  MSan::CheckMemIsInitialized(mRaw->getByteDataAsUncroppedArray2DRef());
-  RawImage nonInterleavedRaw = mRaw;
-
-  invariant(nonInterleavedRaw->dim.x % 4 == 0);
-  iPoint2D interleavedDims = {nonInterleavedRaw->dim.x / 2,
-                              2 * nonInterleavedRaw->dim.y};
-  mRaw = RawImage::create(interleavedDims, RawImageType::UINT16, 1);
-
-  const Array2DRef<const uint16_t> in =
-      nonInterleavedRaw->getU16DataAsUncroppedArray2DRef();
-  const Array2DRef<uint16_t> out = mRaw->getU16DataAsUncroppedArray2DRef();
-
-#ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(static) default(none) firstprivate(in, out)
-#endif
-  for (int inRow = 0; inRow < in.height(); ++inRow) {
-    static constexpr iPoint2D inMCUSize = {4, 1};
-    static constexpr iPoint2D outMCUSize = {2, 2};
-
-    invariant(in.width() % inMCUSize.x == 0);
-    for (int MCUIdx = 0, numMCUsPerRow = in.width() / inMCUSize.x;
-         MCUIdx < numMCUsPerRow; ++MCUIdx) {
-      for (int outMCURow = 0; outMCURow != outMCUSize.y; ++outMCURow) {
-        for (int outMCUСol = 0; outMCUСol != outMCUSize.x; ++outMCUСol) {
-          out(outMCUSize.y * inRow + outMCURow,
-              outMCUSize.x * MCUIdx + outMCUСol) =
-              in(inRow,
-                 MCUIdx * inMCUSize.x + outMCUSize.x * outMCURow + outMCUСol);
-        }
-      }
-    }
-  }
 }
 
 void ArwDecoder::DecodeARW2(ByteStream input, uint32_t w, uint32_t h,

--- a/src/librawspeed/decoders/ArwDecoder.h
+++ b/src/librawspeed/decoders/ArwDecoder.h
@@ -54,7 +54,6 @@ private:
   RawImage decodeSRF();
   void DecodeARW2(ByteStream input, uint32_t w, uint32_t h, uint32_t bpp);
   void DecodeLJpeg(const TiffIFD* raw);
-  void PostProcessLJpeg();
   void DecodeUncompressed(const TiffIFD* raw) const;
   static void SonyDecrypt(Array1DRef<const uint8_t> ibuf,
                           Array1DRef<uint8_t> obuf, int len, uint32_t key);

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -138,11 +138,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
     ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
 
-  if (iPoint2D{1, 1} != MCUSize && iPoint2D{2, 1} != MCUSize &&
-      iPoint2D{3, 1} != MCUSize && iPoint2D{4, 1} != MCUSize)
-    ThrowRDE("Unexpected MCU size: {%i, %i}", MCUSize.x, MCUSize.y);
-
-  const LJpegDecompressor::Frame jpegFrame = {N_COMP, jpegFrameDim};
+  const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
   int numRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -135,6 +135,15 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   if (maxRes.x % jpegFrame.dim.x != 0 || maxRes.y % jpegFrame.dim.y != 0)
     ThrowRDE("Maximal output tile size is not a multiple of LJpeg frame size");
 
+  auto MCUSize =
+      iPoint2D{maxRes.x / jpegFrame.dim.x, maxRes.y / jpegFrame.dim.y};
+  if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
+    ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
+
+  if (iPoint2D{1, 1} != MCUSize && iPoint2D{2, 1} != MCUSize &&
+      iPoint2D{3, 1} != MCUSize && iPoint2D{4, 1} != MCUSize)
+    ThrowRDE("Unexpected MCU size: {%i, %i}", MCUSize.x, MCUSize.y);
+
   int numRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {
     // Restart interval not enabled, so all of the rows

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -128,9 +128,9 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   const LJpegDecompressor::Frame jpegFrame = {N_COMP,
                                               iPoint2D(frame.w, frame.h)};
 
-  if (iPoint2D(mRaw->getCpp() * maxDim.x, maxDim.y) !=
-      iPoint2D(N_COMP * frame.w, frame.h))
-    ThrowRDE("LJpeg frame does not match maximal tile size");
+  auto maxRes = iPoint2D(mRaw->getCpp() * maxDim.x, maxDim.y);
+  if (maxRes.area() != N_COMP * jpegFrame.dim.area())
+    ThrowRDE("LJpeg frame area does not match maximal tile area");
 
   int numRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -140,19 +140,20 @@ Buffer::size_type LJpegDecoder::decodeScan() {
 
   const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
-  int numRowsPerRestartInterval;
+  int numLJpegRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {
     // Restart interval not enabled, so all of the rows
     // are contained in the first (implicit) restart interval.
-    numRowsPerRestartInterval = jpegFrameDim.y;
+    numLJpegRowsPerRestartInterval = jpegFrameDim.y;
   } else {
     const int numMCUsPerRow = jpegFrameDim.x;
     if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
       ThrowRDE("Restart interval is not a multiple of frame row size");
-    numRowsPerRestartInterval = numMCUsPerRestartInterval / numMCUsPerRow;
+    numLJpegRowsPerRestartInterval = numMCUsPerRestartInterval / numMCUsPerRow;
   }
 
-  LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec, numRowsPerRestartInterval,
+  LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
+                      numLJpegRowsPerRestartInterval,
                       input.peekRemainingBuffer().getAsArray1DRef());
   return d.decode();
 }

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -132,6 +132,9 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   if (maxRes.area() != N_COMP * jpegFrame.dim.area())
     ThrowRDE("LJpeg frame area does not match maximal tile area");
 
+  if (maxRes.x % jpegFrame.dim.x != 0 || maxRes.y % jpegFrame.dim.y != 0)
+    ThrowRDE("Maximal output tile size is not a multiple of LJpeg frame size");
+
   int numRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {
     // Restart interval not enabled, so all of the rows

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -261,8 +261,9 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
   invariant(imgFrame.pos.y + imgFrame.dim.y <= mRaw->dim.y);
   invariant(imgFrame.pos.x + imgFrame.dim.x <= mRaw->dim.x);
 
-  const auto numRestartIntervals = implicit_cast<int>(
-      roundUpDivision(imgFrame.dim.y, numLJpegRowsPerRestartInterval));
+  invariant(imgFrame.dim.y % frame.mcu.y == 0);
+  const auto numRestartIntervals = implicit_cast<int>(roundUpDivision(
+      imgFrame.dim.y / frame.mcu.y, numLJpegRowsPerRestartInterval));
   invariant(numRestartIntervals >= 0);
   invariant(numRestartIntervals != 0);
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -141,7 +141,7 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
   }
 
   // How many full pixel blocks will we produce?
-  fullBlocks = tileRequiredWidth / frame.mcu.x; // Truncating division!
+  numFullMCUs = tileRequiredWidth / frame.mcu.x; // Truncating division!
   // Do we need to also produce part of a block?
   trailingPixels = tileRequiredWidth % frame.mcu.x;
 
@@ -190,7 +190,7 @@ void LJpegDecompressor::decodeRowN(
 
   int col = 0;
   // For x, we first process all full pixel blocks within the image buffer ...
-  for (; col < N_COMP * fullBlocks; col += N_COMP) {
+  for (; col < N_COMP * numFullMCUs; col += N_COMP) {
     for (int i = 0; i != N_COMP; ++i) {
       pred[i] =
           uint16_t(pred[i] + (static_cast<const PrefixCodeDecoder<>&>(ht[i]))

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -51,11 +51,11 @@ namespace rawspeed {
 LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
                                      Frame frame_,
                                      std::vector<PerComponentRecipe> rec_,
-                                     int numRowsPerRestartInterval_,
+                                     int numLJpegRowsPerRestartInterval_,
                                      Array1DRef<const uint8_t> input_)
     : mRaw(std::move(img)), input(input_), imgFrame(imgFrame_),
       frame(std::move(frame_)), rec(std::move(rec_)),
-      numRowsPerRestartInterval(numRowsPerRestartInterval_) {
+      numLJpegRowsPerRestartInterval(numLJpegRowsPerRestartInterval_) {
 
   if (mRaw->getDataType() != RawImageType::UINT16)
     ThrowRDE("Unexpected data type (%u)",
@@ -107,7 +107,7 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
       ThrowRDE("Huffman table is not of a full decoding variety");
   }
 
-  if (numRowsPerRestartInterval < 1)
+  if (numLJpegRowsPerRestartInterval < 1)
     ThrowRDE("Number of rows per restart interval must be positives");
 
   if (static_cast<int64_t>(frame.mcu.x) * frame.dim.x >
@@ -262,7 +262,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
   invariant(imgFrame.pos.x + imgFrame.dim.x <= mRaw->dim.x);
 
   const auto numRestartIntervals = implicit_cast<int>(
-      roundUpDivision(imgFrame.dim.y, numRowsPerRestartInterval));
+      roundUpDivision(imgFrame.dim.y, numLJpegRowsPerRestartInterval));
   invariant(numRestartIntervals >= 0);
   invariant(numRestartIntervals != 0);
 
@@ -287,9 +287,9 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
     BitStreamerJPEG bs(inputStream.peekRemainingBuffer().getAsArray1DRef());
 
     for (int rowOfRestartInterval = 0;
-         rowOfRestartInterval != numRowsPerRestartInterval;
+         rowOfRestartInterval != numLJpegRowsPerRestartInterval;
          ++rowOfRestartInterval) {
-      const int row = numRowsPerRestartInterval * restartIntervalIndex +
+      const int row = numLJpegRowsPerRestartInterval * restartIntervalIndex +
                       rowOfRestartInterval;
       invariant(row >= 0);
       invariant(row <= imgFrame.dim.y);

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -123,6 +123,9 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
   if (imgFrame.dim.x < frame.mcu.x || imgFrame.dim.y < frame.mcu.y)
     ThrowRDE("Tile size is smaller than a single frame MCU");
 
+  if (imgFrame.dim.y % frame.mcu.y != 0)
+    ThrowRDE("Output row count is not a multiple of MCU row count");
+
   const int tileRequiredWidth =
       static_cast<int>(mRaw->getCpp()) * imgFrame.dim.x;
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -96,12 +96,12 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
   if (imgFrame.pos.y + imgFrame.dim.y > mRaw->dim.y)
     ThrowRDE("Tile overflows image vertically");
 
-  cps = frame.cps;
+  if (iPoint2D{1, 1} != frame.mcu && iPoint2D{2, 1} != frame.mcu &&
+      iPoint2D{3, 1} != frame.mcu && iPoint2D{4, 1} != frame.mcu)
+    ThrowRDE("Unexpected MCU size: {%i, %i}", frame.mcu.x, frame.mcu.y);
+  cps = implicit_cast<int>(frame.mcu.area()); // FIXME;
 
-  if (cps < 1 || cps > 4)
-    ThrowRDE("Unsupported number of components: %u", cps);
-
-  if (rec.size() != static_cast<unsigned>(cps))
+  if (rec.size() != static_cast<unsigned>(frame.mcu.area()))
     ThrowRDE("Must have exactly one recepie per component");
 
   for (const auto& recip : rec) {

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -289,18 +289,19 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
     for (int ljpegRowOfRestartInterval = 0;
          ljpegRowOfRestartInterval != numLJpegRowsPerRestartInterval;
          ++ljpegRowOfRestartInterval) {
-      const int row = numLJpegRowsPerRestartInterval * restartIntervalIndex +
-                      ljpegRowOfRestartInterval;
-      invariant(row >= 0);
-      invariant(row <= imgFrame.dim.y);
+      const int ljpegRow =
+          numLJpegRowsPerRestartInterval * restartIntervalIndex +
+          ljpegRowOfRestartInterval;
+      invariant(ljpegRow >= 0);
+      invariant(ljpegRow <= imgFrame.dim.y);
 
       // For y, we can simply stop decoding when we reached the border.
-      if (row == imgFrame.dim.y) {
+      if (ljpegRow == imgFrame.dim.y) {
         invariant((restartIntervalIndex + 1) == numRestartIntervals);
         break;
       }
 
-      auto outRow = img[row];
+      auto outRow = img[ljpegRow];
       copy_n(predNext.begin(), N_COMP, pred.data());
       // the predictor for the next line is the start of this line
       predNext = outRow

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -286,11 +286,11 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
 
     BitStreamerJPEG bs(inputStream.peekRemainingBuffer().getAsArray1DRef());
 
-    for (int rowOfRestartInterval = 0;
-         rowOfRestartInterval != numLJpegRowsPerRestartInterval;
-         ++rowOfRestartInterval) {
+    for (int ljpegRowOfRestartInterval = 0;
+         ljpegRowOfRestartInterval != numLJpegRowsPerRestartInterval;
+         ++ljpegRowOfRestartInterval) {
       const int row = numLJpegRowsPerRestartInterval * restartIntervalIndex +
-                      rowOfRestartInterval;
+                      ljpegRowOfRestartInterval;
       invariant(row >= 0);
       invariant(row <= imgFrame.dim.y);
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -97,7 +97,8 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
     ThrowRDE("Tile overflows image vertically");
 
   if (iPoint2D{1, 1} != frame.mcu && iPoint2D{2, 1} != frame.mcu &&
-      iPoint2D{3, 1} != frame.mcu && iPoint2D{4, 1} != frame.mcu)
+      iPoint2D{3, 1} != frame.mcu && iPoint2D{4, 1} != frame.mcu &&
+      iPoint2D{2, 2} != frame.mcu)
     ThrowRDE("Unexpected MCU size: {%i, %i}", frame.mcu.x, frame.mcu.y);
 
   if (rec.size() != static_cast<unsigned>(frame.mcu.area()))
@@ -367,6 +368,9 @@ ByteStream::size_type LJpegDecompressor::decode() const {
   case 4:
     if (frame.mcu == MCU<4, 1>) {
       return decodeN<MCU<4, 1>>();
+    }
+    if (frame.mcu == MCU<2, 2>) {
+      return decodeN<MCU<2, 2>>();
     }
     break;
   default:

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -269,7 +269,6 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
   // The tiles at the bottom and the right may extend beyond the dimension of
   // the raw image buffer. The excessive content has to be ignored.
 
-  invariant(frame.dim.y >= imgFrame.dim.y);
   invariant(static_cast<int64_t>(cps) * frame.dim.x >=
             static_cast<int64_t>(mRaw->getCpp()) * imgFrame.dim.x);
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -290,19 +290,19 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
     for (int ljpegRowOfRestartInterval = 0;
          ljpegRowOfRestartInterval != numLJpegRowsPerRestartInterval;
          ++ljpegRowOfRestartInterval) {
-      const int ljpegRow =
-          numLJpegRowsPerRestartInterval * restartIntervalIndex +
-          ljpegRowOfRestartInterval;
-      invariant(ljpegRow >= 0);
-      invariant(ljpegRow <= imgFrame.dim.y);
+      const int row =
+          frame.mcu.y * (numLJpegRowsPerRestartInterval * restartIntervalIndex +
+                         ljpegRowOfRestartInterval);
+      invariant(row >= 0);
+      invariant(row <= imgFrame.dim.y);
 
       // For y, we can simply stop decoding when we reached the border.
-      if (ljpegRow == imgFrame.dim.y) {
+      if (row == imgFrame.dim.y) {
         invariant((restartIntervalIndex + 1) == numRestartIntervals);
         break;
       }
 
-      auto outRow = img[ljpegRow];
+      auto outRow = img[row];
       copy_n(predNext.begin(), N_COMP, pred.data());
       // the predictor for the next line is the start of this line
       predNext = outRow

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -178,11 +178,13 @@ constexpr iPoint2D MCU = {MCUWidth, MCUHeight};
 
 } // namespace
 
-template <int N_COMP>
+template <const iPoint2D& MCUSize, int N_COMP>
 void LJpegDecompressor::decodeRowN(
     Array1DRef<uint16_t> outRow, std::array<uint16_t, N_COMP> pred,
     std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
     BitStreamerJPEG& bs) const {
+  invariant(MCUSize.area() == N_COMP);
+
   // FIXME: predictor may have value outside of the uint16_t.
   // https://github.com/darktable-org/rawspeed/issues/175
 
@@ -306,7 +308,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
                                /*index=*/0)
                      .getAsArray1DRef();
 
-      decodeRowN<N_COMP>(outRow, pred, ht, bs);
+      decodeRowN<MCU, N_COMP>(outRow, pred, ht, bs);
     }
 
     inputStream.skipBytes(bs.getStreamPosition());

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -194,15 +194,19 @@ void LJpegDecompressor::decodeRowN(
   int mcuIdx = 0;
   // For x, we first process all full pixel MCUs within the image buffer ...
   for (; mcuIdx < numFullMCUs; ++mcuIdx) {
+    const auto outTile = CroppedArray2DRef(outStripe,
+                                           /*offsetCols=*/MCUSize.x * mcuIdx,
+                                           /*offsetRows=*/0,
+                                           /*croppedWidth=*/MCUSize.x,
+                                           /*croppedHeight=*/MCUSize.y)
+                             .getAsArray2DRef();
     for (int MCURow = 0; MCURow != MCUSize.y; ++MCURow) {
       for (int MCUСol = 0; MCUСol != MCUSize.x; ++MCUСol) {
         int c = MCUSize.x * MCURow + MCUСol;
         pred[c] =
             uint16_t(pred[c] + (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
                                    .decodeDifference(bs));
-        int stripeRow = MCURow;
-        int stripeCol = (MCUSize.x * mcuIdx) + MCUСol;
-        outStripe(stripeRow, stripeCol) = pred[c];
+        outTile(MCURow, MCUСol) = pred[c];
       }
     }
   }

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -82,7 +82,8 @@ private:
       std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
       BitStreamerJPEG& bs) const;
 
-  template <int N_COMP> [[nodiscard]] ByteStream::size_type decodeN() const;
+  template <const iPoint2D& MCUSize>
+  [[nodiscard]] ByteStream::size_type decodeN() const;
 
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -83,7 +83,7 @@ private:
       BitStreamerJPEG& bs) const;
 
   template <const iPoint2D& MCUSize>
-  [[nodiscard]] ByteStream::size_type decodeN() const;
+  [[nodiscard]] __attribute__((noinline)) ByteStream::size_type decodeN() const;
 
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -41,7 +41,7 @@ namespace rawspeed {
 class LJpegDecompressor final {
 public:
   struct Frame final {
-    const int cps;
+    const iPoint2D mcu;
     const iPoint2D dim;
   };
   struct PerComponentRecipe final {

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -76,7 +76,7 @@ private:
   template <int N_COMP>
   [[nodiscard]] std::array<uint16_t, N_COMP> getInitialPreds() const;
 
-  template <int N_COMP>
+  template <const iPoint2D& MCUSize, int N_COMP>
   __attribute__((always_inline)) inline void decodeRowN(
       Array1DRef<uint16_t> outRow, std::array<uint16_t, N_COMP> pred,
       std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -59,6 +59,7 @@ private:
   const std::vector<PerComponentRecipe> rec;
   const int numRowsPerRestartInterval;
 
+  int cps = 0;
   int fullBlocks = 0;
   int trailingPixels = 0;
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -57,7 +57,7 @@ private:
 
   const Frame frame;
   const std::vector<PerComponentRecipe> rec;
-  const int numRowsPerRestartInterval;
+  const int numLJpegRowsPerRestartInterval;
 
   int cps = 0;
   int fullBlocks = 0;
@@ -88,7 +88,7 @@ private:
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,
                     std::vector<PerComponentRecipe> rec,
-                    int numRowsPerRestartInterval_,
+                    int numLJpegRowsPerRestartInterval_,
                     Array1DRef<const uint8_t> input);
 
   [[nodiscard]] ByteStream::size_type decode() const;

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -78,7 +78,7 @@ private:
 
   template <const iPoint2D& MCUSize, int N_COMP>
   __attribute__((always_inline)) inline void decodeRowN(
-      Array1DRef<uint16_t> outRow, std::array<uint16_t, N_COMP> pred,
+      Array2DRef<uint16_t> outStripe, std::array<uint16_t, N_COMP> pred,
       std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
       BitStreamerJPEG& bs) const;
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -60,7 +60,7 @@ private:
   const int numLJpegRowsPerRestartInterval;
 
   int cps = 0;
-  int fullBlocks = 0;
+  int numFullMCUs = 0;
   int trailingPixels = 0;
 
   template <int N_COMP, size_t... I>


### PR DESCRIPTION
This is essentially rebased #483, and partially reverts #484,
now that i've figured out how we can deduce the MCU size:
e9e3f1bb8f269dba773de61a987ab2f31b62e7ec + 63f717036daad19e87b0f305a35ebd7644d69470 !

This, hopefully, partially solves the roadblock towards different predictor support.

```
Comparing /home/lebedevri/rawspeed/build-Clang18-release/src/utilities/rsbench/rsbench-old to /home/lebedevri/rawspeed/build-Clang18-release/src/utilities/rsbench/rsbench
Benchmark                                                                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_pvalue                 0.0081          0.0066      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_mean                  -0.0160         -0.0162            11            11           364           359
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_median                -0.0181         -0.0156            11            11           361           356
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_stddev                +0.1098         +0.1135             0             0             8             9
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9394-compressed-lossless.DNG/threads:32/process_time/real_time_cv                    +0.1279         +0.1318             0             0             0             0
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_pvalue                 0.3683          0.4781      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_mean                  +0.0089         +0.0082            15            15           464           468
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_median                +0.0145         +0.0152            15            15           461           468
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_stddev                +0.2341         +0.2787             0             0            11            14
./Adobe DNG Converter/Canon EOS 5D Mark III/5G4A9395-compressed-lossless.DNG/threads:32/process_time/real_time_cv                    +0.2232         +0.2683             0             0             0             0
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_pvalue                                      0.2913          0.2326      U Test, Repetitions: 27 vs 27
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_mean                                       -0.0098         -0.0102            30            29           939           930
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_median                                     -0.0193         -0.0181            30            29           936           920
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_stddev                                     -0.1583         -0.1647             1             1            28            23
./Adobe DNG Converter/Canon EOS 5D Mark IV/B13A0729.dng/threads:32/process_time/real_time_cv                                         -0.1500         -0.1561             0             0             0             0
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_pvalue                                        0.0001          0.0000      U Test, Repetitions: 27 vs 27
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_mean                                         -0.0312         -0.0321             4             4           129           125
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_median                                       -0.0479         -0.0480             4             4           128           122
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_stddev                                       +0.8491         +0.7719             0             0             4             8
./Fujifilm/X100S/fujifilm-x100s-daylight-DSCF9505.dng/threads:32/process_time/real_time_cv                                           +0.9087         +0.8306             0             0             0             0
./Samsung/Galaxy S21 Ultra/20230712_115041.dng/threads:32/process_time/real_time_pvalue                                               0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Samsung/Galaxy S21 Ultra/20230712_115041.dng/threads:32/process_time/real_time_mean                                                +0.0128         +0.0128           149           151           149           151
./Samsung/Galaxy S21 Ultra/20230712_115041.dng/threads:32/process_time/real_time_median                                              +0.0128         +0.0128           149           151           149           151
./Samsung/Galaxy S21 Ultra/20230712_115041.dng/threads:32/process_time/real_time_stddev                                              -0.0387         -0.0437             0             0             0             0
./Samsung/Galaxy S21 Ultra/20230712_115041.dng/threads:32/process_time/real_time_cv                                                  -0.0509         -0.0558             0             0             0             0
./Samsung/Galaxy S23 Ultra/20231214_130645.dng/threads:32/process_time/real_time_pvalue                                               0.0066          0.7687      U Test, Repetitions: 27 vs 27
./Samsung/Galaxy S23 Ultra/20231214_130645.dng/threads:32/process_time/real_time_mean                                                +0.0055         -0.0000           580           584          7001          7001
./Samsung/Galaxy S23 Ultra/20231214_130645.dng/threads:32/process_time/real_time_median                                              +0.0076         -0.0107           579           583          7224          7147
./Samsung/Galaxy S23 Ultra/20231214_130645.dng/threads:32/process_time/real_time_stddev                                              +0.5071         -0.0321             4             6          1181          1143
./Samsung/Galaxy S23 Ultra/20231214_130645.dng/threads:32/process_time/real_time_cv                                                  +0.4988         -0.0320             0             0             0             0
./Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_pvalue                                       0.0000          0.0000      U Test, Repetitions: 27 vs 27
./Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_mean                                        -0.3269         -0.3256            29            19           910           614
./Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_median                                      -0.3205         -0.3224            29            19           908           615
./Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_stddev                                      -0.0947         -0.0594             1             1            21            20
./Sony/ILCE-7RM5/7RM5-S35-LosslessCompressedMedium.ARW/threads:32/process_time/real_time_cv                                          +0.3449         +0.3946             0             0             0             0
OVERALL_GEOMEAN                                                                                                                      -0.0593         -0.0594             0             0             1             1

```