### PR TITLE
Fujifilm GFX 100S II support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -15482,8 +15482,39 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="FUJIFILM" model="GFX100S II" supported="unknown-no-samples">
-		<ID make="Fujifilm" model="GFX100S II">Fujifilm GFX100S II</ID>
+	<Camera make="FUJIFILM" model="GFX100S II">
+		<ID make="Fujifilm" model="GFX100S II">Fujifilm GFX 100S II</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Sensor black="0" white="0"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">12806 -5779 -1110</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3546 11507 2318</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-177 996 5715</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
+	</Camera>
+	<Camera make="FUJIFILM" model="GFX100S II" mode="compressed">
+		<ID make="Fujifilm" model="GFX100S II">Fujifilm GFX 100S II</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Sensor black="0" white="0"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">12806 -5779 -1110</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3546 11507 2318</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-177 996 5715</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="FUJIFILM" model="GFX100 II">
 		<ID make="Fujifilm" model="GFX100 II">Fujifilm GFX 100 II</ID>


### PR DESCRIPTION
For now, freely downloadable samples from https://www.photographyblog.com/reviews/fujifilm_gfx_100s_ii_review were used for the color matrix data. 

There are no licensing restrictions on the download page, just the wording "We've provided some Fujifilm RAW (RAF) samples for you to download". Obviously, this doesn't prevent me from looking at the metadata of such images.

Yes, this wording is not a proper license and is insufficient for raw.pixls.us, but since @paperdigits now owns such a camera, he can provide the necessary samples. 😀