### PR TITLE
rawspeed: improve Samsung EX1 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -12510,8 +12510,8 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="2" width="-8" height="-22"/>
-		<Sensor black="0" white="16383"/>
+		<Crop x="0" y="10" width="-52" height="-22"/>
+		<Sensor black="0" white="15600"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
 				<ColorMatrixRow plane="0">8898 -2498 -994</ColorMatrixRow>


### PR DESCRIPTION
The crop range is manually tuned based on actual pictures, the black/white levels are based on dngmeta.sh output.