### PR TITLE
Apple MakerNotes parsing support

### DIFF
--- a/src/librawspeed/tiff/TiffIFD.cpp
+++ b/src/librawspeed/tiff/TiffIFD.cpp
@@ -80,7 +80,7 @@ void TiffIFD::parseIFDEntry(NORangesSet<Buffer>* ifds, ByteStream& bs) {
       break;
 
     case MAKERNOTE:
-    case MAKERNOTE_ALT:
+    // case MAKERNOTE_ALT:
       add(parseMakerNote(ifds, t.get()));
       break;
 
@@ -194,6 +194,8 @@ TiffRootIFDOwner TiffIFD::parseMakerNote(NORangesSet<Buffer>* ifds,
     setup(true, 16);
   } else if (bs.hasPrefix("EPSON")) {
     setup(false, 8);
+  } else if (bs.hasPrefix("Apple iOS")) {
+    setup(true, 14, 12, "Apple makernote");
   } else if (bs.hasPatternAt("Exif", 6)) {
     // TODO: for none of the rawsamples.ch files from Panasonic is this true,
     // instead their MakerNote start with "Panasonic" Panasonic has the word


### PR DESCRIPTION
Saves significant load time by skipping the erroneous scanning of 16752 ("Ap" = 0x4170) entries otherwise.

WIP: there is a 0x2e entry in the Apple makernotes that now clashes w/ the (Panasonic?) MAKERNOTE_ALT. Don't seem to have access to `make` at that point, so not sure how to best handle this? @LebedevRI 

It might in general be a good idea to add a mechanism to bail out of trying to parse some known unsupported makernotes earlier? Another example: Google's are not in the IFD format, but we try parsing 17480 ("DH" = 0x4448) entries anyway.