### PR TITLE
Sony ILCE-9M3 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14127,8 +14127,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="ILCE-9M3" supported="unknown-no-samples">
+	<Camera make="SONY" model="ILCE-9M3">
 		<ID make="Sony" model="ILCE-9M3">Sony ILCE-9M3</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-32" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9811 -3908 -752</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3704 11577 2417</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-73 950 5980</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX1">
 		<ID make="Sony" model="DSC-RX1">Sony DSC-RX1</ID>


### PR DESCRIPTION
Resolves https://github.com/darktable-org/darktable/issues/16523

Luckily the APS-C crop is smaller than the FF one (unlike w/ the [7M4](https://github.com/darktable-org/rawspeed/issues/520)), so this is good to go IMHO. Otherwise, we switch all "modern" Sonys to vendor metadata crop...