### PR TITLE
Add Panasonic DC-TZ99 and DC-ZS99 aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11741,7 +11741,9 @@
 		<Aliases>
 			<Alias>DC-TZ95</Alias>
 			<Alias>DC-TZ95D</Alias>
+			<Alias>DC-TZ99</Alias>
 			<Alias>DC-ZS80</Alias>
+			<Alias>DC-ZS99</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -11758,7 +11760,9 @@
 		<Aliases>
 			<Alias>DC-TZ95</Alias>
 			<Alias>DC-TZ95D</Alias>
+			<Alias>DC-TZ99</Alias>
 			<Alias>DC-ZS80</Alias>
+			<Alias>DC-ZS99</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
ADC 17.2 confirms these are aliases of ZS80.
```
Exif.Image.Model                             Ascii       8  DC-TZ99
Exif.Image.UniqueCameraModel                 Ascii      18  Panasonic DC-ZS80
Exif.Image.LocalizedCameraModel              Ascii      18  Panasonic DC-TZ99
```
Addresses https://github.com/darktable-org/darktable/issues/18425