### PR TITLE
Add Sony ILCE-6100A and ILCE-6400A aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13832,6 +13832,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="-22" height="0"/>
 		<Sensor black="512" white="16383"/>
+		<Aliases>
+			<Alias>ILCE-6400A</Alias>
+		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">7657 -2847 -607</ColorMatrixRow>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13793,6 +13793,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="512" white="16300"/>
+		<Aliases>
+			<Alias>ILCE-6100A</Alias>
+		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">7657 -2847 -607</ColorMatrixRow>


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/18416 and https://github.com/darktable-org/darktable/issues/18776

Color matrix confirmed to be the same as the original model using ADC 17.2