### PR TITLE
Remove bogus Canon EOS aliases

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -310,7 +310,6 @@
 		<Aliases>
 			<Alias id="EOS Digital Rebel XT">Canon EOS DIGITAL REBEL XT</Alias>
 			<Alias id="EOS Kiss Digital N">Canon EOS Kiss Digital N</Alias>
-			<Alias id="EOS 350D">Canon EOS 350D</Alias>
 			<Alias id="EOS 350D">Canon EOS 350D Digital</Alias>
 		</Aliases>
 		<ColorMatrices>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -384,7 +384,6 @@
 		<Crop x="22" y="18" width="4290" height="2856"/>
 		<Aliases>
 			<Alias id="EOS Digital Rebel XSi">Canon EOS DIGITAL REBEL XSi</Alias>
-			<Alias id="EOS Kiss Digital X2">Canon EOS Kiss Digital X2</Alias>
 			<Alias id="EOS Kiss X2">Canon EOS Kiss X2</Alias>
 		</Aliases>
 		<ColorMatrices>
@@ -1293,7 +1292,6 @@
 		</BlackAreas>
 		<Aliases>
 			<Alias id="EOS Digital Rebel XS">Canon EOS DIGITAL REBEL XS</Alias>
-			<Alias id="EOS Kiss Digital F">Canon EOS Kiss Digital F</Alias>
 			<Alias id="EOS Kiss F">Canon EOS Kiss F</Alias>
 		</Aliases>
 		<ColorMatrices>


### PR DESCRIPTION
X-ref https://github.com/darktable-org/darktable/issues/15299, https://github.com/darktable-org/darktable/commit/c404c118273bd90bbcbb4e60df1fd4e4b6393e9b, https://github.com/darktable-org/darktable/commit/9e7a53ad2d16c762286331356dacf9b007feb192, and https://github.com/darktable-org/darktable/commit/3fb92ee6aa8f6337c1c8dc33d86fd5377a48919f

See also https://global.canon/en/c-museum/product/dslr797.html and https://global.canon/en/c-museum/product/dslr798.html

EOS 350D is no different to 300D and 400D - there is only the base "EOS 350D DIGITAL" to normalize, [w/ the exception of "EOS 350D Digital"](https://github.com/darktable-org/darktable/pull/1055) in presumably one firmware version.