### PR TITLE
Samsung EX2F: correct white point

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12398,7 +12398,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="22" y="12" width="-148" height="-18"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="4000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">10648 -3897 -1055</ColorMatrixRow>


### PR DESCRIPTION
The old white-point of 4095 yields pink spots in the sky in bright pictures (sample submitted to RPU). This PR reduces the value to 4000, similar to the NX mini.

Slightly higher values may work as well, I don't know how to correctly calibrate that value from an over-exposed image.