### PR TITLE
Fix build with Clang on Window

### DIFF
--- a/src/librawspeed/decompressors/VC5Decompressor.cpp
+++ b/src/librawspeed/decompressors/VC5Decompressor.cpp
@@ -418,7 +418,7 @@ VC5Decompressor::VC5Decompressor(ByteStream bs, const RawImage& img)
       wavelet.height = waveletHeight;
 
       wavelet.bands.resize(
-          &wavelet == channel.wavelets.begin() ? 1 : Wavelet::maxBands);
+          &wavelet == &*channel.wavelets.begin() ? 1 : Wavelet::maxBands);
     }
   }
 

--- a/src/librawspeed/io/Endianness.h
+++ b/src/librawspeed/io/Endianness.h
@@ -26,6 +26,18 @@
 #include <cstdint>
 #include <cstring>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+
+#define BSWAP16(A) _byteswap_ushort(A)
+#define BSWAP32(A) _byteswap_ulong(A)
+#define BSWAP64(A) _byteswap_uint64(A)
+#else
+#define BSWAP16(A) __builtin_bswap16(A)
+#define BSWAP32(A) __builtin_bswap32(A)
+#define BSWAP64(A) __builtin_bswap64(A)
+#endif
+
 namespace rawspeed {
 
 enum class Endianness : uint16_t {
@@ -59,18 +71,6 @@ inline Endianness getHostEndianness() {
   return getHostEndiannessRuntime();
 #endif
 }
-
-#ifdef _MSC_VER
-#include <intrin.h>
-
-#define BSWAP16(A) _byteswap_ushort(A)
-#define BSWAP32(A) _byteswap_ulong(A)
-#define BSWAP64(A) _byteswap_uint64(A)
-#else
-#define BSWAP16(A) __builtin_bswap16(A)
-#define BSWAP32(A) __builtin_bswap32(A)
-#define BSWAP64(A) __builtin_bswap64(A)
-#endif
 
 inline int8_t getByteSwapped(int8_t v) { return v; }
 inline uint8_t getByteSwapped(uint8_t v) { return v; }


### PR DESCRIPTION
This PR fixes two issues that made it impossible to build rawspeed on Windows with Clang (and probably MSVC too, though I have not tested that).

Note that I'm currently building the library without any of the external dependencies, and hence there could exist other problematic code paths that I'm not hitting.