### PR TITLE
Mark Canon EOS R5 Mark II as not supported

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1618,7 +1618,7 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS M200" supported="no">
+	<Camera make="Canon" model="Canon EOS M200" supported="unknown-no-samples">
 		<ID make="Canon" model="EOS M200">Canon EOS M200</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS R" supported="no">
@@ -1642,7 +1642,7 @@
 	<Camera make="Canon" model="Canon EOS R5m2" supported="no">
 		<ID make="Canon" model="EOS R5 Mark II">Canon EOS R5 Mark II</ID>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS R5 C" supported="no">
+	<Camera make="Canon" model="Canon EOS R5 C" supported="unknown-no-samples">
 		<ID make="Canon" model="EOS R5 C">Canon EOS R5 C</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS R6" supported="no">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1639,7 +1639,7 @@
 	<Camera make="Canon" model="Canon EOS R5" supported="no">
 		<ID make="Canon" model="EOS R5">Canon EOS R5</ID>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS R5m2" supported="unknown-no-samples">
+	<Camera make="Canon" model="Canon EOS R5m2" supported="no">
 		<ID make="Canon" model="EOS R5 Mark II">Canon EOS R5 Mark II</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS R5 C" supported="no">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1624,7 +1624,7 @@
 	<Camera make="Canon" model="Canon EOS R" supported="no">
 		<ID make="Canon" model="EOS R">Canon EOS R</ID>
 	</Camera>
-	<Camera make="Canon" model="Canon EOS Ra" supported="no">
+	<Camera make="Canon" model="Canon EOS Ra" supported="unknown-no-samples">
 		<ID make="Canon" model="EOS Ra">Canon EOS Ra</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS RP" supported="no">


### PR DESCRIPTION
R5m2 seems to have RPU samples now.

M200, R5 C and Ra are missing in RPU though.

R100 should have had samples uploaded before the crash, would be nice if they can be resurrected as well?