### PR TITLE
docs: support table generation tweaks

### DIFF
--- a/docs/CameraSupport.rst
+++ b/docs/CameraSupport.rst
@@ -82,7 +82,7 @@ Camera Support
         models = OrderedDict(sorted(models.items()))
         for model, content in models.items():
             # Leaf cameras have aliases in their model name, we need to split them here
-            aliases = model.split("/")
+            aliases = model.split("/", 1) if make == "Leaf" else [model]
             model_name = aliases[0]
 
             # Concatenate official aliases with the ones we found above

--- a/docs/CameraSupport.rst
+++ b/docs/CameraSupport.rst
@@ -85,8 +85,8 @@ Camera Support
             aliases = model.split("/", 1) if make == "Leaf" else [model]
             model_name = aliases[0]
 
-            # Concatenate official aliases with the ones we found above
-            aliases = list(content['aliases']) + aliases[1:]
+            # Concatenate unique official aliases with the ones we found above
+            aliases = [a for a in list(content['aliases']) if a != model_name] + aliases[1:]
 
             modes = [mode for mode in content['modes']
                     if "unsupported" not in mode]


### PR DESCRIPTION
Actually do as the comment suggests for Leaf cameras only, and only up to the first delimiter.

Prevents e.g. Kodak DCS Pro SLR/n from being split.

We also don't want duplicated aliases for e.g. Hasselblad X1D II 50C, X2D 100C, X2D II 100C.