### PR TITLE
PanasonicV8Decompressor: maor faster (-33%)

### DIFF
--- a/src/librawspeed/adt/Bit.h
+++ b/src/librawspeed/adt/Bit.h
@@ -134,4 +134,16 @@ constexpr typename std::make_signed_t<T>
   return static_cast<SignedT>(value << SpareSignBits) >> SpareSignBits;
 }
 
+template <class T>
+  requires std::same_as<T, uint8_t>
+T bitreverse(const T v) {
+#if __has_builtin(__builtin_bitreverse8)
+  return __builtin_bitreverse8(v);
+#endif
+  // Reverse the order of bits within each byte using a bit-twiddle trick.
+  // Three operation bit reversal from:
+  // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv
+  return uint8_t((uint8_t(v) * 0x0202020202ULL & 0x010884422010ULL) % 1023);
+}
+
 } // namespace rawspeed

--- a/src/librawspeed/adt/Bit.h
+++ b/src/librawspeed/adt/Bit.h
@@ -24,10 +24,12 @@
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <climits>
 #include <concepts>
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 
 namespace rawspeed {
@@ -144,6 +146,30 @@ T bitreverse(const T v) {
   // Three operation bit reversal from:
   // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv
   return uint8_t((uint8_t(v) * 0x0202020202ULL & 0x010884422010ULL) % 1023);
+}
+
+#if __has_builtin(__builtin_bitreverse32)
+template <class T>
+  requires std::same_as<T, uint32_t>
+T bitreverse(const T v) {
+  return __builtin_bitreverse32(v);
+}
+#endif
+
+template <class T>
+  requires std::same_as<T, uint8_t>
+std::array<T, 4> bitreverse_each(std::array<T, 4> x) {
+#if !__has_builtin(__builtin_bitreverse32)
+  for (T& e : x)
+    e = bitreverse(e);
+#else
+  uint32_t tmp;
+  std::memcpy(&tmp, x.data(), sizeof(uint32_t));
+  tmp = bitreverse(tmp);
+  tmp = __builtin_bswap32(tmp);
+  std::memcpy(x.data(), &tmp, sizeof(uint32_t));
+#endif
+  return x;
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -89,8 +89,12 @@ struct BitStreamerReversedSequentialReplenisher
       std::copy_n(currInput.begin(), BitStreamerTraits<Tag>::MaxProcessBytes,
                   tmp.begin());
 
-      for (std::byte& b : tmp)
-        b = std::byte{bitreverse(uint8_t(b))};
+      std::array<uint8_t, 4> ints;
+      for (int i = 0; i != 4; ++i)
+        ints[i] = uint8_t(tmp(i));
+      ints = bitreverse_each(ints);
+      for (int i = 0; i != 4; ++i)
+        tmp(i) = std::byte{ints[i]};
 
       return tmpStorage;
     }

--- a/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
+++ b/src/librawspeed/decompressors/PanasonicV8Decompressor.cpp
@@ -89,13 +89,8 @@ struct BitStreamerReversedSequentialReplenisher
       std::copy_n(currInput.begin(), BitStreamerTraits<Tag>::MaxProcessBytes,
                   tmp.begin());
 
-      // Reverse the order of bits within each byte using a bit-twiddle trick.
-      // Three operation bit reversal from:
-      // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv
-      for (std::byte& b : tmp) {
-        b = std::byte{
-            uint8_t((uint8_t(b) * 0x0202020202ULL & 0x010884422010ULL) % 1023)};
-      }
+      for (std::byte& b : tmp)
+        b = std::byte{bitreverse(uint8_t(b))};
 
       return tmpStorage;
     }


### PR DESCRIPTION
```
Comparing /home/lebedevri/rawspeed/build-old/src/utilities/rsbench/rsbench to /home/lebedevri/rawspeed/build-new/src/utilities/rsbench/rsbench
Benchmark                                                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------------------
P1126458_mechanical.RW2/threads:1/process_time/real_time_pvalue                  0.0000          0.0000      U Test, Repetitions: 99 vs 99
P1126458_mechanical.RW2/threads:1/process_time/real_time_mean                   -0.3026         -0.3026           208           145           208           145
P1126458_mechanical.RW2/threads:1/process_time/real_time_median                 -0.3033         -0.3034           208           145           208           145
P1126458_mechanical.RW2/threads:1/process_time/real_time_stddev                 +1.8832         +2.0210             0             0             0             0
P1126458_mechanical.RW2/threads:1/process_time/real_time_cv                     +3.1344         +3.3320             0             0             0             0
P1126458_mechanical.RW2/threads:32/process_time/real_time_pvalue                 0.0000          0.0000      U Test, Repetitions: 99 vs 99
P1126458_mechanical.RW2/threads:32/process_time/real_time_mean                  -0.3328         -0.3327           112            75           224           150
P1126458_mechanical.RW2/threads:32/process_time/real_time_median                -0.3328         -0.3328           112            75           224           150
P1126458_mechanical.RW2/threads:32/process_time/real_time_stddev                -0.1861         -0.1548             0             0             0             0
P1126458_mechanical.RW2/threads:32/process_time/real_time_cv                    +0.2198         +0.2667             0             0             0             0
OVERALL_GEOMEAN                                                                 -0.3179         -0.3179             0             0             0             0

```