### PR TITLE
Preserve CFA pattern for rotated RAFs

### DIFF
--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -244,6 +244,7 @@ void RafDecoder::applyCorrections(const Camera* cam) {
     iPoint2D final_size(rotatedsize, rotatedsize - 1);
     RawImage rotated = RawImage::create(final_size, RawImageType::UINT16, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0, 0), rotated->dim));
+    rotated->cfa = mRaw->cfa;
     rotated->metadata = mRaw->metadata;
     rotated->metadata.fujiRotationPos = rotationPos;
 


### PR DESCRIPTION
Before 91bcae1 the CFA was set after applying corrections, this fixes another fallout on rotated SuperCCD sensors by ensuring it is preserved during corrections.

Apologies again for the lack of testing. 😳 @LebedevRI 

Cf. https://www.reddit.com/r/DarkTable/comments/1jh5gzk/darktable_images_heavily_distortedtinted_after/