### PR TITLE
Add OM System OM-3

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7358,7 +7358,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="OM Digital Solutions" model="OM-3">
-	  <ID make="OM System" model="OM-3">OM Digital Solutions OM-3</ID>
+		<ID make="OM System" model="OM-3">OM Digital Solutions OM-3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7357,8 +7357,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="OM Digital Solutions" model="OM-3" supported="unknown-no-samples">
-		<ID make="OM System" model="OM-3">OM Digital Solutions OM-3</ID>
+	<Camera make="OM Digital Solutions" model="OM-3">
+	  <ID make="OM System" model="OM-3">OM Digital Solutions OM-3</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="254" white="4095"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">9090 -3591 -756</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3252 11396 2109</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-318 1059 5606</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="OM Digital Solutions" model="OM-5">
 		<ID make="OM System" model="OM-5">OM Digital Solutions OM-5</ID>


### PR DESCRIPTION
Note:

Value same as OM-1 Mark II, checked with Adobe DNG Converter 17.2.

Sample photo:
https://www.dpreview.com/sample-galleries/1564684221/om-system-om-3-sample-gallery/8774082355

```
☁  dngconverter [master] ⚡  exiv2 -pt /P1140053.dng | rg BlackLevel Error: Failed to read Olympus2 IFD Makernote header.
Exif.SubImage1.BlackLevelRepeatDim           Short       2  2 2
Exif.SubImage1.BlackLevel                    Rational    4  65024/256 65280/256 65280/256 65024/256
Exif.SubImage3.BlackLevel                    Rational    3  4675/1 2158/1 0/1
Exif.SubImage4.BlackLevel                    Rational    3  4557/1 6153/1 4260/1
Exif.SubImage5.BlackLevel                    Rational    3  5546/1 6774/1 5570/1
```

```
☁  dngconverter [master] ⚡  exiv2 -pt /P1140053.dng | rg ColorMa Error: Failed to read Olympus2 IFD Makernote header.
Exif.Image.ColorMatrix1                      SRational   9  10602/10000 -5977/10000 574/10000 -3109/10000 11296/10000 2063/10000 2/10000 521/10000 6609/10000
Exif.Image.ColorMatrix2                      SRational   9  9090/10000 -3591/10000 -756/10000 -3252/10000 11396/10000 2109/10000 -318/10000 1059/10000 5606/10000
```