### PR TITLE
Bump github/codeql-action from 3 to 4

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Initialize CodeQL (for CodeQL static analysis)
         timeout-minutes: 1
         if: inputs.flavor == 'CodeQLAnalysis'
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: cpp
       - name: Set up JDK 11 (for SonarCloud static analysis)
@@ -500,7 +500,7 @@ jobs:
       - name: Upload results of clang-tidy static analysis [SARIF]
         timeout-minutes: 1
         if: inputs.flavor == 'ClangTidy' && failure() && steps.CC-CTSA.conclusion == 'failure'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "${{ github.workspace }}/codechecker_clangtidy_report.json"
           checkout_path: "${{ github.workspace }}/rawspeed"
@@ -538,7 +538,7 @@ jobs:
       - name: Upload results of clang static analysis [SARIF] (plain mode)
         timeout-minutes: 1
         if: inputs.flavor == 'ClangStaticAnalysis' && failure() && steps.CC-CSA-plain.conclusion == 'failure'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "${{ github.workspace }}/codechecker_report.json"
           checkout_path: "${{ github.workspace }}/rawspeed"
@@ -576,7 +576,7 @@ jobs:
       - name: Upload results of clang static analysis [SARIF] (plain mode)
         timeout-minutes: 1
         if: inputs.flavor == 'ClangCTUStaticAnalysis' && failure() && steps.CC-CSA-CTU.conclusion == 'failure'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "${{ github.workspace }}/codechecker_ctu_report.json"
           checkout_path: "${{ github.workspace }}/rawspeed"
@@ -594,7 +594,7 @@ jobs:
       - name: Perform CodeQL static analysis
         timeout-minutes: 11
         if: inputs.flavor == 'CodeQLAnalysis' && !cancelled() && steps.build.conclusion != 'skipped'
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
       - name: Perform SonarCloud static analysis
         timeout-minutes: 6
         if: inputs.flavor == 'SonarCloudStaticAnalysis'


### PR DESCRIPTION
See https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

Addresses the warnings that started appearing in actions output.