### PR TITLE
Drop CFA element for Panasonic DC-S1RM2

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -10862,12 +10862,6 @@
 	</Camera>
 	<Camera make="Panasonic" model="DC-S1RM2">
 		<ID make="Panasonic" model="DC-S1RM2">Panasonic DC-S1RM2</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="512" white="16380"/>
 		<ColorMatrices>
@@ -10880,12 +10874,6 @@
 	</Camera>
 	<Camera make="Panasonic" model="DC-S1RM2" mode="3:2">
 		<ID make="Panasonic" model="DC-S1RM2">Panasonic DC-S1RM2</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="512" white="16380"/>
 		<ColorMatrices>


### PR DESCRIPTION
This is nonoptionally parsed from metadata like for all other v8 Panasonic raws.