### PR TITLE
Sony ZV-E10M2 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14489,8 +14489,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="ZV-E10M2" supported="unknown-no-samples">
+	<Camera make="SONY" model="ZV-E10M2">
 		<ID make="Sony" model="ZV-E10M2">Sony ZV-E10M2</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-28" height="0"/>
+		<Sensor black="512" white="16380"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">6972 -2408 -600</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4330 12101 2515</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-388 1277 5847</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="SONY" model="ILME-FX3">
 		<ID make="Sony" model="ILME-FX3">Sony ILME-FX3</ID>


### PR DESCRIPTION
Confirmed color matrix is identical to FX30 using ADC 16.5

Edit: Addresses https://github.com/darktable-org/darktable/issues/18438