### PR TITLE
Nikon Z50_2 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4304,8 +4304,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Z50_2" supported="unknown-no-samples">
+	<Camera make="NIKON CORPORATION" model="NIKON Z50_2" mode="14bit-compressed">
 		<ID make="Nikon" model="Z50_2">Nikon Z 50 2</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="1008" white="15892"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11640 -4829 -1079</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-5107 13006 2325</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-972 1711 7380</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON Z fc" mode="14bit-compressed">
 		<ID make="Nikon" model="Z fc">Nikon Z fc</ID>


### PR DESCRIPTION
Confirmed color matrix is identical to Z fc and Z 50 using using ADC 17.0.

Covers traditional 14b lossless only (12b option is dropped), no HE obviously.

Addresses https://github.com/darktable-org/darktable/issues/17966