### PR TITLE
Sony ILCE-7M5 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14029,9 +14029,9 @@
 		<Sensor black="512" white="16383"/>
 		<ColorMatrices>
 			<ColorMatrix planes="3">
-				<ColorMatrixRow plane="0">7460 -2365 -588</ColorMatrixRow>
-				<ColorMatrixRow plane="1">-5687 13442 2474</ColorMatrixRow>
-				<ColorMatrixRow plane="2">-624 1156 6584</ColorMatrixRow>
+				<ColorMatrixRow plane="0">9089 -3577 -787</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3563 11326 2557</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-114 928 5904</ColorMatrixRow>
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -14017,8 +14017,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="ILCE-7M5" supported="unknown-no-samples">
+	<Camera make="SONY" model="ILCE-7M5">
 		<ID make="Sony" model="ILCE-7M5">Sony ILCE-7M5</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-8" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">7460 -2365 -588</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-5687 13442 2474</ColorMatrixRow>
+				<ColorMatrixRow plane="2">-624 1156 6584</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7C">
 		<ID make="Sony" model="ILCE-7C">Sony ILCE-7C</ID>


### PR DESCRIPTION
Partly addresses [#19917](https://github.com/darktable-org/darktable/issues/19917) _for lossless only_.

ADC 18.1 color matrix is not marked as final.