### PR TITLE
rstest: use `mmap()` to map files into memory

### DIFF
--- a/src/librawspeed/io/CMakeLists.txt
+++ b/src/librawspeed/io/CMakeLists.txt
@@ -14,6 +14,8 @@ FILE(GLOB SOURCES
   "FileWriter.h"
   "IOException.cpp"
   "IOException.h"
+  "MMapReader.cpp"
+  "MMapReader.h"
 )
 
 target_sources(rawspeed_io PRIVATE

--- a/src/librawspeed/io/MMapReader.cpp
+++ b/src/librawspeed/io/MMapReader.cpp
@@ -1,0 +1,64 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2025 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#if !defined(_WIN32)
+
+#include "io/MMapReader.h"
+#include "io/FileIOException.h"
+#include <fcntl.h>
+#include <limits>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace rawspeed {
+
+MMapReader::MMapReader(const std::string& fname) {
+  fd = open(fname.c_str(), O_RDONLY);
+  if (fd == -1)
+    ThrowFIE("Could not open file \"%s\".", fname.c_str());
+
+  struct stat sb;
+  if (fstat(fd, &sb) == -1)
+    ThrowFIE("Could not obtain the file size");
+
+  length = sb.st_size;
+
+  addr = mmap(nullptr, length, PROT_READ, MAP_PRIVATE, fd, 0);
+  if (addr == MAP_FAILED)
+    ThrowFIE("Could not mmap the file");
+}
+
+Buffer MMapReader::getAsBuffer() const {
+  if (static_cast<int64_t>(length) >
+      std::numeric_limits<Buffer::size_type>::max())
+    ThrowFIE("File is too big (%zu bytes).", length);
+  return Array1DRef(static_cast<const uint8_t*>(addr),
+                    implicit_cast<Buffer::size_type>(length));
+}
+
+MMapReader::~MMapReader() {
+  munmap(addr, length);
+  close(fd);
+}
+
+} // namespace rawspeed
+
+#endif // !defined(_WIN32)

--- a/src/librawspeed/io/MMapReader.h
+++ b/src/librawspeed/io/MMapReader.h
@@ -1,0 +1,45 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2025 Roman Lebedev
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#if !defined(_WIN32)
+
+#include "io/Buffer.h"
+#include <cstddef>
+
+namespace rawspeed {
+
+class MMapReader final {
+  int fd;
+  void* addr;
+  size_t length;
+
+public:
+  MMapReader(const std::string& fname);
+
+  Buffer getAsBuffer() const;
+
+  ~MMapReader();
+};
+
+} // namespace rawspeed
+
+#endif // !defined(_WIN32)

--- a/src/utilities/rstest/rstest.cpp
+++ b/src/utilities/rstest/rstest.cpp
@@ -26,6 +26,7 @@
 #include "adt/DefaultInitAllocatorAdaptor.h"
 #include "adt/NotARational.h"
 #include "io/FileIOException.h"
+#include "io/MMapReader.h"
 #include "md5.h"
 #include <array>
 #include <bit>
@@ -383,6 +384,12 @@ int64_t process(const std::string& filename, const CameraMetaData* metadata,
   cout << left << setw(55) << filename << ": starting decoding ... " << '\n';
 #endif
 
+#if !defined(_WIN32) &&                                                        \
+    !(__has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__))
+  MMapReader reader(filename);
+
+  rawspeed::Buffer buf = reader.getAsBuffer();
+#else
   FileReader reader(filename.c_str());
 
   std::unique_ptr<std::vector<
@@ -391,6 +398,7 @@ int64_t process(const std::string& filename, const CameraMetaData* metadata,
       storage;
   rawspeed::Buffer buf;
   std::tie(storage, buf) = reader.readFile();
+#endif
 
   Timer t;
 


### PR DESCRIPTION
RPU has grown to ~55GiB, and,
having taken out half of the memory sticks
from my machine due to faulty bits,
RPU no longer fits into memory,
especially because `FileReader` takes a copy of the data...