### PR TITLE
Included Hasselblad Electronic Shutter mode for CFV aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17915,6 +17915,7 @@
 			<Alias id="X1D II 50C">Hasselblad X1DM2-50c</Alias>
 			<Alias id="CFV II 50C">Hasselblad CFV II 50C</Alias>
 			<Alias id="CFV II 50C">CFV II 50C/907X</Alias>
+			<Alias id="CFV II 50C">CFV II 50C/Electronic Shutter</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
@@ -17938,6 +17939,7 @@
 			<Alias id="X2D 100C">Hasselblad X2D 100C</Alias>
 			<Alias id="CFV 100C">Hasselblad CFV 100C</Alias>
 			<Alias id="CFV 100C">CFV 100C/907X</Alias>
+			<Alias id="CFV 100C">CFV 100C/Electronic Shutter</Alias>
 		</Aliases>
 		<ColorMatrices>
 			<ColorMatrix planes="3">


### PR DESCRIPTION
rawspeed was breaking when a Hasselblad CFV sensor is used in Electronic shutter mode (such as on Flexbody and other cameras without metadata)

This change involved creating two aliases, one for the CFV II 50C and one for the CFV 100C. under the respective camera profiles for X2d etc. I did not add entries for older CFV models since it appears those area already more verbose with specific syncs/camera bodies, and I cannot determine their behaviour readily for electronic shutter in cases not already covered by the Hasselblad firmware.

~H