### PR TITLE
Update Sony ILCE-1M2 color matrix

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13915,9 +13915,9 @@
 		<Sensor black="512" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">8161 -2947 -739</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-4811 12668 2389</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-437 1229 6524</ColorMatrixRow>
+				<ColorMatrixRow plane="0">10279 -3899 -1462</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-7108 16980 -168</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-168 544 6116</ColorMatrixRow>
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>


### PR DESCRIPTION
Changed in ADC 17.2 since https://github.com/darktable-org/rawspeed/pull/768