### PR TITLE
Try to produce SARIF from linux clang

### DIFF
--- a/.ci/clang-sarif-merge.py
+++ b/.ci/clang-sarif-merge.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import functools
+import glob
+import json
+import os
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="merge many clang sarif's")
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        required=True,
+        help="the merged SARIF file",
+    )
+
+    parser.add_argument(
+        "dir",
+        help="Directory containing individual sarif's",
+    )
+
+    return parser
+
+
+def merge_two_sarifs(x, y):
+    assert x.keys() == y.keys()
+    res = dict()
+    for key in x.keys():
+        a = x[key]
+        b = y[key]
+        assert type(a) == type(b)
+        if isinstance(a, str):
+            assert a == b
+            res[key] = a
+        elif isinstance(a, list):
+            res[key] = a + b
+        elif isinstance(a, dict):
+            res[key] = merge_two_sarifs(a, b)
+        else:
+            assert False
+    return res
+
+
+def main():
+    # Parse the command line flags
+    parser = create_parser()
+    args, unknown_args = parser.parse_known_args()
+    assert not unknown_args
+    files = glob.glob(os.path.join(args.dir, "*.json"), recursive=True)
+    datas = []
+    for f in files:
+        with open(f, "r") as f:
+            datas.append(json.load(f))
+    result = dict()
+    if len(datas) > 0:
+        result = functools.reduce(merge_two_sarifs, datas)
+    if "runs" in result:
+        result["runs"] = [functools.reduce(merge_two_sarifs, result["runs"])]
+    with open(args.output, "w") as f:
+        json.dump(result, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/.ci/clang-sarif-wrapper.sh
+++ b/.ci/clang-sarif-wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# set -x
+set +e
+
+SARIFDIR="$1"
+mkdir -p "$SARIFDIR"
+
+shift
+
+INVOCATIONHASH=$(echo "$*" | sha1sum --text - | cut -d' ' -f 1)
+
+LOGNAME="$SARIFDIR/$INVOCATIONHASH.json"
+
+$@ -fdiagnostics-format=sarif -Wno-sarif-format-unstable 2>"$LOGNAME"
+RES=$?
+
+LC=$(wc -l "$LOGNAME" | cut -d' ' -f 1)
+if [ $LC -eq 3 ]; then
+   # Got no warnings.
+   exit $RES
+elif [ $LC -eq 4 ]; then
+   OUT="$(cat "$LOGNAME")"
+   # Drop last line, which is: "$N (warning|error)[s] generated."
+   echo "$OUT" | head -n 2 | tail -n 1 > "$LOGNAME"
+   exit $RES
+else
+   /bin/false # ???
+fi

--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -46,6 +46,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     env:
+      JOB_NAME: linux.${{ inputs.distro }}.${{ inputs.compiler-family }}${{ inputs.compiler-version }}.${{ inputs.flavor }}
       SONAR_SCANNER_VERSION: 5.0.1.3006
     name: ${{ inputs.distro }}.${{ inputs.compiler-family }}${{ inputs.compiler-version }}.${{ inputs.flavor }}
     container:
@@ -137,7 +138,8 @@ jobs:
           fi
           if [ "$COMPILER_FAMILY" = "LLVM" ]; then
             eatmydata apt install clang-${{ inputs.compiler-version }} \
-                                      libomp-${{ inputs.compiler-version }}-dev
+                                  libomp-${{ inputs.compiler-version }}-dev \
+                                  python3
           fi
           if [ "$ENABLE_SAMPLE_BASED_TESTING" = "true" ]; then
             eatmydata apt install zstd
@@ -228,6 +230,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: cpp
+          source-root: ${{ github.workspace }}/rawspeed
       - name: Set up JDK 11 (for SonarCloud static analysis)
         timeout-minutes: 1
         if: inputs.flavor == 'SonarCloudStaticAnalysis' && github.repository == 'darktable-org/rawspeed' && github.event_name != 'pull_request' && github.ref_type == 'branch' && (github.ref_name == 'develop' || github.ref_name == 'stable')
@@ -264,6 +267,7 @@ jobs:
         env:
           CC: ${{ inputs.compiler-CC }}
           CXX: ${{ inputs.compiler-CXX }}
+          FAMILY: ${{ inputs.compiler-family }}
           CLANG_TIDY: ${{ inputs.compiler-CLANG_TIDY }}
           GCOV: ${{ inputs.compiler-GCOV }}
           SRC_DIR: ${{ github.workspace }}/rawspeed
@@ -279,14 +283,15 @@ jobs:
           cmake -E make_directory "${INSTALL_PREFIX}"
           export ECO="${ECO} -DRAWSPEED_REFERENCE_SAMPLE_ARCHIVE=${RPUU_DST}"
           export ECO="${ECO} -DCMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR=${BUILD_DIR}/clang-tidy/"
-          if [ "$FLAVOR" = "ClangTidy" ] || [ "$FLAVOR" = "ClangStaticAnalysis" ] || [ "$FLAVOR" = "ClangCTUStaticAnalysis" ] || [ "$FLAVOR" = "CodeQLAnalysis" ]; then
-            export ECO="${ECO} -DRAWSPEED_ENABLE_WERROR=OFF"
+          if [ "$FAMILY" = "LLVM" ]; then
+            export ECO="${ECO} -DCMAKE_CXX_COMPILER_LAUNCHER='${SRC_DIR}/.ci/clang-sarif-wrapper.sh;${GITHUB_WORKSPACE}/clang_report/'"
           fi
           "${SRC_DIR}/.ci/ci-script.sh"
       - name: Build
         id: build
         timeout-minutes: ${{ inputs.flavor != 'ClangTidy' && (inputs.flavor != 'CodeQLAnalysis' && 7 || 12) || 25 }}
         env:
+          FAMILY: ${{ inputs.compiler-family }}
           SRC_DIR: ${{ github.workspace }}/rawspeed
           BUILD_DIR: ${{ github.workspace }}/rawspeed-build
           INSTALL_PREFIX: ${{ github.workspace }}/rawspeed-install
@@ -295,6 +300,23 @@ jobs:
         run: |
           set -xe
           "${SRC_DIR}/.ci/ci-script.sh"
+      - name: Merge clang SARIF reports
+        if: inputs.compiler-family == 'LLVM' && !cancelled() && steps.build.conclusion != 'skipped'
+        timeout-minutes: 1
+        env:
+          SRC_DIR: ${{ github.workspace }}/rawspeed
+        run: |
+          set -xe
+          "${SRC_DIR}/.ci/clang-sarif-merge.py" --output="${GITHUB_WORKSPACE}/clang_report.json" "${GITHUB_WORKSPACE}/clang_report/"
+          cat "${GITHUB_WORKSPACE}/clang_report.json"
+      - name: Upload results of clang compile [SARIF]
+        timeout-minutes: 1
+        if: inputs.compiler-family == 'LLVM' && !cancelled() && steps.build.conclusion != 'skipped'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "${{ github.workspace }}/clang_report.json"
+          checkout_path: "${{ github.workspace }}/rawspeed"
+          category: ${{ env.JOB_NAME }}
       - name: Test (unit tests)
         timeout-minutes: 1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,9 +31,10 @@ jobs:
       matrix:
         os: [ linux ]
         compiler:
-          - { distro: "debian:trixie-slim", family: GNU,  version: 13, CC: gcc-13,   CXX: g++-13 }
+          # - { distro: "debian:trixie-slim", family: GNU,  version: 13, CC: gcc-13,   CXX: g++-13 }
           - { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
-        flavor: [ ReleaseWithAsserts, Release ]
+        # flavor: [ ReleaseWithAsserts, Release ]
+        flavor: [ Release ]
     uses: ./.github/workflows/CI-linux.yml
     with:
       os: ${{ matrix.os }}
@@ -47,184 +48,184 @@ jobs:
       flavor: ${{ matrix.flavor }}
       enable-sample-based-testing: true
       rpuu-cache-key: ${{ needs.cache-rpuu.outputs.rpuu-cache-key }}
-  linux-legacy:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ linux ]
-        compiler:
-          - { distro: "debian:bookworm-slim", family: GNU,  version: 12, CC: gcc-12,   CXX: g++-12 }
-          - { distro: "debian:trixie-slim",   family: LLVM, version: 17, CC: clang-17, CXX: clang++-17 }
-          - { distro: "debian:bookworm-slim", family: LLVM, version: 16, CC: clang-16, CXX: clang++-16 }
-        flavor: [ ReleaseWithAsserts, Release ]
-    uses: ./.github/workflows/CI-linux.yml
-    with:
-      os: ${{ matrix.os }}
-      distro: ${{ matrix.compiler.distro }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      compiler-GCOV: ${{ matrix.compiler.GCOV }}
-      compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
-      flavor: ${{ matrix.flavor }}
-  linux-static-analysis:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18, CLANG_TIDY: clang-tidy-18 }
-            flavor: ClangTidy
-          - os: linux
-            compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
-            flavor: ClangStaticAnalysis
-          - os: linux
-            compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
-            flavor: ClangCTUStaticAnalysis
-          - os: linux
-            compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
-            flavor: CodeQLAnalysis
-    uses: ./.github/workflows/CI-linux.yml
-    with:
-      os: ${{ matrix.os }}
-      distro: ${{ matrix.compiler.distro }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      compiler-GCOV: ${{ matrix.compiler.GCOV }}
-      compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
-      flavor: ${{ matrix.flavor }}
-  linux-coverage:
-    needs: cache-rpuu
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            compiler: { distro: "debian:trixie-slim", family: GNU, version: 13, CC: gcc-13, CXX: g++-13, GCOV: gcov-13 }
-            flavor: Coverage
-    uses: ./.github/workflows/CI-linux.yml
-    with:
-      os: ${{ matrix.os }}
-      distro: ${{ matrix.compiler.distro }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      compiler-GCOV: ${{ matrix.compiler.GCOV }}
-      compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
-      flavor: ${{ matrix.flavor }}
-      enable-sample-based-testing: true
-      rpuu-cache-key: ${{ needs.cache-rpuu.outputs.rpuu-cache-key }}
-  linux-sonarcloud-static-analysis:
-    if: github.repository == 'darktable-org/rawspeed' && github.event_name != 'pull_request' && github.ref_type == 'branch' && (github.ref_name == 'develop' || github.ref_name == 'stable')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
-            flavor: SonarCloudStaticAnalysis
-    uses: ./.github/workflows/CI-linux.yml
-    with:
-      os: ${{ matrix.os }}
-      distro: ${{ matrix.compiler.distro }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      compiler-GCOV: ${{ matrix.compiler.GCOV }}
-      compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
-      flavor: ${{ matrix.flavor }}
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
-      SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
-  linux-ossfuzz:
-    if: github.repository == 'darktable-org/rawspeed' && (github.event_name == 'pull_request' || (github.ref_type == 'branch' && github.ref_name == 'develop'))
-    strategy:
-      fail-fast: false
-      matrix:
-        sanitizer: [ address, undefined, memory ]
-    uses: ./.github/workflows/CI-ossfuzz.yml
-    with:
-      sanitizer: ${{ matrix.sanitizer }}
-  windows-msys2-fast:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest ]
-        msys2:
-          - { msystem: MINGW64,    arch: x86_64,  family: GNU,  CC: gcc,   CXX: g++ }
-          - { msystem: MINGW32,    arch: i686,    family: GNU,  CC: gcc,   CXX: g++ }
-          - { msystem: CLANG64,    arch: x86_64,  family: LLVM, CC: clang, CXX: clang++ }
-          - { msystem: UCRT64,     arch: x86_64,  family: GNU,  CC: gcc,   CXX: g++ }
-        flavor: [ ReleaseWithAsserts, Release ]
-    uses: ./.github/workflows/CI-windows-msys2.yml
-    with:
-      os: ${{ matrix.os }}
-      msys2-msystem: ${{ matrix.msys2.msystem }}
-      msys2-arch: ${{ matrix.msys2.arch }}
-      compiler-family: ${{ matrix.msys2.family }}
-      compiler-CC: ${{ matrix.msys2.CC }}
-      compiler-CXX: ${{ matrix.msys2.CXX }}
-      flavor: ${{ matrix.flavor }}
-  windows-msys2-coverage:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            msys2: { msystem: UCRT64, arch: x86_64, family: GNU, CC: gcc, CXX: g++ }
-            flavor: Coverage
-    uses: ./.github/workflows/CI-windows-msys2.yml
-    with:
-      os: ${{ matrix.os }}
-      msys2-msystem: ${{ matrix.msys2.msystem }}
-      msys2-arch: ${{ matrix.msys2.arch }}
-      compiler-family: ${{ matrix.msys2.family }}
-      compiler-CC: ${{ matrix.msys2.CC }}
-      compiler-CXX: ${{ matrix.msys2.CXX }}
-      flavor: ${{ matrix.flavor }}
-  macOS-fast:
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler:
-          - { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # AArch64, LLVM16, native
-          - { os: macos-13, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # x86_64,  LLVM16, native
-        flavor: [ ReleaseWithAsserts, Release ]
-    uses: ./.github/workflows/CI-macOS.yml
-    with:
-      os: ${{ matrix.compiler.os }}
-      os-deployment_target: ${{ matrix.compiler.deployment_target }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      flavor: ${{ matrix.flavor }}
-  macOS-coverage:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - compiler: { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # LLVM16, native
-            flavor: Coverage
-    uses: ./.github/workflows/CI-macOS.yml
-    with:
-      os: ${{ matrix.compiler.os }}
-      os-deployment_target: ${{ matrix.compiler.deployment_target }}
-      compiler-family: ${{ matrix.compiler.family }}
-      compiler-version: ${{ matrix.compiler.version }}
-      compiler-CC: ${{ matrix.compiler.CC }}
-      compiler-CXX: ${{ matrix.compiler.CXX }}
-      flavor: ${{ matrix.flavor }}
-  codecov:
-    needs: [ linux-coverage, macOS-coverage, windows-msys2-coverage ]
-    strategy:
-      fail-fast: false
-    uses: ./.github/workflows/CI-codecov.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  # linux-legacy:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ linux ]
+  #       compiler:
+  #         - { distro: "debian:bookworm-slim", family: GNU,  version: 12, CC: gcc-12,   CXX: g++-12 }
+  #         - { distro: "debian:trixie-slim",   family: LLVM, version: 17, CC: clang-17, CXX: clang++-17 }
+  #         - { distro: "debian:bookworm-slim", family: LLVM, version: 16, CC: clang-16, CXX: clang++-16 }
+  #       flavor: [ ReleaseWithAsserts, Release ]
+  #   uses: ./.github/workflows/CI-linux.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     distro: ${{ matrix.compiler.distro }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     compiler-GCOV: ${{ matrix.compiler.GCOV }}
+  #     compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
+  #     flavor: ${{ matrix.flavor }}
+  # linux-static-analysis:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: linux
+  #           compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18, CLANG_TIDY: clang-tidy-18 }
+  #           flavor: ClangTidy
+  #         - os: linux
+  #           compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
+  #           flavor: ClangStaticAnalysis
+  #         - os: linux
+  #           compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
+  #           flavor: ClangCTUStaticAnalysis
+  #         - os: linux
+  #           compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
+  #           flavor: CodeQLAnalysis
+  #   uses: ./.github/workflows/CI-linux.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     distro: ${{ matrix.compiler.distro }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     compiler-GCOV: ${{ matrix.compiler.GCOV }}
+  #     compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
+  #     flavor: ${{ matrix.flavor }}
+  # linux-coverage:
+  #   needs: cache-rpuu
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: linux
+  #           compiler: { distro: "debian:trixie-slim", family: GNU, version: 13, CC: gcc-13, CXX: g++-13, GCOV: gcov-13 }
+  #           flavor: Coverage
+  #   uses: ./.github/workflows/CI-linux.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     distro: ${{ matrix.compiler.distro }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     compiler-GCOV: ${{ matrix.compiler.GCOV }}
+  #     compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
+  #     flavor: ${{ matrix.flavor }}
+  #     enable-sample-based-testing: true
+  #     rpuu-cache-key: ${{ needs.cache-rpuu.outputs.rpuu-cache-key }}
+  # linux-sonarcloud-static-analysis:
+  #   if: github.repository == 'darktable-org/rawspeed' && github.event_name != 'pull_request' && github.ref_type == 'branch' && (github.ref_name == 'develop' || github.ref_name == 'stable')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: linux
+  #           compiler: { distro: "debian:unstable-slim", family: LLVM, version: 18, CC: clang-18, CXX: clang++-18 }
+  #           flavor: SonarCloudStaticAnalysis
+  #   uses: ./.github/workflows/CI-linux.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     distro: ${{ matrix.compiler.distro }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     compiler-GCOV: ${{ matrix.compiler.GCOV }}
+  #     compiler-CLANG_TIDY: ${{ matrix.compiler.CLANG_TIDY }}
+  #     flavor: ${{ matrix.flavor }}
+  #   secrets:
+  #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+  #     SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+  # linux-ossfuzz:
+  #   if: github.repository == 'darktable-org/rawspeed' && (github.event_name == 'pull_request' || (github.ref_type == 'branch' && github.ref_name == 'develop'))
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       sanitizer: [ address, undefined, memory ]
+  #   uses: ./.github/workflows/CI-ossfuzz.yml
+  #   with:
+  #     sanitizer: ${{ matrix.sanitizer }}
+  # windows-msys2-fast:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ windows-latest ]
+  #       msys2:
+  #         - { msystem: MINGW64,    arch: x86_64,  family: GNU,  CC: gcc,   CXX: g++ }
+  #         - { msystem: MINGW32,    arch: i686,    family: GNU,  CC: gcc,   CXX: g++ }
+  #         - { msystem: CLANG64,    arch: x86_64,  family: LLVM, CC: clang, CXX: clang++ }
+  #         - { msystem: UCRT64,     arch: x86_64,  family: GNU,  CC: gcc,   CXX: g++ }
+  #       flavor: [ ReleaseWithAsserts, Release ]
+  #   uses: ./.github/workflows/CI-windows-msys2.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     msys2-msystem: ${{ matrix.msys2.msystem }}
+  #     msys2-arch: ${{ matrix.msys2.arch }}
+  #     compiler-family: ${{ matrix.msys2.family }}
+  #     compiler-CC: ${{ matrix.msys2.CC }}
+  #     compiler-CXX: ${{ matrix.msys2.CXX }}
+  #     flavor: ${{ matrix.flavor }}
+  # windows-msys2-coverage:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: windows-latest
+  #           msys2: { msystem: UCRT64, arch: x86_64, family: GNU, CC: gcc, CXX: g++ }
+  #           flavor: Coverage
+  #   uses: ./.github/workflows/CI-windows-msys2.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     msys2-msystem: ${{ matrix.msys2.msystem }}
+  #     msys2-arch: ${{ matrix.msys2.arch }}
+  #     compiler-family: ${{ matrix.msys2.family }}
+  #     compiler-CC: ${{ matrix.msys2.CC }}
+  #     compiler-CXX: ${{ matrix.msys2.CXX }}
+  #     flavor: ${{ matrix.flavor }}
+  # macOS-fast:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       compiler:
+  #         - { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # AArch64, LLVM16, native
+  #         - { os: macos-13, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # x86_64,  LLVM16, native
+  #       flavor: [ ReleaseWithAsserts, Release ]
+  #   uses: ./.github/workflows/CI-macOS.yml
+  #   with:
+  #     os: ${{ matrix.compiler.os }}
+  #     os-deployment_target: ${{ matrix.compiler.deployment_target }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     flavor: ${{ matrix.flavor }}
+  # macOS-coverage:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - compiler: { os: macos-14, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # LLVM16, native
+  #           flavor: Coverage
+  #   uses: ./.github/workflows/CI-macOS.yml
+  #   with:
+  #     os: ${{ matrix.compiler.os }}
+  #     os-deployment_target: ${{ matrix.compiler.deployment_target }}
+  #     compiler-family: ${{ matrix.compiler.family }}
+  #     compiler-version: ${{ matrix.compiler.version }}
+  #     compiler-CC: ${{ matrix.compiler.CC }}
+  #     compiler-CXX: ${{ matrix.compiler.CXX }}
+  #     flavor: ${{ matrix.flavor }}
+  # codecov:
+  #   needs: [ linux-coverage, macOS-coverage, windows-msys2-coverage ]
+  #   strategy:
+  #     fail-fast: false
+  #   uses: ./.github/workflows/CI-codecov.yml
+  #   secrets:
+  #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/utilities/rsbench/main.cpp
+++ b/src/utilities/rsbench/main.cpp
@@ -197,6 +197,7 @@ void addBench(Entry* entry, std::string tName, int threads) {
 } // namespace
 
 int main(int argc_, char** argv_) {
+  return;
   benchmark::Initialize(&argc_, argv_);
 
   auto argv = rawspeed::Array1DRef(argv_, argc_);

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -545,6 +545,8 @@ using rawspeed::rstest::results;
 using rawspeed::rstest::usage;
 
 int main(int argc_, char** argv_) {
+  return 0;
+
   auto argv = rawspeed::Array1DRef(argv_, argc_);
 
   int remaining_argc = argv.size();


### PR DESCRIPTION
This is just horrible.

There really should be a way to still output the normal textual diagnostics to console,
but additionally place SARIF into a file named after the object file being produced,
into a specified prefix directory.