### PR TITLE
Windows building fixes

### DIFF
--- a/src/librawspeed/adt/AlignedAllocator.h
+++ b/src/librawspeed/adt/AlignedAllocator.h
@@ -44,6 +44,19 @@ public:
     using other = AlignedAllocator<U, alignment>;
   };
 
+  // Default constructor
+  AlignedAllocator() noexcept = default;
+
+  // Copy constructor
+  AlignedAllocator(const AlignedAllocator&) noexcept = default;
+
+  // Copy assignment
+  AlignedAllocator& operator=(const AlignedAllocator&) noexcept = default;
+
+  // Converting constructor from other AlignedAllocator types
+  template <class U>
+  AlignedAllocator(const AlignedAllocator<U, alignment>&) noexcept {}
+
   [[nodiscard]] T* allocate(std::size_t numElts) const {
     static_assert(size_t(alignment) >= alignof(T), "insufficient alignment");
     invariant(numElts > 0 && "Should not be trying to allocate no elements");

--- a/src/librawspeed/adt/DefaultInitAllocatorAdaptor.h
+++ b/src/librawspeed/adt/DefaultInitAllocatorAdaptor.h
@@ -59,8 +59,14 @@ public:
   explicit DefaultInitAllocatorAdaptor(
       const DefaultInitAllocatorAdaptor<
           To, typename allocator_traits::template rebind_alloc<To>>&
-          allocator_) noexcept
-      : allocator(allocator_.get_allocator()) {}
+          allocator_) noexcept {
+    if constexpr (std::is_constructible_v<allocator_type, 
+                    typename allocator_traits::template rebind_alloc<To>>) {
+      allocator = allocator_type(allocator_.get_allocator());
+    } else {
+      allocator = allocator_type{};
+    }
+  }
 
   T* allocate(std::size_t n) {
     return allocator_traits::allocate(allocator, n);

--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -416,7 +416,7 @@ VC5Decompressor::VC5Decompressor(ByteStream bs, const RawImage& img)
       wavelet.height = waveletHeight;
 
       wavelet.bands.resize(
-          &wavelet == channel.wavelets.begin() ? 1 : Wavelet::maxBands);
+          std::addressof(wavelet) == std::addressof(*channel.wavelets.begin()) ? 1 : Wavelet::maxBands);
     }
   }
 

--- a/src/librawspeed/io/Endianness.h
+++ b/src/librawspeed/io/Endianness.h
@@ -26,6 +26,10 @@
 #include <cstdint>
 #include <cstring>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 namespace rawspeed {
 
 enum class Endianness : uint16_t {
@@ -61,7 +65,6 @@ inline Endianness getHostEndianness() {
 }
 
 #ifdef _MSC_VER
-#include <intrin.h>
 
 #define BSWAP16(A) _byteswap_ushort(A)
 #define BSWAP32(A) _byteswap_ulong(A)


### PR DESCRIPTION
Sorry, it was the first time I pushed to the wrong branch

• Added explicit constructors and assignment operators to AlignedAllocator for better standards compliance. 
• Updated DefaultInitAllocatorAdaptor to use allocator_type construction more robustly. 
• Fixed pointer comparison in VC5Decompressor for correctness. 
• Moved intrin.h include in Endianness.h to avoid re-inclusion and improve MSVC compatibility.