### PR TITLE
Add Panasonic DC-G97 alias

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11393,6 +11393,7 @@
 			<Alias>DC-G90</Alias>
 			<Alias>DC-G91</Alias>
 			<Alias>DC-G95D</Alias>
+			<Alias>DC-G97</Alias>
 			<Alias>DC-G99</Alias>
 			<Alias>DC-G99D</Alias>
 		</Aliases>
@@ -11412,6 +11413,7 @@
 			<Alias>DC-G90</Alias>
 			<Alias>DC-G91</Alias>
 			<Alias>DC-G95D</Alias>
+			<Alias>DC-G97</Alias>
 			<Alias>DC-G99</Alias>
 			<Alias>DC-G99D</Alias>
 		</Aliases>
@@ -11422,9 +11424,6 @@
 				<ColorMatrixRow plane="2">-568 1415 5158</ColorMatrixRow>
 			</ColorMatrix>
 		</ColorMatrices>
-	</Camera>
-	<Camera make="Panasonic" model="DC-G97" supported="unknown-no-samples">
-		<ID make="Panasonic" model="DC-G97">Panasonic DC-G97</ID>
 	</Camera>
 	<Camera make="Panasonic" model="DC-G99M2" supported="unknown-no-samples">
 		<ID make="Panasonic" model="DC-G99M2">Panasonic DC-G99M2</ID>


### PR DESCRIPTION
Confirmed ADC 17.3.1 identifies it as DC-G99

See also https://www.dpreview.com/news/8943078360/panasonic-g97-zs99-tz99-refresh-usb-c

Addresses https://github.com/darktable-org/darktable/issues/18836