### PR TITLE
extend Olympus/OM-System raw-decoder to allow 14-bit ORF files also

### DIFF
--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -167,7 +167,6 @@ int OrfDecoder::getBitsPerPixel() const {
   return result;
 }
 
-
 void OrfDecoder::decodeUncompressedInterleaved(ByteStream s, uint32_t w,
                                                uint32_t h,
                                                uint32_t size) const {
@@ -381,7 +380,7 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         // range is the same)
         mRaw->whitePoint =
             *mRaw->whitePoint - (mRaw->blackLevel - blackLevelSeparate1D(0));
-        if ( getBitsPerPixel() == 14 ) {
+        if (getBitsPerPixel() == 14) {
           mRaw->whitePoint = *mRaw->whitePoint * 4;
           mRaw->blackLevel = mRaw->blackLevel * 4;
           for (int i = 0; i < 4; i++) {

--- a/src/librawspeed/decoders/OrfDecoder.cpp
+++ b/src/librawspeed/decoders/OrfDecoder.cpp
@@ -131,6 +131,23 @@ RawImage OrfDecoder::decodeRawInternal() {
     ThrowRDE("%u stripes, and not uncompressed. Unsupported.",
              raw->getEntry(TiffTag::STRIPOFFSETS)->count);
 
+  if (const int bitsPerPixel = getBitsPerPixel(); bitsPerPixel == 12) {
+    input.skipBytes(7);
+  } else if (bitsPerPixel == 14) {
+    input.skipBytes(8);
+  } else {
+    ThrowRDE("%i-bit images are not supported currently.", bitsPerPixel);
+  }
+
+  const OlympusDecompressor o(mRaw);
+  mRaw->createData();
+  o.decompress(input);
+
+  return mRaw;
+}
+
+int OrfDecoder::getBitsPerPixel() const {
+  int result = 12;
   if (mRootIFD->hasEntryRecursive(TiffTag::OLYMPUSIMAGEPROCESSING)) {
     // Newer cameras process the Image Processing SubIFD in the makernote
     const TiffEntry* img_entry =
@@ -144,17 +161,12 @@ RawImage OrfDecoder::decodeRawInternal() {
     if (image_processing.hasEntry(static_cast<TiffTag>(0x0611))) {
       const TiffEntry* validBits =
           image_processing.getEntry(static_cast<TiffTag>(0x0611));
-      if (validBits->getU16() != 12)
-        ThrowRDE("Only 12-bit images are supported currently.");
+      result = validBits->getU16();
     }
   }
-
-  OlympusDecompressor o(mRaw);
-  mRaw->createData();
-  o.decompress(input);
-
-  return mRaw;
+  return result;
 }
+
 
 void OrfDecoder::decodeUncompressedInterleaved(ByteStream s, uint32_t w,
                                                uint32_t h,
@@ -369,6 +381,13 @@ void OrfDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         // range is the same)
         mRaw->whitePoint =
             *mRaw->whitePoint - (mRaw->blackLevel - blackLevelSeparate1D(0));
+        if ( getBitsPerPixel() == 14 ) {
+          mRaw->whitePoint = *mRaw->whitePoint * 4;
+          mRaw->blackLevel = mRaw->blackLevel * 4;
+          for (int i = 0; i < 4; i++) {
+            blackLevelSeparate1D(i) = blackLevelSeparate1D(i) * 4;
+          }
+        }
       }
     }
   }

--- a/src/librawspeed/decoders/OrfDecoder.h
+++ b/src/librawspeed/decoders/OrfDecoder.h
@@ -53,6 +53,8 @@ private:
                                      uint32_t size) const;
   [[nodiscard]] bool decodeUncompressed(ByteStream s, uint32_t w, uint32_t h,
                                         uint32_t size) const;
+
+  [[nodiscard]] int getBitsPerPixel() const;
 };
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/OlympusDecompressor.cpp
+++ b/src/librawspeed/decompressors/OlympusDecompressor.cpp
@@ -207,7 +207,6 @@ void OlympusDecompressorImpl::decompress(ByteStream input) const {
   invariant(mRaw->dim.x > 0);
   invariant(mRaw->dim.x % 2 == 0);
 
-  input.skipBytes(7);
   BitStreamerMSB bits(input.peekRemainingBuffer().getAsArray1DRef());
 
   for (int y = 0; y < mRaw->dim.y; y++)
@@ -227,7 +226,7 @@ OlympusDecompressor::OlympusDecompressor(RawImage img) : mRaw(std::move(img)) {
              mRaw->dim.y);
 }
 
-void OlympusDecompressor::decompress(ByteStream input) const {
+void OlympusDecompressor::decompress(const ByteStream& input) const {
   OlympusDecompressorImpl(mRaw).decompress(input);
 }
 

--- a/src/librawspeed/decompressors/OlympusDecompressor.h
+++ b/src/librawspeed/decompressors/OlympusDecompressor.h
@@ -32,7 +32,7 @@ class OlympusDecompressor final : public AbstractDecompressor {
 
 public:
   explicit OlympusDecompressor(RawImage img);
-  void decompress(ByteStream input) const;
+  void decompress(const ByteStream& input) const;
 };
 
 } // namespace rawspeed


### PR DESCRIPTION
OrfDecoder and OrfDecompressor are extended to handle 14 bit files, by

* skip 8 instead of 7 bytes before decoding
* multiply white-, black-level and the detailed black-levels by 4

Tests were done with an installed darktable based on a Release-build (no asserts). The test pictures are described in #686 