### PR TITLE
Fix CI failing for Linux static analysis (unstable) & macOS homebrew

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -124,6 +124,7 @@ jobs:
                                     cmake \
                                     git \
                                     googletest \
+                                    binutils-gold \
                                     libjpeg-dev \
                                     libpugixml-dev \
                                     libxml2-utils \

--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           set -xe
           brew update --quiet
-          brew tap Homebrew/bundle
           cd "${SRC_DIR}/.ci/"
           brew bundle cleanup --quiet --force
           brew autoremove --quiet


### PR DESCRIPTION
Fix CI failed due to `ld.gold` not found.

Note: `ld.gold` deprecated from GNU binutils

* Debian moves ld.gold from binutils to binutils-gold and flag deprecated:

  https://packages.debian.org/search?suite=trixie&searchon=contents&keywords=ld.gold

* Which the GNU announced in GNU Binutils 2.44 released:

  https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html