### PR TITLE
CI: "fix" caching of LFS-based rpu masterset

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           path: 'rawspeed'
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache raw.pixls.us masterset
+      - name: Get cache of raw.pixls.us masterset
         timeout-minutes: 1
         if: inputs.enable-sample-based-testing
         uses: actions/cache/restore@v4
@@ -200,6 +200,17 @@ jobs:
           path: ${{ env.RPUU_DST }}
           key: ${{ inputs.rpuu-cache-key }}
           fail-on-cache-miss: true
+      - name: Checkout raw.pixls.us masterset
+        if: inputs.enable-sample-based-testing
+        timeout-minutes: 1
+        env:
+          RPUU_DST: ${{ env.RPUU_DST }}
+        run: |
+          set -xe
+          eatmydata apt install git-lfs
+          cd ${RPUU_DST}
+          git checkout -f
+          git lfs dedup || /bin/true
       - name: Fetch/Checkout CodeChecker git repo (for clang static analysis)
         timeout-minutes: 1
         if: inputs.flavor == 'ClangTidy' || inputs.flavor == 'ClangStaticAnalysis' || inputs.flavor == 'ClangCTUStaticAnalysis'

--- a/.github/workflows/CI-rpuu.yml
+++ b/.github/workflows/CI-rpuu.yml
@@ -104,6 +104,9 @@ jobs:
           set -xe
           rm -rf ${RPUU_DST}
           git clone https://raw.pixls.us/data-unique.git ${RPUU_DST}
-          cd ${RPUU_DST} && sha256sum -c --strict filelist.sha256
+          cd ${RPUU_DST}
+          sha256sum -c --strict filelist.sha256
+          rm -rf *
+          # avoid doubling the cache size, undo with `git checkout`.
     outputs:
       rpuu-cache-key: ${{ steps.fetch-rpuu-digest.outputs.rpuu-cache-key }}


### PR DESCRIPTION
The cache size doubled once git LFS got used,
because we'd cache both the `.git/lfs/objects/`,
and checked out tree...