### PR TITLE
BitStreamer: some bit streams have favorable bit flow

### DIFF
--- a/src/librawspeed/bitstreams/BitStreamJPEG.h
+++ b/src/librawspeed/bitstreams/BitStreamJPEG.h
@@ -38,6 +38,8 @@ template <> struct BitStreamTraits<BitStreamJPEG> final {
   using ChunkType = uint32_t;
 
   static constexpr Endianness ChunkEndianness = Endianness::big;
+
+  static constexpr int MinLoadStepByteMultiple = 1;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamLSB.h
+++ b/src/librawspeed/bitstreams/BitStreamLSB.h
@@ -38,6 +38,8 @@ template <> struct BitStreamTraits<BitStreamLSB> final {
   using ChunkType = uint32_t;
 
   static constexpr Endianness ChunkEndianness = Endianness::little;
+
+  static constexpr int MinLoadStepByteMultiple = 1;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamMSB.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB.h
@@ -38,6 +38,8 @@ template <> struct BitStreamTraits<BitStreamMSB> final {
   using ChunkType = uint32_t;
 
   static constexpr Endianness ChunkEndianness = Endianness::big;
+
+  static constexpr int MinLoadStepByteMultiple = 1;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamMSB16.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB16.h
@@ -38,6 +38,8 @@ template <> struct BitStreamTraits<BitStreamMSB16> final {
   using ChunkType = uint16_t;
 
   static constexpr Endianness ChunkEndianness = Endianness::little;
+
+  static constexpr int MinLoadStepByteMultiple = 2;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamMSB32.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB32.h
@@ -38,6 +38,8 @@ template <> struct BitStreamTraits<BitStreamMSB32> final {
   using ChunkType = uint32_t;
 
   static constexpr Endianness ChunkEndianness = Endianness::little;
+
+  static constexpr int MinLoadStepByteMultiple = 4;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamer.h
+++ b/src/librawspeed/bitstreams/BitStreamer.h
@@ -42,6 +42,9 @@ template <typename BIT_STREAM> struct BitStreamerTraits;
 template <typename Tag> struct BitStreamerReplenisherBase {
   using size_type = int32_t;
 
+  using Traits = BitStreamerTraits<Tag>;
+  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
+
   Array1DRef<const std::byte> input;
   int pos = 0;
 
@@ -62,6 +65,7 @@ BitStreamerReplenisherBase<Tag>::establishClassInvariants() const noexcept {
   input.establishClassInvariants();
   invariant(input.size() >= BitStreamerTraits<Tag>::MaxProcessBytes);
   invariant(pos >= 0);
+  invariant(pos % StreamTraits::MinLoadStepByteMultiple == 0);
   // `pos` *could* be out-of-bounds of `input`.
 }
 
@@ -69,6 +73,8 @@ template <typename Tag>
 struct BitStreamerForwardSequentialReplenisher final
     : public BitStreamerReplenisherBase<Tag> {
   using Base = BitStreamerReplenisherBase<Tag>;
+  using Traits = BitStreamerTraits<Tag>;
+  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
 
   using Base::BitStreamerReplenisherBase;
 
@@ -86,6 +92,7 @@ struct BitStreamerForwardSequentialReplenisher final
     Base::establishClassInvariants();
     invariant(numBytes >= 0);
     invariant(numBytes != 0);
+    invariant(numBytes % StreamTraits::MinLoadStepByteMultiple == 0);
     Base::pos += numBytes;
   }
 

--- a/test/librawspeed/bitstreams/BitVacuumerLSBTest.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerLSBTest.cpp
@@ -202,6 +202,54 @@ TEST_P(BitVacuumerLSBTest, Dissolution) {
   }
 }
 
+TEST(BitVacuumerLSBTest, LoadPos) {
+  std::vector<uint8_t> bitstream;
+
+  constexpr int numByteElts = 64;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerLSB<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts; ++e)
+      bv.put(e, 8);
+  }
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  using BitStreamer = BitStreamerLSB;
+  using BitStreamerTraits = BitStreamer::Traits;
+  using BitStreamTraits = BitStreamer::StreamTraits;
+
+  for (int fillLevel : {8, 32}) {
+    for (int baseLoadPosStep = 1;
+         baseLoadPosStep <= 2 * BitStreamTraits::MinLoadStepByteMultiple;
+         ++baseLoadPosStep) {
+      for (int baseLoadPos = 0;
+           baseLoadPos <= numByteElts - BitStreamerTraits::MaxProcessBytes;
+           baseLoadPos += baseLoadPosStep) {
+        auto input =
+            fullInput.getCrop(baseLoadPos, fullInput.size() - baseLoadPos)
+                .getAsArray1DRef();
+        auto bs = BitStreamer(input);
+        for (int i = 0; i != input.size(); ++i) {
+          const auto expectedVal = baseLoadPos + i;
+          bs.fill(fillLevel);
+          const auto actualVal = bs.getBitsNoFill(8);
+          if (baseLoadPosStep % BitStreamTraits::MinLoadStepByteMultiple == 0 ||
+              baseLoadPos % BitStreamTraits::MinLoadStepByteMultiple == 0) {
+            ASSERT_THAT(actualVal, expectedVal);
+          } else {
+            ASSERT_NE(actualVal, expectedVal);
+          }
+        }
+      }
+    }
+  }
+}
+
 } // namespace
 
 } // namespace rawspeed

--- a/test/librawspeed/bitstreams/BitVacuumerMSB32Test.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerMSB32Test.cpp
@@ -202,6 +202,54 @@ TEST_P(BitVacuumerMSB32Test, Dissolution) {
   }
 }
 
+TEST(BitVacuumerMSB32Test, LoadPos) {
+  std::vector<uint8_t> bitstream;
+
+  constexpr int numByteElts = 64;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerMSB32<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts; ++e)
+      bv.put(e, 8);
+  }
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  using BitStreamer = BitStreamerMSB32;
+  using BitStreamerTraits = BitStreamer::Traits;
+  using BitStreamTraits = BitStreamer::StreamTraits;
+
+  for (int fillLevel : {8, 32}) {
+    for (int baseLoadPosStep = 1;
+         baseLoadPosStep <= 2 * BitStreamTraits::MinLoadStepByteMultiple;
+         ++baseLoadPosStep) {
+      for (int baseLoadPos = 0;
+           baseLoadPos <= numByteElts - BitStreamerTraits::MaxProcessBytes;
+           baseLoadPos += baseLoadPosStep) {
+        auto input =
+            fullInput.getCrop(baseLoadPos, fullInput.size() - baseLoadPos)
+                .getAsArray1DRef();
+        auto bs = BitStreamer(input);
+        for (int i = 0; i != input.size(); ++i) {
+          const auto expectedVal = baseLoadPos + i;
+          bs.fill(fillLevel);
+          const auto actualVal = bs.getBitsNoFill(8);
+          if (baseLoadPosStep % BitStreamTraits::MinLoadStepByteMultiple == 0 ||
+              baseLoadPos % BitStreamTraits::MinLoadStepByteMultiple == 0) {
+            ASSERT_THAT(actualVal, expectedVal);
+          } else {
+            ASSERT_NE(actualVal, expectedVal);
+          }
+        }
+      }
+    }
+  }
+}
+
 } // namespace
 
 } // namespace rawspeed

--- a/test/librawspeed/bitstreams/BitVacuumerMSBTest.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerMSBTest.cpp
@@ -202,6 +202,54 @@ TEST_P(BitVacuumerMSBTest, Dissolution) {
   }
 }
 
+TEST(BitVacuumerMSBTest, LoadPos) {
+  std::vector<uint8_t> bitstream;
+
+  constexpr int numByteElts = 64;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerMSB<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts; ++e)
+      bv.put(e, 8);
+  }
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  using BitStreamer = BitStreamerMSB;
+  using BitStreamerTraits = BitStreamer::Traits;
+  using BitStreamTraits = BitStreamer::StreamTraits;
+
+  for (int fillLevel : {8, 32}) {
+    for (int baseLoadPosStep = 1;
+         baseLoadPosStep <= 2 * BitStreamTraits::MinLoadStepByteMultiple;
+         ++baseLoadPosStep) {
+      for (int baseLoadPos = 0;
+           baseLoadPos <= numByteElts - BitStreamerTraits::MaxProcessBytes;
+           baseLoadPos += baseLoadPosStep) {
+        auto input =
+            fullInput.getCrop(baseLoadPos, fullInput.size() - baseLoadPos)
+                .getAsArray1DRef();
+        auto bs = BitStreamer(input);
+        for (int i = 0; i != input.size(); ++i) {
+          const auto expectedVal = baseLoadPos + i;
+          bs.fill(fillLevel);
+          const auto actualVal = bs.getBitsNoFill(8);
+          if (baseLoadPosStep % BitStreamTraits::MinLoadStepByteMultiple == 0 ||
+              baseLoadPos % BitStreamTraits::MinLoadStepByteMultiple == 0) {
+            ASSERT_THAT(actualVal, expectedVal);
+          } else {
+            ASSERT_NE(actualVal, expectedVal);
+          }
+        }
+      }
+    }
+  }
+}
+
 } // namespace
 
 } // namespace rawspeed


### PR DESCRIPTION
The underlying byte buffer, from which we then read the `BitStreamLSB` and `BitStreamMSB` bit streams, can be advanced by any number of bytes and that
results in equivalent number of bits skipped
in the actual parsed bit stream.

However, the `BitStreamMSB16` and `BitStreamMSB32` aren't so lucky, and theirs underlying byte stream must be slided by their chunk size...