### PR TITLE
Correct Fujifilm FinePix X100 CFA pattern

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -15204,12 +15204,12 @@
 	<Camera make="FUJIFILM" model="FinePix X100">
 		<ID make="Fujifilm" model="FinePix X100">Fujifilm FinePix X100</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
+			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
+			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="73" y="1" width="-73" height="-1"/>
+		<Crop x="68" y="0" width="-70" height="0"/>
 		<Sensor black="254" white="4000"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
Manual pattern fudge for odd crop is no longer needed since commit https://github.com/darktable-org/rawspeed/commit/91bcae126127597d6b85691eba482a978ec8d382

Adjust crop to max active area from vendor metadata as well

See https://discuss.pixls.us/t/raw-files-from-fuji-x100-original-bayer-sensor-colors-messed-up-rotated-shifted-swapped/48552/1

Also checked cameras.xml, there are no more instances of odd crop for Fujifilm cameras.