### PR TITLE
Add Panasonic DC-FZ80D/FZ82D/FZ85D aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11311,6 +11311,9 @@
 			<Alias>DC-FZ80</Alias>
 			<Alias>DMC-FZ80</Alias>
 			<Alias>DMC-FZ85</Alias>
+			<Alias>DC-FZ80D</Alias>
+			<Alias>DC-FZ82D</Alias>
+			<Alias>DC-FZ85D</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -11328,6 +11331,9 @@
 			<Alias>DC-FZ80</Alias>
 			<Alias>DMC-FZ80</Alias>
 			<Alias>DMC-FZ85</Alias>
+			<Alias>DC-FZ80D</Alias>
+			<Alias>DC-FZ82D</Alias>
+			<Alias>DC-FZ85D</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Seems to be display & USB port refresh like with other recent "D" models:
https://www.dpreview.com/news/0698534590/panasonic-lumix-fz80d-brings-usb-c-and-new-displays-to-60x-superzoom
https://petapixel.com/2024/07/02/panasonics-new-lumix-fz80d-is-a-480-60x-superzoom-camera/