### PR TITLE
Nikon Z6_3 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4009,6 +4009,24 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON Z6_3" mode="14bit-compressed">
+		<ID make="Nikon" model="Z6_3">Nikon Z 6 3</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="1008" white="15892"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11206 -4286 -941</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4879 12847 2251</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-745 1654 7374</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON Z 7" mode="14bit-compressed">
 		<ID make="Nikon" model="Z 7">Nikon Z 7</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/17075 using ADC 16.4.

Covers traditional lossless only, obviously.