### PR TITLE
Fujifilm X-M5 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -15925,8 +15925,43 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="X-M5" supported="unknown-no-samples">
+	<Camera make="FUJIFILM" model="X-M5">
 		<ID make="Fujifilm" model="X-M5">Fujifilm X-M5</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Sensor black="1022" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">12836 -5909 -1032</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3087 11132 2236</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-35 872 5330</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="X-M5" mode="compressed">
+		<ID make="Fujifilm" model="X-M5">Fujifilm X-M5</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">GGRGGB</ColorRow>
+			<ColorRow y="1">GGBGGR</ColorRow>
+			<ColorRow y="2">BRGRBG</ColorRow>
+			<ColorRow y="3">GGBGGR</ColorRow>
+			<ColorRow y="4">GGRGGB</ColorRow>
+			<ColorRow y="5">RBGBRG</ColorRow>
+		</CFA2>
+		<Sensor black="1022" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">12836 -5909 -1032</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3087 11132 2236</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-35 872 5330</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-A1">
 		<ID make="Fujifilm" model="X-A1">Fujifilm X-A1</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -15925,6 +15925,9 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="FUJIFILM" model="X-M5" supported="unknown-no-samples">
+		<ID make="Fujifilm" model="X-M5">Fujifilm X-M5</ID>
+	</Camera>
 	<Camera make="FUJIFILM" model="X-A1">
 		<ID make="Fujifilm" model="X-A1">Fujifilm X-A1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
Confirmed color matrix is identical to X-S20 using ADC 17.0

Addresses https://github.com/darktable-org/darktable/issues/17868 (see for samples in absence of RPU)