### PR TITLE
Sony ILCE-1M2 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13897,8 +13897,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="ILCE-1M2" supported="unknown-no-samples">
+	<Camera make="SONY" model="ILCE-1M2">
 		<ID make="Sony" model="ILCE-1M2">Sony ILCE-1M2</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-8" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">8161 -2947 -739</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-4811 12668 2389</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-437 1229 6524</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7">
 		<ID make="Sony" model="ILCE-7">Sony ILCE-7</ID>


### PR DESCRIPTION
Confirmed color matrix is identical to ILCE-1 using ADC 17.1.

Edit: See related issue for samples. Unfortunately the APS-C crop doesn't work out perfectly (like it does for most other models), similarly to [7M4](https://github.com/darktable-org/rawspeed/issues/520).