### PR TITLE
PefDecoder: support rebranded Samsung cameras

### DIFF
--- a/src/librawspeed/decoders/PefDecoder.cpp
+++ b/src/librawspeed/decoders/PefDecoder.cpp
@@ -52,7 +52,8 @@ bool PefDecoder::isAppropriateDecoder(const TiffRootIFD* rootIFD,
   // FIXME: magic
 
   return make == "PENTAX Corporation" ||
-         make == "RICOH IMAGING COMPANY, LTD." || make == "PENTAX";
+         make == "RICOH IMAGING COMPANY, LTD." || make == "PENTAX" ||
+         make == "SAMSUNG TECHWIN";
 }
 
 RawImage PefDecoder::decodeRawInternal() {


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/issues/19228 and complements #877.

Hope this is trivial enough to make an exception for touching the code, apologies for not catching it earlier... ;)