### PR TITLE
Correct Phase One P25+ white level

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17085,7 +17085,7 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="34" y="24" width="-12" height="-12"/>
-		<Sensor black="0" white="65535"/>
+		<Sensor black="0" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">2905 732 -237</ColorMatrixRow>


### PR DESCRIPTION
Following up from https://github.com/darktable-org/darktable/issues/16539#issuecomment-2041143375

Use 14b as with other Phase One models.