### PR TITLE
Updated EOS 2000D BlackAreas cameras.xml

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1388,7 +1388,7 @@
 		</CFA>
 		<Crop x="78" y="42" width="-4" height="-6"/>
 		<BlackAreas>
-			<Vertical x="0" width="70"/>
+			<Vertical x="5" width="70"/>
 			<Horizontal y="4" height="30"/>
 		</BlackAreas>
 		<Aliases>


### PR DESCRIPTION
This change solves https://github.com/darktable-org/rawspeed/issues/717 and is cropping out the first 4 columns from left optical black area when the first 4 columns are not black.