### PR TITLE
Invent roundripping between `BitStreamer` state and byte stream position

### DIFF
--- a/bench/librawspeed/decompressors/UncompressedDecompressorBenchmark.cpp
+++ b/bench/librawspeed/decompressors/UncompressedDecompressorBenchmark.cpp
@@ -22,6 +22,7 @@
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "bench/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "io/Buffer.h"

--- a/cmake/Modules/cpu-cache-line-size.cpp
+++ b/cmake/Modules/cpu-cache-line-size.cpp
@@ -1,9 +1,14 @@
+#include <cerrno>
 #include <cstdint>
 #include <iostream>
 #include <optional>
 
 #if defined(__unix__)
 #include <unistd.h>
+#endif
+
+#if defined(__GLIBC__)
+#include <elf.h>
 #endif
 
 #if defined(_POSIX_C_SOURCE) && defined(_SC_LEVEL1_DCACHE_LINESIZE)

--- a/cmake/Modules/cpu-large-page-size.cpp
+++ b/cmake/Modules/cpu-large-page-size.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <iostream>
 
 #if defined(__i386__) || defined(__x86_64__)

--- a/fuzz/librawspeed/decompressors/UncompressedDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/UncompressedDecompressor.cpp
@@ -54,6 +54,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
       case static_cast<int>(rawspeed::BitOrder::MSB):
       case static_cast<int>(rawspeed::BitOrder::MSB16):
       case static_cast<int>(rawspeed::BitOrder::MSB32):
+      case static_cast<int>(rawspeed::BitOrder::JPEG):
         return rawspeed::BitOrder(val);
       default:
         ThrowRSE("Unknown bit order: %u", val);

--- a/fuzz/librawspeed/decompressors/UncompressedDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/UncompressedDecompressor.cpp
@@ -22,7 +22,7 @@
 #include "MemorySanitizer.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "common/RawspeedException.h"
 #include "fuzz/Common.h"

--- a/src/librawspeed/bitstreams/BitStream.h
+++ b/src/librawspeed/bitstreams/BitStream.h
@@ -25,11 +25,12 @@
 #include "adt/Bit.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
+#include "bitstreams/BitStreams.h"
 #include <cstdint>
 
 namespace rawspeed {
 
-template <typename BIT_STREAM> struct BitStreamTraits;
+template <BitOrder bo> struct BitStreamTraits;
 
 // simple 64-bit wide cache implementation that acts like a FiFo.
 // There are two variants:

--- a/src/librawspeed/bitstreams/BitStreamJPEG.h
+++ b/src/librawspeed/bitstreams/BitStreamJPEG.h
@@ -28,9 +28,9 @@
 
 namespace rawspeed {
 
-class BitStreamJPEG;
+template <> struct BitStreamTraits<BitOrder::JPEG> final {
+  static constexpr BitOrder Tag = BitOrder::JPEG;
 
-template <> struct BitStreamTraits<BitStreamJPEG> final {
   using StreamFlow = BitStreamCacheRightInLeftOut;
 
   static constexpr bool FixedSizeChunks = false; // Stuffing byte...

--- a/src/librawspeed/bitstreams/BitStreamLSB.h
+++ b/src/librawspeed/bitstreams/BitStreamLSB.h
@@ -28,9 +28,9 @@
 
 namespace rawspeed {
 
-class BitStreamLSB;
+template <> struct BitStreamTraits<BitOrder::LSB> final {
+  static constexpr BitOrder Tag = BitOrder::LSB;
 
-template <> struct BitStreamTraits<BitStreamLSB> final {
   using StreamFlow = BitStreamCacheLeftInRightOut;
 
   static constexpr bool FixedSizeChunks = true;

--- a/src/librawspeed/bitstreams/BitStreamMSB.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB.h
@@ -28,9 +28,9 @@
 
 namespace rawspeed {
 
-class BitStreamMSB;
+template <> struct BitStreamTraits<BitOrder::MSB> final {
+  static constexpr BitOrder Tag = BitOrder::MSB;
 
-template <> struct BitStreamTraits<BitStreamMSB> final {
   using StreamFlow = BitStreamCacheRightInLeftOut;
 
   static constexpr bool FixedSizeChunks = true;

--- a/src/librawspeed/bitstreams/BitStreamMSB16.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB16.h
@@ -28,9 +28,9 @@
 
 namespace rawspeed {
 
-class BitStreamMSB16;
+template <> struct BitStreamTraits<BitOrder::MSB16> final {
+  static constexpr BitOrder Tag = BitOrder::MSB16;
 
-template <> struct BitStreamTraits<BitStreamMSB16> final {
   using StreamFlow = BitStreamCacheRightInLeftOut;
 
   static constexpr bool FixedSizeChunks = true;

--- a/src/librawspeed/bitstreams/BitStreamMSB32.h
+++ b/src/librawspeed/bitstreams/BitStreamMSB32.h
@@ -28,9 +28,9 @@
 
 namespace rawspeed {
 
-class BitStreamMSB32;
+template <> struct BitStreamTraits<BitOrder::MSB32> final {
+  static constexpr BitOrder Tag = BitOrder::MSB32;
 
-template <> struct BitStreamTraits<BitStreamMSB32> final {
   using StreamFlow = BitStreamCacheRightInLeftOut;
 
   static constexpr bool FixedSizeChunks = true;

--- a/src/librawspeed/bitstreams/BitStreamPosition.h
+++ b/src/librawspeed/bitstreams/BitStreamPosition.h
@@ -1,0 +1,78 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2024 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "adt/Casts.h"
+#include "adt/Invariant.h"
+#include "bitstreams/BitStreams.h"
+#include "common/Common.h"
+
+namespace rawspeed {
+
+template <BitOrder bo> struct BitStreamTraits;
+
+template <BitOrder bo> struct BitStreamPosition {
+  int pos;
+  int fillLevel;
+};
+
+template <BitOrder bo> struct ByteStreamPosition {
+  int bytePos;
+  int numBitsToSkip;
+};
+
+template <BitOrder bo>
+  requires BitStreamTraits<bo>::FixedSizeChunks
+ByteStreamPosition<bo> getAsByteStreamPosition(BitStreamPosition<bo> state) {
+  const int MinByteStepMultiple = BitStreamTraits<bo>::MinLoadStepByteMultiple;
+
+  invariant(state.pos >= 0);
+  invariant(state.pos % MinByteStepMultiple == 0);
+  invariant(state.fillLevel >= 0);
+
+  auto numBytesRemainingInCache =
+      implicit_cast<int>(roundUpDivision(state.fillLevel, CHAR_BIT));
+  invariant(numBytesRemainingInCache >= 0);
+  invariant(numBytesRemainingInCache <= state.pos);
+
+  auto numBytesToBacktrack = implicit_cast<int>(
+      roundUp(numBytesRemainingInCache, MinByteStepMultiple));
+  invariant(numBytesToBacktrack >= 0);
+  invariant(numBytesToBacktrack <= state.pos);
+  invariant(numBytesToBacktrack % MinByteStepMultiple == 0);
+
+  auto numBitsToBacktrack = CHAR_BIT * numBytesToBacktrack;
+  invariant(numBitsToBacktrack >= 0);
+
+  ByteStreamPosition<bo> res;
+  invariant(state.pos >= numBytesToBacktrack);
+  res.bytePos = state.pos - numBytesToBacktrack;
+  invariant(numBitsToBacktrack >= state.fillLevel);
+  res.numBitsToSkip = numBitsToBacktrack - state.fillLevel;
+
+  invariant(res.bytePos >= 0);
+  invariant(res.bytePos <= state.pos);
+  invariant(res.bytePos % MinByteStepMultiple == 0);
+  invariant(res.numBitsToSkip >= 0);
+  return res;
+}
+
+} // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreamer.h
+++ b/src/librawspeed/bitstreams/BitStreamer.h
@@ -278,11 +278,11 @@ public:
     return getBitsNoFill(nbits);
   }
 
-  // This may be used to skip arbitrarily large number of *bytes*,
+  // This may be used to skip arbitrarily large number of *bits*,
   // not limited by the fill level.
-  void skipBytes(int nbytes) {
+  void skipManyBits(int nbits) {
     establishClassInvariants();
-    int remainingBitsToSkip = 8 * nbytes;
+    int remainingBitsToSkip = nbits;
     for (; remainingBitsToSkip >= Cache::MaxGetBits;
          remainingBitsToSkip -= Cache::MaxGetBits) {
       fill(Cache::MaxGetBits);
@@ -292,6 +292,14 @@ public:
       fill(remainingBitsToSkip);
       skipBitsNoFill(remainingBitsToSkip);
     }
+  }
+
+  // This may be used to skip arbitrarily large number of *bytes*,
+  // not limited by the fill level.
+  void skipBytes(int nbytes) {
+    establishClassInvariants();
+    int nbits = 8 * nbytes;
+    skipManyBits(nbits);
   }
 };
 

--- a/src/librawspeed/bitstreams/BitStreamer.h
+++ b/src/librawspeed/bitstreams/BitStreamer.h
@@ -43,7 +43,7 @@ template <typename Tag> struct BitStreamerReplenisherBase {
   using size_type = int32_t;
 
   using Traits = BitStreamerTraits<Tag>;
-  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
+  using StreamTraits = BitStreamTraits<Traits::Tag>;
 
   Array1DRef<const std::byte> input;
   int pos = 0;
@@ -74,7 +74,7 @@ struct BitStreamerForwardSequentialReplenisher final
     : public BitStreamerReplenisherBase<Tag> {
   using Base = BitStreamerReplenisherBase<Tag>;
   using Traits = BitStreamerTraits<Tag>;
-  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
+  using StreamTraits = BitStreamTraits<Traits::Tag>;
 
   using Base::BitStreamerReplenisherBase;
 
@@ -138,7 +138,7 @@ class BitStreamer {
 public:
   using size_type = int32_t;
   using Traits = BitStreamerTraits<Derived>;
-  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
+  using StreamTraits = BitStreamTraits<Traits::Tag>;
 
   using Cache = typename StreamTraits::StreamFlow;
 

--- a/src/librawspeed/bitstreams/BitStreamerJPEG.h
+++ b/src/librawspeed/bitstreams/BitStreamerJPEG.h
@@ -23,12 +23,12 @@
 #include "rawspeedconfig.h"
 #include "adt/Array1DRef.h"
 #include "adt/Bit.h"
+#include "adt/Casts.h"
 #include "adt/Invariant.h"
 #include "bitstreams/BitStream.h"
 #include "bitstreams/BitStreamJPEG.h"
 #include "bitstreams/BitStreamer.h"
 #include "io/Endianness.h"
-#include <algorithm>
 #include <array>
 #include <concepts>
 #include <cstddef>

--- a/src/librawspeed/bitstreams/BitStreamerJPEG.h
+++ b/src/librawspeed/bitstreams/BitStreamerJPEG.h
@@ -68,7 +68,7 @@ public:
 class BitStreamerJPEG;
 
 template <> struct BitStreamerTraits<BitStreamerJPEG> final {
-  using Stream = BitStreamJPEG;
+  static constexpr BitOrder Tag = BitOrder::JPEG;
 
   static constexpr bool canUseWithPrefixCodeDecoder = true;
 

--- a/src/librawspeed/bitstreams/BitStreamerLSB.h
+++ b/src/librawspeed/bitstreams/BitStreamerLSB.h
@@ -29,7 +29,7 @@ namespace rawspeed {
 class BitStreamerLSB;
 
 template <> struct BitStreamerTraits<BitStreamerLSB> final {
-  using Stream = BitStreamLSB;
+  static constexpr BitOrder Tag = BitOrder::LSB;
 
   // How many bytes can we read from the input per each fillCache(), at most?
   static constexpr int MaxProcessBytes = 4;

--- a/src/librawspeed/bitstreams/BitStreamerMSB.h
+++ b/src/librawspeed/bitstreams/BitStreamerMSB.h
@@ -29,7 +29,7 @@ namespace rawspeed {
 class BitStreamerMSB;
 
 template <> struct BitStreamerTraits<BitStreamerMSB> final {
-  using Stream = BitStreamMSB;
+  static constexpr BitOrder Tag = BitOrder::MSB;
 
   static constexpr bool canUseWithPrefixCodeDecoder = true;
 

--- a/src/librawspeed/bitstreams/BitStreamerMSB16.h
+++ b/src/librawspeed/bitstreams/BitStreamerMSB16.h
@@ -29,7 +29,7 @@ namespace rawspeed {
 class BitStreamerMSB16;
 
 template <> struct BitStreamerTraits<BitStreamerMSB16> final {
-  using Stream = BitStreamMSB16;
+  static constexpr BitOrder Tag = BitOrder::MSB16;
 
   // How many bytes can we read from the input per each fillCache(), at most?
   static constexpr int MaxProcessBytes = 4;

--- a/src/librawspeed/bitstreams/BitStreamerMSB32.h
+++ b/src/librawspeed/bitstreams/BitStreamerMSB32.h
@@ -29,7 +29,7 @@ namespace rawspeed {
 class BitStreamerMSB32;
 
 template <> struct BitStreamerTraits<BitStreamerMSB32> final {
-  using Stream = BitStreamMSB32;
+  static constexpr BitOrder Tag = BitOrder::MSB32;
 
   static constexpr bool canUseWithPrefixCodeDecoder = true;
 

--- a/src/librawspeed/bitstreams/BitStreams.h
+++ b/src/librawspeed/bitstreams/BitStreams.h
@@ -31,6 +31,7 @@ enum class BitOrder : uint8_t {
               from top */
   MSB16, /* Same as above, but 16 bits at the time */
   MSB32, /* Same as above, but 32 bits at the time */
+  JPEG,  /* Same as MSB, but 0xFF byte is followed by an 0x00 stuffing byte */
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitStreams.h
+++ b/src/librawspeed/bitstreams/BitStreams.h
@@ -2,7 +2,7 @@
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
-    Copyright (C) 2014 Pedro Côrte-Real
+    Copyright (C) 2024 Roman Lebedev
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -21,37 +21,16 @@
 
 #pragma once
 
-#include "bitstreams/BitStreams.h"
-#include "common/RawImage.h"
-#include "decoders/RawDecoder.h"
 #include <cstdint>
 
 namespace rawspeed {
 
-class Buffer;
-class Camera;
-class CameraMetaData;
-
-class NakedDecoder final : public RawDecoder {
-  const Camera* cam;
-
-  uint32_t width{0};
-  uint32_t height{0};
-  uint32_t filesize{0};
-  uint32_t bits{0};
-  uint32_t offset{0};
-  BitOrder bo{BitOrder::MSB16};
-
-  void parseHints();
-
-public:
-  NakedDecoder(Buffer file, const Camera* c);
-  RawImage decodeRawInternal() override;
-  void checkSupportInternal(const CameraMetaData* meta) override;
-  void decodeMetaDataInternal(const CameraMetaData* meta) override;
-
-private:
-  [[nodiscard]] int getDecoderVersion() const override { return 0; }
+enum class BitOrder : uint8_t {
+  LSB,   /* Memory order */
+  MSB,   /* Input is added to stack byte by byte, and output is lifted
+              from top */
+  MSB16, /* Same as above, but 16 bits at the time */
+  MSB32, /* Same as above, but 32 bits at the time */
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/bitstreams/BitVacuumer.h
+++ b/src/librawspeed/bitstreams/BitVacuumer.h
@@ -37,7 +37,7 @@ template <typename Derived_, typename OutputIterator_>
 class BitVacuumer {
 public:
   using Traits = BitVacuumerTraits<Derived_>;
-  using StreamTraits = BitStreamTraits<typename Traits::Stream>;
+  using StreamTraits = BitStreamTraits<Traits::Tag>;
 
   using Cache = typename StreamTraits::StreamFlow;
 

--- a/src/librawspeed/bitstreams/BitVacuumerJPEG.h
+++ b/src/librawspeed/bitstreams/BitVacuumerJPEG.h
@@ -35,7 +35,7 @@ template <typename OutputIterator> class BitVacuumerJPEG;
 
 template <typename OutputIterator>
 struct BitVacuumerTraits<BitVacuumerJPEG<OutputIterator>> final {
-  using Stream = BitStreamJPEG;
+  static constexpr BitOrder Tag = BitOrder::JPEG;
 
   static constexpr bool canUseWithPrefixCodeEncoder = true;
 };

--- a/src/librawspeed/bitstreams/BitVacuumerLSB.h
+++ b/src/librawspeed/bitstreams/BitVacuumerLSB.h
@@ -29,7 +29,7 @@ template <typename OutputIterator> class BitVacuumerLSB;
 
 template <typename OutputIterator>
 struct BitVacuumerTraits<BitVacuumerLSB<OutputIterator>> final {
-  using Stream = BitStreamLSB;
+  static constexpr BitOrder Tag = BitOrder::LSB;
 };
 
 template <typename OutputIterator>

--- a/src/librawspeed/bitstreams/BitVacuumerMSB.h
+++ b/src/librawspeed/bitstreams/BitVacuumerMSB.h
@@ -29,7 +29,7 @@ template <typename OutputIterator> class BitVacuumerMSB;
 
 template <typename OutputIterator>
 struct BitVacuumerTraits<BitVacuumerMSB<OutputIterator>> final {
-  using Stream = BitStreamMSB;
+  static constexpr BitOrder Tag = BitOrder::MSB;
 
   static constexpr bool canUseWithPrefixCodeEncoder = true;
 };

--- a/src/librawspeed/bitstreams/BitVacuumerMSB16.h
+++ b/src/librawspeed/bitstreams/BitVacuumerMSB16.h
@@ -29,7 +29,7 @@ template <typename OutputIterator> class BitVacuumerMSB16;
 
 template <typename OutputIterator>
 struct BitVacuumerTraits<BitVacuumerMSB16<OutputIterator>> final {
-  using Stream = BitStreamMSB16;
+  static constexpr BitOrder Tag = BitOrder::MSB16;
 };
 
 template <typename OutputIterator>

--- a/src/librawspeed/bitstreams/BitVacuumerMSB32.h
+++ b/src/librawspeed/bitstreams/BitVacuumerMSB32.h
@@ -29,7 +29,7 @@ template <typename OutputIterator> class BitVacuumerMSB32;
 
 template <typename OutputIterator>
 struct BitVacuumerTraits<BitVacuumerMSB32<OutputIterator>> final {
-  using Stream = BitStreamMSB32;
+  static constexpr BitOrder Tag = BitOrder::MSB32;
 
   static constexpr bool canUseWithPrefixCodeEncoder = true;
 };

--- a/src/librawspeed/bitstreams/CMakeLists.txt
+++ b/src/librawspeed/bitstreams/CMakeLists.txt
@@ -8,6 +8,7 @@ FILE(GLOB SOURCES
   "BitStreamMSB.h"
   "BitStreamMSB16.h"
   "BitStreamMSB32.h"
+  "BitStreamPosition.h"
   "BitStreamer.cpp"
   "BitStreamer.h"
   "BitStreamerJPEG.h"

--- a/src/librawspeed/bitstreams/CMakeLists.txt
+++ b/src/librawspeed/bitstreams/CMakeLists.txt
@@ -15,6 +15,7 @@ FILE(GLOB SOURCES
   "BitStreamerMSB.h"
   "BitStreamerMSB16.h"
   "BitStreamerMSB32.h"
+  "BitStreams.h"
   "BitVacuumer.h"
   "BitVacuumerJPEG.h"
   "BitVacuumerLSB.h"

--- a/src/librawspeed/common/Common.h
+++ b/src/librawspeed/common/Common.h
@@ -199,12 +199,4 @@ inline std::array<T, N> to_array(const std::vector<T>& v) {
   return a;
 }
 
-enum class BitOrder : uint8_t {
-  LSB,   /* Memory order */
-  MSB,   /* Input is added to stack byte by byte, and output is lifted
-                     from top */
-  MSB16, /* Same as above, but 16 bits at the time */
-  MSB32, /* Same as above, but 32 bits at the time */
-};
-
 } // namespace rawspeed

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -26,6 +26,7 @@
 #include "adt/Invariant.h"
 #include "adt/NORangesSet.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "common/RawspeedException.h"

--- a/src/librawspeed/decoders/DcsDecoder.cpp
+++ b/src/librawspeed/decoders/DcsDecoder.cpp
@@ -21,7 +21,7 @@
 
 #include "decoders/DcsDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decoders/SimpleTiffDecoder.h"

--- a/src/librawspeed/decoders/ErfDecoder.cpp
+++ b/src/librawspeed/decoders/ErfDecoder.cpp
@@ -21,7 +21,7 @@
 
 #include "decoders/ErfDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decoders/SimpleTiffDecoder.h"

--- a/src/librawspeed/decoders/KdcDecoder.cpp
+++ b/src/librawspeed/decoders/KdcDecoder.cpp
@@ -23,7 +23,7 @@
 #include "adt/Casts.h"
 #include "adt/NORangesSet.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/UncompressedDecompressor.h"

--- a/src/librawspeed/decoders/MefDecoder.cpp
+++ b/src/librawspeed/decoders/MefDecoder.cpp
@@ -21,7 +21,7 @@
 
 #include "decoders/MefDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decoders/SimpleTiffDecoder.h"

--- a/src/librawspeed/decoders/MosDecoder.cpp
+++ b/src/librawspeed/decoders/MosDecoder.cpp
@@ -22,6 +22,7 @@
 #include "decoders/MosDecoder.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/AbstractTiffDecoder.h"

--- a/src/librawspeed/decoders/MrwDecoder.cpp
+++ b/src/librawspeed/decoders/MrwDecoder.cpp
@@ -22,7 +22,7 @@
 
 #include "decoders/MrwDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/UncompressedDecompressor.h"

--- a/src/librawspeed/decoders/NakedDecoder.cpp
+++ b/src/librawspeed/decoders/NakedDecoder.cpp
@@ -22,7 +22,7 @@
 #include "decoders/NakedDecoder.h"
 #include "adt/Optional.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoder.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decoders/NefDecoder.cpp
+++ b/src/librawspeed/decoders/NefDecoder.cpp
@@ -26,6 +26,7 @@
 #include "adt/Casts.h"
 #include "adt/Point.h"
 #include "bitstreams/BitStreamerMSB.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -27,6 +27,7 @@
 #include "adt/NORangesSet.h"
 #include "adt/Point.h"
 #include "bitstreams/BitStreamerMSB.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Casts.h"
 #include "adt/Optional.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -24,7 +24,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/FujiDecompressor.h"

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -25,6 +25,7 @@
 #include "adt/Array2DRef.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decompressors/UncompressedDecompressor.h"

--- a/src/librawspeed/decoders/RawDecoder.h
+++ b/src/librawspeed/decoders/RawDecoder.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "io/Buffer.h"
 #include "metadata/Camera.h"

--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -23,6 +23,7 @@
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decoders/SrwDecoder.cpp
+++ b/src/librawspeed/decoders/SrwDecoder.cpp
@@ -21,7 +21,7 @@
 
 #include "decoders/SrwDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/SamsungV0Decompressor.h"
 #include "decompressors/SamsungV1Decompressor.h"

--- a/src/librawspeed/decoders/StiDecoder.cpp
+++ b/src/librawspeed/decoders/StiDecoder.cpp
@@ -20,7 +20,7 @@
 
 #include "decoders/StiDecoder.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/HasselbladLJpegDecoder.h"

--- a/src/librawspeed/decoders/ThreefrDecoder.cpp
+++ b/src/librawspeed/decoders/ThreefrDecoder.cpp
@@ -22,7 +22,7 @@
 #include "decoders/ThreefrDecoder.h"
 #include "adt/Casts.h"
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"
 #include "decompressors/HasselbladLJpegDecoder.h"

--- a/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
@@ -25,6 +25,7 @@
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
 #include "adt/Point.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/RawImage.h"
 #include "decoders/RawDecoderException.h"

--- a/src/librawspeed/decompressors/LJpegDecoder.h
+++ b/src/librawspeed/decompressors/LJpegDecoder.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "adt/Point.h"
 #include "decompressors/AbstractLJpegDecoder.h"
 #include <cstdint>
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "adt/Array1DRef.h"
+#include "adt/Array2DRef.h"
 #include "adt/Point.h"
 #include "bitstreams/BitStreamerJPEG.h"
 #include "codes/PrefixCodeDecoder.h"

--- a/src/librawspeed/decompressors/UncompressedDecompressor.cpp
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.cpp
@@ -29,6 +29,7 @@
 #include "bitstreams/BitStreamerMSB.h"
 #include "bitstreams/BitStreamerMSB16.h"
 #include "bitstreams/BitStreamerMSB32.h"
+#include "bitstreams/BitStreams.h"
 #include "common/Common.h"
 #include "common/FloatingPoint.h"
 #include "common/RawImage.h"

--- a/src/librawspeed/decompressors/UncompressedDecompressor.cpp
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.cpp
@@ -116,6 +116,16 @@ UncompressedDecompressor::UncompressedDecompressor(
   if (inputPitchBytes < 1)
     ThrowRDE("Input pitch is non-positive");
 
+  switch (order) {
+  case BitOrder::LSB:
+  case BitOrder::MSB:
+  case BitOrder::MSB16:
+  case BitOrder::MSB32:
+    break;
+  case BitOrder::JPEG:
+    ThrowRDE("JPEG bit order not supported.");
+  }
+
   uint32_t w = size.x;
   uint32_t h = size.y;
   uint32_t cpp = mRaw->getCpp();

--- a/src/librawspeed/decompressors/UncompressedDecompressor.h
+++ b/src/librawspeed/decompressors/UncompressedDecompressor.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "adt/Point.h"
-#include "common/Common.h"
+#include "bitstreams/BitStreams.h"
 #include "common/RawImage.h"
 #include "decompressors/AbstractDecompressor.h"
 #include "io/ByteStream.h"

--- a/test/librawspeed/bitstreams/BitVacuumerMSB16Test.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerMSB16Test.cpp
@@ -20,9 +20,13 @@
 
 #include "bitstreams/BitVacuumerMSB16.h"
 #include "adt/Array1DRef.h"
+#include "adt/Bit.h"
 #include "adt/Casts.h"
 #include "adt/PartitioningOutputIterator.h"
+#include "bitstreams/BitStreamPosition.h"
 #include "bitstreams/BitStreamerMSB16.h"
+#include "common/Common.h"
+#include <climits>
 #include <cstdint>
 #include <iterator>
 #include <utility>
@@ -243,6 +247,62 @@ TEST(BitVacuumerMSB16Test, LoadPos) {
           }
         }
       }
+    }
+  }
+}
+
+TEST(BitVacuumerMSB16Test, DependencyBreaking) {
+  std::vector<uint8_t> bitstream;
+
+  using BitStreamer = BitStreamerMSB16;
+  using BitStreamerTraits = BitStreamer::Traits;
+
+  constexpr int numByteElts = 256;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerMSB16<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts + BitStreamerTraits::MaxProcessBytes; ++e)
+      bv.put(e, 8);
+  }
+  constexpr int numBitsTotal = CHAR_BIT * numByteElts;
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  for (int numBitsToSkip = 0; numBitsToSkip <= numBitsTotal; ++numBitsToSkip) {
+    const int numBitsRemaining = numBitsTotal - numBitsToSkip;
+    auto bsRef = BitStreamer(fullInput);
+    bsRef.fill();
+    bsRef.skipManyBits(numBitsToSkip);
+
+    BitStreamPosition<BitStreamerTraits::Tag> state;
+    state.pos = bsRef.getInputPosition();
+    state.fillLevel = bsRef.getFillLevel();
+    const auto bsPos = getAsByteStreamPosition(state);
+
+    auto rebasedInput =
+        fullInput.getCrop(bsPos.bytePos, fullInput.size() - bsPos.bytePos)
+            .getAsArray1DRef();
+    auto bsRebased = BitStreamer(rebasedInput);
+    if (bsPos.numBitsToSkip != 0)
+      bsRebased.skipBits(bsPos.numBitsToSkip);
+
+    int numSubByteBitsRemaining = numBitsRemaining % CHAR_BIT;
+    int numBytesRemaining = numBitsRemaining / CHAR_BIT;
+    if (numSubByteBitsRemaining != 0) {
+      const auto expectedVal = extractLowBits<unsigned>(
+          numBitsToSkip / CHAR_BIT, numSubByteBitsRemaining);
+      ASSERT_THAT(bsRef.getBits(numSubByteBitsRemaining), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(numSubByteBitsRemaining), expectedVal);
+    }
+
+    for (int i = 0; i != numBytesRemaining; ++i) {
+      const auto expectedVal = roundUpDivision(numBitsToSkip, CHAR_BIT) + i;
+      ASSERT_THAT(bsRef.getBits(8), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(8), expectedVal);
     }
   }
 }

--- a/test/librawspeed/bitstreams/BitVacuumerMSB32Test.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerMSB32Test.cpp
@@ -20,9 +20,13 @@
 
 #include "bitstreams/BitVacuumerMSB32.h"
 #include "adt/Array1DRef.h"
+#include "adt/Bit.h"
 #include "adt/Casts.h"
 #include "adt/PartitioningOutputIterator.h"
+#include "bitstreams/BitStreamPosition.h"
 #include "bitstreams/BitStreamerMSB32.h"
+#include "common/Common.h"
+#include <climits>
 #include <cstdint>
 #include <iterator>
 #include <utility>
@@ -246,6 +250,62 @@ TEST(BitVacuumerMSB32Test, LoadPos) {
           }
         }
       }
+    }
+  }
+}
+
+TEST(BitVacuumerMSB32Test, DependencyBreaking) {
+  std::vector<uint8_t> bitstream;
+
+  using BitStreamer = BitStreamerMSB32;
+  using BitStreamerTraits = BitStreamer::Traits;
+
+  constexpr int numByteElts = 256;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerMSB32<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts + BitStreamerTraits::MaxProcessBytes; ++e)
+      bv.put(e, 8);
+  }
+  constexpr int numBitsTotal = CHAR_BIT * numByteElts;
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  for (int numBitsToSkip = 0; numBitsToSkip <= numBitsTotal; ++numBitsToSkip) {
+    const int numBitsRemaining = numBitsTotal - numBitsToSkip;
+    auto bsRef = BitStreamer(fullInput);
+    bsRef.fill();
+    bsRef.skipManyBits(numBitsToSkip);
+
+    BitStreamPosition<BitStreamerTraits::Tag> state;
+    state.pos = bsRef.getInputPosition();
+    state.fillLevel = bsRef.getFillLevel();
+    const auto bsPos = getAsByteStreamPosition(state);
+
+    auto rebasedInput =
+        fullInput.getCrop(bsPos.bytePos, fullInput.size() - bsPos.bytePos)
+            .getAsArray1DRef();
+    auto bsRebased = BitStreamer(rebasedInput);
+    if (bsPos.numBitsToSkip != 0)
+      bsRebased.skipBits(bsPos.numBitsToSkip);
+
+    int numSubByteBitsRemaining = numBitsRemaining % CHAR_BIT;
+    int numBytesRemaining = numBitsRemaining / CHAR_BIT;
+    if (numSubByteBitsRemaining != 0) {
+      const auto expectedVal = extractLowBits<unsigned>(
+          numBitsToSkip / CHAR_BIT, numSubByteBitsRemaining);
+      ASSERT_THAT(bsRef.getBits(numSubByteBitsRemaining), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(numSubByteBitsRemaining), expectedVal);
+    }
+
+    for (int i = 0; i != numBytesRemaining; ++i) {
+      const auto expectedVal = roundUpDivision(numBitsToSkip, CHAR_BIT) + i;
+      ASSERT_THAT(bsRef.getBits(8), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(8), expectedVal);
     }
   }
 }

--- a/test/librawspeed/bitstreams/BitVacuumerMSBTest.cpp
+++ b/test/librawspeed/bitstreams/BitVacuumerMSBTest.cpp
@@ -20,9 +20,13 @@
 
 #include "bitstreams/BitVacuumerMSB.h"
 #include "adt/Array1DRef.h"
+#include "adt/Bit.h"
 #include "adt/Casts.h"
 #include "adt/PartitioningOutputIterator.h"
+#include "bitstreams/BitStreamPosition.h"
 #include "bitstreams/BitStreamerMSB.h"
+#include "common/Common.h"
+#include <climits>
 #include <cstdint>
 #include <iterator>
 #include <utility>
@@ -246,6 +250,62 @@ TEST(BitVacuumerMSBTest, LoadPos) {
           }
         }
       }
+    }
+  }
+}
+
+TEST(BitVacuumerMSBTest, DependencyBreaking) {
+  std::vector<uint8_t> bitstream;
+
+  using BitStreamer = BitStreamerMSB;
+  using BitStreamerTraits = BitStreamer::Traits;
+
+  constexpr int numByteElts = 256;
+
+  {
+    auto bsInserter = PartitioningOutputIterator(std::back_inserter(bitstream));
+    using BitVacuumer = BitVacuumerMSB<decltype(bsInserter)>;
+    auto bv = BitVacuumer(bsInserter);
+
+    for (int e = 0; e != numByteElts + BitStreamerTraits::MaxProcessBytes; ++e)
+      bv.put(e, 8);
+  }
+  constexpr int numBitsTotal = CHAR_BIT * numByteElts;
+
+  auto fullInput =
+      Array1DRef(bitstream.data(), implicit_cast<int>(bitstream.size()));
+
+  for (int numBitsToSkip = 0; numBitsToSkip <= numBitsTotal; ++numBitsToSkip) {
+    const int numBitsRemaining = numBitsTotal - numBitsToSkip;
+    auto bsRef = BitStreamer(fullInput);
+    bsRef.fill();
+    bsRef.skipManyBits(numBitsToSkip);
+
+    BitStreamPosition<BitStreamerTraits::Tag> state;
+    state.pos = bsRef.getInputPosition();
+    state.fillLevel = bsRef.getFillLevel();
+    const auto bsPos = getAsByteStreamPosition(state);
+
+    auto rebasedInput =
+        fullInput.getCrop(bsPos.bytePos, fullInput.size() - bsPos.bytePos)
+            .getAsArray1DRef();
+    auto bsRebased = BitStreamer(rebasedInput);
+    if (bsPos.numBitsToSkip != 0)
+      bsRebased.skipBits(bsPos.numBitsToSkip);
+
+    int numSubByteBitsRemaining = numBitsRemaining % CHAR_BIT;
+    int numBytesRemaining = numBitsRemaining / CHAR_BIT;
+    if (numSubByteBitsRemaining != 0) {
+      const auto expectedVal = extractLowBits<unsigned>(
+          numBitsToSkip / CHAR_BIT, numSubByteBitsRemaining);
+      ASSERT_THAT(bsRef.getBits(numSubByteBitsRemaining), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(numSubByteBitsRemaining), expectedVal);
+    }
+
+    for (int i = 0; i != numBytesRemaining; ++i) {
+      const auto expectedVal = roundUpDivision(numBitsToSkip, CHAR_BIT) + i;
+      ASSERT_THAT(bsRef.getBits(8), expectedVal);
+      ASSERT_THAT(bsRebased.getBits(8), expectedVal);
     }
   }
 }


### PR DESCRIPTION
This might be useful for a different `fill()` implementation,
one that does not require previous `cache`,
but instead fully reloads each time.
Or maybe that will be slower.