### PR TITLE
Hasselblad H4D-60 and H6D-50c placeholders

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17983,6 +17983,9 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
+	<Camera make="Hasselblad" model="Hasselblad H4D-60" supported="unknown-no-samples">
+		<ID make="Hasselblad" model="H4D-60">Hasselblad 60-Coated</ID>
+	</Camera>
 	<Camera make="Hasselblad" model="Hasselblad H5D-40">
 		<ID make="Hasselblad" model="H5D-40">Hasselblad 40-Coated5</ID>
 		<CFA width="2" height="2">
@@ -18031,6 +18034,9 @@
 				<ColorMatrixRow plane="2">-1138 1961 7067</ColorMatrixRow>
 			</ColorMatrix>
 		</ColorMatrices>
+	</Camera>
+	<Camera make="Hasselblad" model="Hasselblad H6D-50c" supported="unknown-no-samples">
+		<ID make="Hasselblad" model="H6D-50c">Hasselblad 50-15-Coated5</ID>
 	</Camera>
 	<Camera make="Hasselblad" model="Flash Sync">
 		<ID make="Hasselblad" model="CF132">Hasselblad 22-Uncoated</ID>


### PR DESCRIPTION
[This H4D sample](https://raw.pixls.us/getfile.php/2631/nice/Hasselblad%20-%20Hasselblad%20H4D%20-%2016bit%20(4:3).3FR) is actually the H4D-60, but it cannot be properly supported as it is actually mistagged in Exif as H3D (perhaps later firmware fixed this?).

ADC identifies it when converting ("Hasselblad H4D-60" in `LocalizedCameraModel`), and so does Phocus SW when importing, but neither doesn't seem to fix up the `Model` tag up when saving to DNG/FFF...