### PR TITLE
CI: fix for deprecated macOS Intel job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,8 +195,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { os: macos-15, family: XCode, version: 16.3, deployment_target: 15.2, CC: cc, CXX: c++ } # AArch64, LLVM19, native
-          - { os: macos-13, family: XCode, version: 15.2, deployment_target: 13.5, CC: cc, CXX: c++ } # x86_64,  LLVM16, native
+          - { os: macos-15,       family: XCode, version: 16.4, deployment_target: 15.3, CC: cc, CXX: c++ } # AArch64, LLVM19, native
+          - { os: macos-15-intel, family: XCode, version: 16.4, deployment_target: 15.3, CC: cc, CXX: c++ } # x86_64,  LLVM19, native
         flavor: [ ReleaseWithAsserts, Release ]
     uses: ./.github/workflows/CI-macOS.yml
     with:
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - compiler: { os: macos-15, family: XCode, version: 16.3, deployment_target: 15.2, CC: cc, CXX: c++ } # AArch64, LLVM19, native
+          - compiler: { os: macos-15, family: XCode, version: 16.4, deployment_target: 15.3, CC: cc, CXX: c++ } # AArch64, LLVM19, native
             flavor: Coverage
     uses: ./.github/workflows/CI-macOS.yml
     with:


### PR DESCRIPTION
Replace with the only available macos-15-intel runner substitute.

Also bump to default macOS 15 runner XCode version and deployment target to match.