### PR TITLE
Adjust Kodak DCS Pro 14n normalization

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17677,7 +17677,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Kodak" model="DCS Pro 14N">
-		<ID make="Kodak" model="DCS Pro 14N">Kodak DCS Pro 14n</ID>
+		<ID make="Kodak" model="DCS Pro 14n">Kodak DCS Pro 14n</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>


### PR DESCRIPTION
Lowercase to align to product badge, manual, and marketing.

See also Kodak DCS Pro 14nx