### PR TITLE
Drop CFA element for OM System cameras

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7056,12 +7056,6 @@
 	</Camera>
 	<Camera make="OM Digital Solutions" model="OM-1">
 		<ID make="OM System" model="OM-1">OM Digital Solutions OM-1</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
 		<Crop x="0" y="0" width="-12" height="0"/>
 		<Sensor black="254" white="4000"/>
 		<ColorMatrices>
@@ -7074,12 +7068,6 @@
 	</Camera>
 	<Camera make="OM Digital Solutions" model="OM-1MarkII">
 		<ID make="OM System" model="OM-1 Mark II">OM Digital Solutions OM-1 Mark II</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="254" white="4095"/>
 		<ColorMatrices>
@@ -7092,12 +7080,6 @@
 	</Camera>
 	<Camera make="OM Digital Solutions" model="OM-3">
 		<ID make="OM System" model="OM-3">OM Digital Solutions OM-3</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="254" white="4095"/>
 		<ColorMatrices>
@@ -7122,12 +7104,6 @@
 	</Camera>
 	<Camera make="OM Digital Solutions" model="TG-7">
 		<ID make="OM System" model="TG-7">OM Digital Solutions TG-7</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">RED</Color>
-			<Color x="0" y="1">BLUE</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
 		<Crop x="0" y="0" width="-24" height="0"/>
 		<Sensor black="257" white="4000"/>
 		<ColorMatrices>


### PR DESCRIPTION
This is nonoptionally parsed from metadata in known ORF raws.