### PR TITLE
`PanasonicV8Decompressor::decompressStrip()`: rewrite

### DIFF
--- a/src/librawspeed/decoders/Rw2Decoder.cpp
+++ b/src/librawspeed/decoders/Rw2Decoder.cpp
@@ -22,6 +22,7 @@
 #include "decoders/Rw2Decoder.h"
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
+#include "adt/CroppedArray2DRef.h"
 #include "adt/Point.h"
 #include "bitstreams/BitStreams.h"
 #include "common/Common.h"
@@ -273,6 +274,33 @@ getInputStrips(const DecompressorV8Params& mParams, Buffer mInputFile) {
   return mStrips;
 }
 
+std::vector<Array2DRef<uint16_t>>
+getOutputTiles(const DecompressorV8Params& mParams,
+               const Array2DRef<uint16_t> img) {
+  std::vector<Array2DRef<uint16_t>> mOutTiles;
+
+  const int totalStrips =
+      mParams.horizontalStripCount * mParams.verticalStripCount;
+
+  for (int stripIdx = 0; stripIdx < totalStrips; ++stripIdx) {
+    const uint32_t stripWidth = mParams.stripWidths[stripIdx];
+    const uint32_t stripHeight = mParams.stripHeights[stripIdx];
+    const uint32_t stripOutputX = mParams.stripLineOffsets[stripIdx] & 0xFFFF;
+    const uint32_t stripOutputY = mParams.stripLineOffsets[stripIdx] >> 16;
+
+    const auto out =
+        CroppedArray2DRef<uint16_t>(img, /*offsetCols=*/stripOutputX,
+                                    /*offsetRows=*/stripOutputY,
+                                    /*croppedWidth=*/stripWidth,
+                                    /*croppedHeight=*/stripHeight)
+            .getAsArray2DRef();
+
+    mOutTiles.emplace_back(out);
+  }
+
+  return mOutTiles;
+}
+
 } // namespace
 
 RawImage Rw2Decoder::decodeRawV8(const TiffIFD& raw) const {
@@ -283,18 +311,20 @@ RawImage Rw2Decoder::decodeRawV8(const TiffIFD& raw) const {
   const std::vector<Array1DRef<const uint8_t>> mStrips =
       getInputStrips(mParams, mFile);
 
+  mRaw->createData();
+
+  const std::vector<Array2DRef<uint16_t>> mOutTiles =
+      getOutputTiles(mParams, mRaw->getU16DataAsUncroppedArray2DRef());
+
   PanasonicV8Decompressor::DecompressorParams mParams2{
-      .stripLineOffsets = getAsArray1DRef(mParams.stripLineOffsets),
-      .stripWidths = getAsArray1DRef(mParams.stripWidths),
-      .stripHeights = getAsArray1DRef(mParams.stripHeights),
       .horizontalStripCount = mParams.horizontalStripCount,
       .verticalStripCount = mParams.verticalStripCount,
       .initialPrediction = mParams.initialPrediction,
       .gammaClipVal = mParams.gammaClipVal,
-      .mStrips = getAsArray1DRef(mStrips)};
+      .mStrips = getAsArray1DRef(mStrips),
+      .mOutTiles = getAsArray1DRef(mOutTiles)};
 
   PanasonicV8Decompressor v8(mRaw, mParams2, getAsArray1DRef(mHuffmanLUT));
-  mRaw->createData();
   v8.decompress();
   return mRaw;
 }

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -242,10 +242,9 @@ void PanasonicV8Decompressor::decompressStrip(
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
 
-      outBlock(0, 0) = tmpBlock(0, 0); // Top Red
-      outBlock(0, 1) = tmpBlock(1, 0); // Top Green
-      outBlock(1, 0) = tmpBlock(0, 1); // Bottom Green
-      outBlock(1, 1) = tmpBlock(1, 1); // Bottom Blue
+      for (int j = 0; j != 2; ++j)
+        for (int i = 0; i != 2; ++i)
+          outBlock(j, i) = tmpBlock(i, j);
     }
     // TODO: Investigate if it makes sense performance wise to structure
     // lineBuffer such that it can be memcpy'd into the output Buffer.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -199,6 +199,10 @@ void PanasonicV8Decompressor::decompressStrip(
   invariant(out.height() % 2 == 0);
   invariant(out.width() % 2 == 0);
 
+  for (int j = 0; j != 2; ++j)
+    for (int i = 0; i != 2; ++i)
+      predicted(i, j) = predicted(j, i);
+
   for (int rowGroup = 0; rowGroup < out.height() / 2; ++rowGroup) {
     const auto outRow = CroppedArray2DRef(out,
                                           /*offsetCols=*/0,
@@ -221,10 +225,11 @@ void PanasonicV8Decompressor::decompressStrip(
       for (int j = 0; j != 2; ++j) {
         for (int i = 0; i != 2; ++i) {
           const int32_t diff = decoder.decodeNextDiffValue();
-          const int32_t decodedValue = predicted(j, i) + diff;
+          const int32_t decodedValue = predicted(i, j) + diff;
           assert(decodedValue > 0);
-          outBlock(i, j) = predicted(j, i) = uint16_t(
+          predicted(i, j) = uint16_t(
               std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
+          outBlock(i, j) = predicted(i, j);
         }
       }
     }
@@ -240,7 +245,7 @@ void PanasonicV8Decompressor::decompressStrip(
     // prior line.
     for (int j = 0; j != 2; ++j)
       for (int i = 0; i != 2; ++i)
-        predicted(j, i) = tmp(i, j);
+        predicted(i, j) = tmp(i, j);
   }
 }
 

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -24,6 +24,7 @@
 #include "decompressors/PanasonicV8Decompressor.h"
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
+#include "adt/CroppedArray2DRef.h"
 #include "adt/Invariant.h"
 #include "bitstreams/BitStream.h"
 #include "bitstreams/BitStreamer.h"
@@ -205,14 +206,21 @@ void PanasonicV8Decompressor::decompressStrip(
   const uint32_t stripOutputX = mParams.stripLineOffsets(stripIdx) & 0xFFFF;
   const uint32_t stripOutputY = mParams.stripLineOffsets(stripIdx) >> 16;
 
-  std::vector<uint16_t> lineBuffer(stripWidth * 2);
+  const auto out =
+      CroppedArray2DRef<uint16_t>(outBuffer, /*offsetCols=*/stripOutputX,
+                                  /*offsetRows=*/stripOutputY,
+                                  /*croppedWidth=*/stripWidth,
+                                  /*croppedHeight=*/stripHeight)
+          .getAsArray2DRef();
+
+  std::vector<uint16_t> lineBuffer(2 * out.width());
   Bayer2x2 predicted = mParams.initialPrediction;
 
-  for (unsigned row = 0; row < stripHeight; row += 2) {
+  for (int row = 0; row < out.height(); row += 2) {
     // Each decoded 'row' is actually two rows of pixels in the raw image
     // because the image is encoded in rows of 2x2 CFA tiles. Likewise the
     // effective width here is 2x the strip width.
-    for (unsigned column = 0; column < stripWidth * 2; ++column) {
+    for (int column = 0; column < 2 * out.width(); ++column) {
       const unsigned ccIdx =
           column % 4; // CFA color component index: r, g1, g2, b
       const int32_t diff = decoder.decodeNextDiffValue();
@@ -232,17 +240,13 @@ void PanasonicV8Decompressor::decompressStrip(
     std::copy_n(&lineBuffer[0], 4, predicted.data());
 
     // Copy lineBuffer into output buffer.
-    for (unsigned linePos = 0; linePos < stripWidth * 2; linePos += 4) {
-      const uint32_t dstStartCol = stripOutputX + linePos / 2;
+    for (int linePos = 0; linePos < 2 * out.width(); linePos += 4) {
+      const int dstStartCol = linePos / 2;
 
-      outBuffer[stripOutputY + row + 0](dstStartCol + 0) =
-          lineBuffer[linePos + 0]; // Top Red
-      outBuffer[stripOutputY + row + 0](dstStartCol + 1) =
-          lineBuffer[linePos + 2]; // Top Green
-      outBuffer[stripOutputY + row + 1](dstStartCol + 0) =
-          lineBuffer[linePos + 1]; // Bottom Green
-      outBuffer[stripOutputY + row + 1](dstStartCol + 1) =
-          lineBuffer[linePos + 3]; // Bottom Blue
+      out(row + 0, dstStartCol + 0) = lineBuffer[linePos + 0]; // Top Red
+      out(row + 0, dstStartCol + 1) = lineBuffer[linePos + 2]; // Top Green
+      out(row + 1, dstStartCol + 0) = lineBuffer[linePos + 1]; // Bottom Green
+      out(row + 1, dstStartCol + 1) = lineBuffer[linePos + 3]; // Bottom Blue
     }
     // TODO: Investigate if it makes sense performance wise to structure
     // lineBuffer such that it can be memcpy'd into the output Buffer.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -194,14 +194,14 @@ void PanasonicV8Decompressor::decompress() const {
 void PanasonicV8Decompressor::decompressStrip(
     const Array2DRef<uint16_t> out, InternalHuffDecoder decoder) const {
   Bayer2x2 predictedStorage = mParams.initialPrediction;
-  const auto predicted = Array2DRef(predictedStorage.data(), 2, 2);
+  const auto pred = Array2DRef(predictedStorage.data(), 2, 2);
 
   invariant(out.height() % 2 == 0);
   invariant(out.width() % 2 == 0);
 
   for (int j = 0; j != 2; ++j)
     for (int i = 0; i != 2; ++i)
-      predicted(i, j) = predicted(j, i);
+      pred(i, j) = pred(j, i);
 
   for (int rowGroup = 0; rowGroup < out.height() / 2; ++rowGroup) {
     const auto outRow = CroppedArray2DRef(out,
@@ -225,11 +225,11 @@ void PanasonicV8Decompressor::decompressStrip(
       for (int j = 0; j != 2; ++j) {
         for (int i = 0; i != 2; ++i) {
           const int32_t diff = decoder.decodeNextDiffValue();
-          const int32_t decodedValue = predicted(i, j) + diff;
+          const int32_t decodedValue = pred(i, j) + diff;
           assert(decodedValue > 0);
-          predicted(i, j) = uint16_t(
+          pred(i, j) = uint16_t(
               std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
-          outBlock(i, j) = predicted(i, j);
+          outBlock(i, j) = pred(i, j);
         }
       }
     }
@@ -245,7 +245,7 @@ void PanasonicV8Decompressor::decompressStrip(
     // prior line.
     for (int j = 0; j != 2; ++j)
       for (int i = 0; i != 2; ++i)
-        predicted(i, j) = tmp(i, j);
+        pred(i, j) = tmp(i, j);
   }
 }
 

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -228,6 +228,13 @@ void PanasonicV8Decompressor::decompressStrip(
     // Copy lineBuffer into output buffer.
     invariant(out.width() % 2 == 0);
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
+      const auto outBlock = CroppedArray2DRef(out,
+                                              /*offsetCols=*/2 * blockIdx,
+                                              /*offsetRows=*/row,
+                                              /*croppedWidth=*/2,
+                                              /*croppedHeight=*/2)
+                                .getAsArray2DRef();
+
       const auto tmpBlock = CroppedArray2DRef(tmp,
                                               /*offsetCols=*/0,
                                               /*offsetRows=*/2 * blockIdx,
@@ -235,10 +242,10 @@ void PanasonicV8Decompressor::decompressStrip(
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
 
-      out(row + 0, 2 * blockIdx + 0) = tmpBlock(0, 0); // Top Red
-      out(row + 0, 2 * blockIdx + 1) = tmpBlock(1, 0); // Top Green
-      out(row + 1, 2 * blockIdx + 0) = tmpBlock(0, 1); // Bottom Green
-      out(row + 1, 2 * blockIdx + 1) = tmpBlock(1, 1); // Bottom Blue
+      outBlock(0, 0) = tmpBlock(0, 0); // Top Red
+      outBlock(0, 1) = tmpBlock(1, 0); // Top Green
+      outBlock(1, 0) = tmpBlock(0, 1); // Bottom Green
+      outBlock(1, 1) = tmpBlock(1, 1); // Bottom Blue
     }
     // TODO: Investigate if it makes sense performance wise to structure
     // lineBuffer such that it can be memcpy'd into the output Buffer.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -202,31 +202,32 @@ void PanasonicV8Decompressor::decompressStrip(
 
   Bayer2x2 predicted = mParams.initialPrediction;
 
+  invariant(out.height() % 2 == 0);
+  invariant(out.width() % 2 == 0);
+
   for (int row = 0; row < out.height(); row += 2) {
     // Each decoded 'row' is actually two rows of pixels in the raw image
     // because the image is encoded in rows of 2x2 CFA tiles. Likewise the
     // effective width here is 2x the strip width.
-    for (int column = 0; column < 2 * out.width(); ++column) {
-      const unsigned ccIdx =
-          column % 4; // CFA color component index: r, g1, g2, b
-      const int32_t diff = decoder.decodeNextDiffValue();
-      const int32_t decodedValue = predicted[ccIdx] + diff;
-      assert(decodedValue > 0);
-      lineBuffer[column] =
-          uint16_t(std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
-
-      if (ccIdx == 3) {
-        // Completed decoding a 2x2 CFA tile. Update the predicted value to
-        // equal the decoded value.
-        std::copy_n(&lineBuffer[column - 3], 4, predicted.data());
+    for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
+      for (int ccIdx = 0; ccIdx != 4; ++ccIdx) {
+        int column = 4 * blockIdx + ccIdx;
+        const int32_t diff = decoder.decodeNextDiffValue();
+        const int32_t decodedValue = predicted[ccIdx] + diff;
+        assert(decodedValue > 0);
+        lineBuffer[column] = uint16_t(
+            std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
       }
+
+      // Completed decoding a 2x2 CFA tile. Update the predicted value to
+      // equal the decoded value.
+      std::copy_n(&lineBuffer[4 * blockIdx], 4, predicted.data());
     }
     // At the end of the line, reset predicted value to the first tile of the
     // prior line.
     std::copy_n(&lineBuffer[0], 4, predicted.data());
 
     // Copy lineBuffer into output buffer.
-    invariant(out.width() % 2 == 0);
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
       const auto outBlock = CroppedArray2DRef(out,
                                               /*offsetCols=*/2 * blockIdx,

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -200,7 +200,8 @@ void PanasonicV8Decompressor::decompressStrip(
       Array1DRef(lineBuffer.data(), implicit_cast<int>(lineBuffer.size())),
       /*width=*/2, /*height=*/out.width(), /*pitch=*/2);
 
-  Bayer2x2 predicted = mParams.initialPrediction;
+  Bayer2x2 predictedStorage = mParams.initialPrediction;
+  const auto predicted = Array2DRef(predictedStorage.data(), 2, 2);
 
   invariant(out.height() % 2 == 0);
   invariant(out.width() % 2 == 0);
@@ -210,22 +211,30 @@ void PanasonicV8Decompressor::decompressStrip(
     // because the image is encoded in rows of 2x2 CFA tiles. Likewise the
     // effective width here is 2x the strip width.
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
-      for (int ccIdx = 0; ccIdx != 4; ++ccIdx) {
-        int column = 4 * blockIdx + ccIdx;
-        const int32_t diff = decoder.decodeNextDiffValue();
-        const int32_t decodedValue = predicted[ccIdx] + diff;
-        assert(decodedValue > 0);
-        lineBuffer[column] = uint16_t(
-            std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
+      const auto tmpBlock = CroppedArray2DRef(tmp,
+                                              /*offsetCols=*/0,
+                                              /*offsetRows=*/2 * blockIdx,
+                                              /*croppedWidth=*/2,
+                                              /*croppedHeight=*/2)
+                                .getAsArray2DRef();
+
+      for (int j = 0; j != 2; ++j) {
+        for (int i = 0; i != 2; ++i) {
+          const int32_t diff = decoder.decodeNextDiffValue();
+          const int32_t decodedValue = predicted(j, i) + diff;
+          assert(decodedValue > 0);
+          tmpBlock(j, i) = uint16_t(
+              std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
+        }
       }
 
       // Completed decoding a 2x2 CFA tile. Update the predicted value to
       // equal the decoded value.
-      std::copy_n(&lineBuffer[4 * blockIdx], 4, predicted.data());
+      std::copy_n(&lineBuffer[4 * blockIdx], 4, predictedStorage.data());
     }
     // At the end of the line, reset predicted value to the first tile of the
     // prior line.
-    std::copy_n(&lineBuffer[0], 4, predicted.data());
+    std::copy_n(&lineBuffer[0], 4, predictedStorage.data());
 
     // Copy lineBuffer into output buffer.
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -226,20 +226,19 @@ void PanasonicV8Decompressor::decompressStrip(
     std::copy_n(&lineBuffer[0], 4, predicted.data());
 
     // Copy lineBuffer into output buffer.
-    for (int linePos = 0; linePos < 2 * out.width(); linePos += 4) {
-      const int dstStartCol = linePos / 2;
-
+    invariant(out.width() % 2 == 0);
+    for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
       const auto tmpBlock = CroppedArray2DRef(tmp,
                                               /*offsetCols=*/0,
-                                              /*offsetRows=*/dstStartCol,
+                                              /*offsetRows=*/2 * blockIdx,
                                               /*croppedWidth=*/2,
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
 
-      out(row + 0, dstStartCol + 0) = tmpBlock(0, 0); // Top Red
-      out(row + 0, dstStartCol + 1) = tmpBlock(1, 0); // Top Green
-      out(row + 1, dstStartCol + 0) = tmpBlock(0, 1); // Bottom Green
-      out(row + 1, dstStartCol + 1) = tmpBlock(1, 1); // Bottom Blue
+      out(row + 0, 2 * blockIdx + 0) = tmpBlock(0, 0); // Top Red
+      out(row + 0, 2 * blockIdx + 1) = tmpBlock(1, 0); // Top Green
+      out(row + 1, 2 * blockIdx + 0) = tmpBlock(0, 1); // Bottom Green
+      out(row + 1, 2 * blockIdx + 1) = tmpBlock(1, 1); // Bottom Blue
     }
     // TODO: Investigate if it makes sense performance wise to structure
     // lineBuffer such that it can be memcpy'd into the output Buffer.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -24,7 +24,6 @@
 #include "decompressors/PanasonicV8Decompressor.h"
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
-#include "adt/CroppedArray2DRef.h"
 #include "adt/Invariant.h"
 #include "bitstreams/BitStream.h"
 #include "bitstreams/BitStreamer.h"
@@ -142,16 +141,10 @@ public:
 void PanasonicV8Decompressor::DecompressorParams::validate() const {
   const int totalStrips = horizontalStripCount * verticalStripCount;
 
-  if (totalStrips > stripWidths.size())
-    ThrowRDE("Strip widths list does not have enough entries for the number of "
-             "strips!");
-  if (totalStrips > stripHeights.size())
-    ThrowRDE("Strip heights list does not have enough entries for the number "
-             "of strips!");
-  if (totalStrips > stripLineOffsets.size())
-    ThrowRDE("Strip line offset list does not have enough entries for the "
-             "number of strips!");
   if (totalStrips > mStrips.size())
+    ThrowRDE("Strip byte buffer array does not have enough entries for the "
+             "number of strips!");
+  if (totalStrips > mOutTiles.size())
     ThrowRDE("Strip byte buffer array does not have enough entries for the "
              "number of strips!");
 }
@@ -183,11 +176,11 @@ void PanasonicV8Decompressor::decompress() const {
   for (int stripIdx = 0; stripIdx < totalStrips; ++stripIdx) {
     try {
       Array1DRef<const uint8_t> strip = mParams.mStrips(stripIdx);
+      Array2DRef<uint16_t> out = mParams.mOutTiles(stripIdx);
 
       InternalHuffDecoder decoder(mHuffmanLUT, strip);
 
-      decompressStrip(stripIdx, decoder,
-                      mRawOutput->getU16DataAsUncroppedArray2DRef());
+      decompressStrip(out, decoder);
     } catch (const RawspeedException& err) {
       // Propagate the exception out of OpenMP magic.
       mRawOutput->setError(err.what());
@@ -199,20 +192,7 @@ void PanasonicV8Decompressor::decompress() const {
 }
 
 void PanasonicV8Decompressor::decompressStrip(
-    const unsigned stripIdx, InternalHuffDecoder decoder,
-    Array2DRef<uint16_t> outBuffer) const {
-  const uint32_t stripWidth = mParams.stripWidths(stripIdx);
-  const uint32_t stripHeight = mParams.stripHeights(stripIdx);
-  const uint32_t stripOutputX = mParams.stripLineOffsets(stripIdx) & 0xFFFF;
-  const uint32_t stripOutputY = mParams.stripLineOffsets(stripIdx) >> 16;
-
-  const auto out =
-      CroppedArray2DRef<uint16_t>(outBuffer, /*offsetCols=*/stripOutputX,
-                                  /*offsetRows=*/stripOutputY,
-                                  /*croppedWidth=*/stripWidth,
-                                  /*croppedHeight=*/stripHeight)
-          .getAsArray2DRef();
-
+    const Array2DRef<uint16_t> out, InternalHuffDecoder decoder) const {
   std::vector<uint16_t> lineBuffer(2 * out.width());
   Bayer2x2 predicted = mParams.initialPrediction;
 

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -24,6 +24,7 @@
 #include "decompressors/PanasonicV8Decompressor.h"
 #include "adt/Array1DRef.h"
 #include "adt/Array2DRef.h"
+#include "adt/CroppedArray2DRef.h"
 #include "adt/Invariant.h"
 #include "bitstreams/BitStream.h"
 #include "bitstreams/BitStreamer.h"
@@ -194,6 +195,11 @@ void PanasonicV8Decompressor::decompress() const {
 void PanasonicV8Decompressor::decompressStrip(
     const Array2DRef<uint16_t> out, InternalHuffDecoder decoder) const {
   std::vector<uint16_t> lineBuffer(2 * out.width());
+
+  const auto tmp = Array2DRef(
+      Array1DRef(lineBuffer.data(), implicit_cast<int>(lineBuffer.size())),
+      /*width=*/2, /*height=*/out.width(), /*pitch=*/2);
+
   Bayer2x2 predicted = mParams.initialPrediction;
 
   for (int row = 0; row < out.height(); row += 2) {
@@ -223,10 +229,17 @@ void PanasonicV8Decompressor::decompressStrip(
     for (int linePos = 0; linePos < 2 * out.width(); linePos += 4) {
       const int dstStartCol = linePos / 2;
 
-      out(row + 0, dstStartCol + 0) = lineBuffer[linePos + 0]; // Top Red
-      out(row + 0, dstStartCol + 1) = lineBuffer[linePos + 2]; // Top Green
-      out(row + 1, dstStartCol + 0) = lineBuffer[linePos + 1]; // Bottom Green
-      out(row + 1, dstStartCol + 1) = lineBuffer[linePos + 3]; // Bottom Blue
+      const auto tmpBlock = CroppedArray2DRef(tmp,
+                                              /*offsetCols=*/0,
+                                              /*offsetRows=*/dstStartCol,
+                                              /*croppedWidth=*/2,
+                                              /*croppedHeight=*/2)
+                                .getAsArray2DRef();
+
+      out(row + 0, dstStartCol + 0) = tmpBlock(0, 0); // Top Red
+      out(row + 0, dstStartCol + 1) = tmpBlock(1, 0); // Top Green
+      out(row + 1, dstStartCol + 0) = tmpBlock(0, 1); // Bottom Green
+      out(row + 1, dstStartCol + 1) = tmpBlock(1, 1); // Bottom Blue
     }
     // TODO: Investigate if it makes sense performance wise to structure
     // lineBuffer such that it can be memcpy'd into the output Buffer.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -199,14 +199,21 @@ void PanasonicV8Decompressor::decompressStrip(
   invariant(out.height() % 2 == 0);
   invariant(out.width() % 2 == 0);
 
-  for (int row = 0; row < out.height(); row += 2) {
+  for (int rowGroup = 0; rowGroup < out.height() / 2; ++rowGroup) {
+    const auto outRow = CroppedArray2DRef(out,
+                                          /*offsetCols=*/0,
+                                          /*offsetRows=*/2 * rowGroup,
+                                          /*croppedWidth=*/out.width(),
+                                          /*croppedHeight=*/2)
+                            .getAsArray2DRef();
+
     // Each decoded 'row' is actually two rows of pixels in the raw image
     // because the image is encoded in rows of 2x2 CFA tiles. Likewise the
     // effective width here is 2x the strip width.
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
-      const auto outBlock = CroppedArray2DRef(out,
+      const auto outBlock = CroppedArray2DRef(outRow,
                                               /*offsetCols=*/2 * blockIdx,
-                                              /*offsetRows=*/row,
+                                              /*offsetRows=*/0,
                                               /*croppedWidth=*/2,
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
@@ -221,8 +228,10 @@ void PanasonicV8Decompressor::decompressStrip(
         }
       }
     }
-    const auto tmp = CroppedArray2DRef(out, /*offsetCols=*/0,
-                                       /*offsetRows=*/row,
+
+    const auto tmp = CroppedArray2DRef(outRow,
+                                       /*offsetCols=*/0,
+                                       /*offsetRows=*/0,
                                        /*croppedWidth=*/2,
                                        /*croppedHeight=*/2)
                          .getAsArray2DRef();

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -41,7 +41,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
-#include <vector>
 
 namespace rawspeed {
 
@@ -194,12 +193,6 @@ void PanasonicV8Decompressor::decompress() const {
 
 void PanasonicV8Decompressor::decompressStrip(
     const Array2DRef<uint16_t> out, InternalHuffDecoder decoder) const {
-  std::vector<uint16_t> lineBuffer(2 * out.width());
-
-  const auto tmp = Array2DRef(
-      Array1DRef(lineBuffer.data(), implicit_cast<int>(lineBuffer.size())),
-      /*width=*/2, /*height=*/out.width(), /*pitch=*/2);
-
   Bayer2x2 predictedStorage = mParams.initialPrediction;
   const auto predicted = Array2DRef(predictedStorage.data(), 2, 2);
 
@@ -218,26 +211,27 @@ void PanasonicV8Decompressor::decompressStrip(
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
 
-      const auto tmpBlock = CroppedArray2DRef(tmp,
-                                              /*offsetCols=*/0,
-                                              /*offsetRows=*/2 * blockIdx,
-                                              /*croppedWidth=*/2,
-                                              /*croppedHeight=*/2)
-                                .getAsArray2DRef();
-
       for (int j = 0; j != 2; ++j) {
         for (int i = 0; i != 2; ++i) {
           const int32_t diff = decoder.decodeNextDiffValue();
           const int32_t decodedValue = predicted(j, i) + diff;
           assert(decodedValue > 0);
-          outBlock(i, j) = tmpBlock(j, i) = predicted(j, i) = uint16_t(
+          outBlock(i, j) = predicted(j, i) = uint16_t(
               std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
         }
       }
     }
+    const auto tmp = CroppedArray2DRef(out, /*offsetCols=*/0,
+                                       /*offsetRows=*/row,
+                                       /*croppedWidth=*/2,
+                                       /*croppedHeight=*/2)
+                         .getAsArray2DRef();
+
     // At the end of the line, reset predicted value to the first tile of the
     // prior line.
-    std::copy_n(&lineBuffer[0], 4, predictedStorage.data());
+    for (int j = 0; j != 2; ++j)
+      for (int i = 0; i != 2; ++i)
+        predicted(j, i) = tmp(i, j);
   }
 }
 

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -211,33 +211,6 @@ void PanasonicV8Decompressor::decompressStrip(
     // because the image is encoded in rows of 2x2 CFA tiles. Likewise the
     // effective width here is 2x the strip width.
     for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
-      const auto tmpBlock = CroppedArray2DRef(tmp,
-                                              /*offsetCols=*/0,
-                                              /*offsetRows=*/2 * blockIdx,
-                                              /*croppedWidth=*/2,
-                                              /*croppedHeight=*/2)
-                                .getAsArray2DRef();
-
-      for (int j = 0; j != 2; ++j) {
-        for (int i = 0; i != 2; ++i) {
-          const int32_t diff = decoder.decodeNextDiffValue();
-          const int32_t decodedValue = predicted(j, i) + diff;
-          assert(decodedValue > 0);
-          tmpBlock(j, i) = uint16_t(
-              std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
-        }
-      }
-
-      // Completed decoding a 2x2 CFA tile. Update the predicted value to
-      // equal the decoded value.
-      std::copy_n(&lineBuffer[4 * blockIdx], 4, predictedStorage.data());
-    }
-    // At the end of the line, reset predicted value to the first tile of the
-    // prior line.
-    std::copy_n(&lineBuffer[0], 4, predictedStorage.data());
-
-    // Copy lineBuffer into output buffer.
-    for (int blockIdx = 0; blockIdx < out.width() / 2; ++blockIdx) {
       const auto outBlock = CroppedArray2DRef(out,
                                               /*offsetCols=*/2 * blockIdx,
                                               /*offsetRows=*/row,
@@ -252,12 +225,23 @@ void PanasonicV8Decompressor::decompressStrip(
                                               /*croppedHeight=*/2)
                                 .getAsArray2DRef();
 
-      for (int j = 0; j != 2; ++j)
-        for (int i = 0; i != 2; ++i)
-          outBlock(j, i) = tmpBlock(i, j);
+      for (int j = 0; j != 2; ++j) {
+        for (int i = 0; i != 2; ++i) {
+          const int32_t diff = decoder.decodeNextDiffValue();
+          const int32_t decodedValue = predicted(j, i) + diff;
+          assert(decodedValue > 0);
+          outBlock(i, j) = tmpBlock(j, i) = uint16_t(
+              std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
+        }
+      }
+
+      // Completed decoding a 2x2 CFA tile. Update the predicted value to
+      // equal the decoded value.
+      std::copy_n(&lineBuffer[4 * blockIdx], 4, predictedStorage.data());
     }
-    // TODO: Investigate if it makes sense performance wise to structure
-    // lineBuffer such that it can be memcpy'd into the output Buffer.
+    // At the end of the line, reset predicted value to the first tile of the
+    // prior line.
+    std::copy_n(&lineBuffer[0], 4, predictedStorage.data());
   }
 }
 

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -230,14 +230,10 @@ void PanasonicV8Decompressor::decompressStrip(
           const int32_t diff = decoder.decodeNextDiffValue();
           const int32_t decodedValue = predicted(j, i) + diff;
           assert(decodedValue > 0);
-          outBlock(i, j) = tmpBlock(j, i) = uint16_t(
+          outBlock(i, j) = tmpBlock(j, i) = predicted(j, i) = uint16_t(
               std::clamp(decodedValue, 0, int32_t(mParams.gammaClipVal)));
         }
       }
-
-      // Completed decoding a 2x2 CFA tile. Update the predicted value to
-      // equal the decoded value.
-      std::copy_n(&lineBuffer[4 * blockIdx], 4, predictedStorage.data());
     }
     // At the end of the line, reset predicted value to the first tile of the
     // prior line.

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.h
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.h
@@ -49,9 +49,6 @@ public:
   /// Decompressor parameters populated from tags. They remain constant after
   /// construction.
   struct DecompressorParams {
-    const Array1DRef<const uint32_t> stripLineOffsets;
-    const Array1DRef<const uint16_t> stripWidths;
-    const Array1DRef<const uint16_t> stripHeights;
     const uint16_t horizontalStripCount;
     const uint16_t verticalStripCount;
 
@@ -60,6 +57,7 @@ public:
     const uint16_t gammaClipVal;
 
     const Array1DRef<const Array1DRef<const uint8_t>> mStrips;
+    const Array1DRef<const Array2DRef<uint16_t>> mOutTiles;
 
     void validate() const;
   };
@@ -79,8 +77,8 @@ private:
 
   /// Thread safe function for decompressing a single data-stripstrip within a
   /// Rw2V8 raw image.
-  void decompressStrip(unsigned stripIdx, InternalHuffDecoder decoder,
-                       Array2DRef<uint16_t> outBuffer) const;
+  void decompressStrip(Array2DRef<uint16_t> out,
+                       InternalHuffDecoder decoder) const;
 
 public:
   PanasonicV8Decompressor(RawImage outputImg, DecompressorParams mParams_,


### PR DESCRIPTION
(as compared to without this PR)
```
$ /repositories/googlebenchmark/tools/compare.py -a benchmarks ~/rawspeed/build-{old,new}/src/utilities/rsbench/rsbench Panasonic/DC-S5M2/P1126458_mechanical.RW2 --benchmark_min_warmup_time=0.5 --benchmark_min_time=0s --benchmark_repetitions=99 --benchmark_counters_tabular=true -t --benchmark_filter="/threads:(1|32)/" 
RUNNING: /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench Panasonic/DC-S5M2/P1126458_mechanical.RW2 --benchmark_min_warmup_time=0.5 --benchmark_min_time=0s --benchmark_repetitions=99 --benchmark_counters_tabular=true -t --benchmark_filter=/threads:(1|32)/ --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpy_nco89y
2025-05-18T20:06:23+03:00
Running /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 8.45, 3.84, 2.61
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                   Time             CPU   Iterations  CPUTime,s CPUTime/WallTime     Pixels Pixels/CPUTime Pixels/WallTime Raws/CPUTime Raws/WallTime WallTime,s
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_mean           243 ms          243 ms           99   0.242746         0.999852   24.0801M       99.1995M        99.1848M      4.11957       4.11896   0.242782
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_median         243 ms          243 ms           99   0.242616         0.999891   24.0801M       99.2518M        99.2357M      4.12174       4.12107   0.242655
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_stddev       0.694 ms        0.681 ms           99   681.374u         160.461u          0        276.32k        281.278k     0.011475     0.0116809   694.023u
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_cv            0.29 %          0.28 %            99      0.28%            0.02%      0.00%          0.28%           0.28%        0.28%         0.28%      0.29%
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_mean          128 ms          256 ms           99   0.255867          1.99978   24.0801M       94.1118M        188.203M      3.90829       7.81573   0.127947
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_median        128 ms          256 ms           99   0.255674          1.99987   24.0801M       94.1827M        188.345M      3.91123       7.82161   0.127851
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_stddev      0.196 ms        0.393 ms           99   392.892u         310.161u          0       144.295k        287.894k     5.99231m     0.0119557   196.012u
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_cv           0.15 %          0.15 %            99      0.15%            0.02%      0.00%          0.15%           0.15%        0.15%         0.15%      0.15%
RUNNING: /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench Panasonic/DC-S5M2/P1126458_mechanical.RW2 --benchmark_min_warmup_time=0.5 --benchmark_min_time=0s --benchmark_repetitions=99 --benchmark_counters_tabular=true -t --benchmark_filter=/threads:(1|32)/ --benchmark_display_aggregates_only=true --benchmark_out=/tmp/tmpta85pklr
2025-05-18T20:07:01+03:00
Running /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench
Run on (32 X 3400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 5.12, 3.55, 2.56
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                   Time             CPU   Iterations  CPUTime,s CPUTime/WallTime     Pixels Pixels/CPUTime Pixels/WallTime Raws/CPUTime Raws/WallTime WallTime,s
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_mean           220 ms          220 ms           99   0.220266         0.999832   24.0801M       109.323M        109.305M      4.53998       4.53922   0.220303
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_median         220 ms          220 ms           99    0.22044         0.999884   24.0801M       109.236M        109.226M      4.53638       4.53594   0.220462
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_stddev       0.484 ms        0.479 ms           99   479.441u         179.485u          0       238.195k        240.159k     9.89181m      9.97333m   483.568u
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_cv            0.22 %          0.22 %            99      0.22%            0.02%      0.00%          0.22%           0.22%        0.22%         0.22%      0.22%
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_mean          120 ms          240 ms           99   0.239875          1.99936   24.0801M       100.387M        200.709M      4.16886       8.33505   0.119976
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_median        120 ms          240 ms           99   0.240076          1.99976   24.0801M       100.302M        200.544M      4.16535       8.32822   0.120074
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_stddev      0.247 ms        0.526 ms           99   526.522u         638.899u          0       220.596k        413.887k     9.16092m     0.0171879   247.158u
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_cv           0.21 %          0.22 %            99      0.22%            0.03%      0.00%          0.22%           0.21%        0.22%         0.21%      0.21%
Comparing /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench to /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench
Benchmark                                                                                            Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_pvalue                  0.0000          0.0000      U Test, Repetitions: 99 vs 99
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_mean                   -0.0926         -0.0926           243           220           243           220
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_median                 -0.0915         -0.0914           243           220           243           220
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_stddev                 -0.3031         -0.2963             1             0             1             0
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:1/process_time/real_time_cv                     -0.2320         -0.2245             0             0             0             0
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 99 vs 99
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_mean                  -0.0623         -0.0625           128           120           256           240
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_median                -0.0608         -0.0610           128           120           256           240
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_stddev                +0.2620         +0.3377             0             0             0             1
Panasonic/DC-S5M2/P1126458_mechanical.RW2/threads:32/process_time/real_time_cv                    +0.3458         +0.4269             0             0             0             0
OVERALL_GEOMEAN                                                                                   -0.0776         -0.0777             0             0             0             0

```
