### PR TITLE
Leica D-Lux 8 normalization

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17908,6 +17908,9 @@
 	<Camera make="LEICA CAMERA AG" model="LEICA CL" mode="dng">
 		<ID make="Leica" model="CL">LEICA CL</ID>
 	</Camera>
+	<Camera make="LEICA CAMERA AG" model="LEICA D-Lux 8" mode="dng">
+		<ID make="Leica" model="D-Lux 8">LEICA D-Lux 8</ID>
+	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="GR" mode="dng">
 		<ID make="Ricoh" model="GR">GR</ID>
 	</Camera>


### PR DESCRIPTION
Looks like from the D-Lux 8 Leica is switching this series to DNG output option only: https://www.dpreview.com/news/3471020867/leica-continues-compacts-with-d-lux-8-featuring-four-thirds-type-sensor