### PR TITLE
Samsung WB2000: correct white point

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12847,7 +12847,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="2" width="-10" height="-2"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="4000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">12093 -3557 -1155</ColorMatrixRow>


### PR DESCRIPTION
The old white-point of 4095 yields pink spots in the sky in bright pictures. This reduces the value to 4000, similarly to the NX mini and the EX2F (537953a71a9284353ae8830e24a4f01b4cdb453f).