### PR TITLE
Adjust Panasonic UniqueCameraModel mappings

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11617,7 +11617,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-GX880">
-		<ID make="Panasonic" model="DC-GX880">Panasonic DC-GX880</ID>
+		<ID make="Panasonic" model="DC-GX880">Panasonic DC-GF10</ID>
 		<Crop x="0" y="0" width="-210" height="0"/>
 		<Sensor black="143" white="4095"/>
 		<Aliases>
@@ -11633,7 +11633,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-GX880" mode="4:3">
-		<ID make="Panasonic" model="DC-GX880">Panasonic DC-GX880</ID>
+		<ID make="Panasonic" model="DC-GX880">Panasonic DC-GF10</ID>
 		<Crop x="0" y="0" width="-210" height="0"/>
 		<Sensor black="143" white="4095"/>
 		<Aliases>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11264,13 +11264,13 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-FZ81" supported="unknown-no-samples">
-		<ID make="Panasonic" model="DC-FZ81">Panasonic DC-FZ82</ID>
+		<ID make="Panasonic" model="DC-FZ81">Panasonic DC-FZ80</ID>
 	</Camera>
 	<Camera make="Panasonic" model="DC-FZ83" supported="unknown-no-samples">
-		<ID make="Panasonic" model="DC-FZ83">Panasonic DC-FZ82</ID>
+		<ID make="Panasonic" model="DC-FZ83">Panasonic DC-FZ80</ID>
 	</Camera>
 	<Camera make="Panasonic" model="DC-FZ82">
-		<ID make="Panasonic" model="DC-FZ82">Panasonic DC-FZ82</ID>
+		<ID make="Panasonic" model="DC-FZ82">Panasonic DC-FZ80</ID>
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="143" white="4095"/>
 		<Aliases>
@@ -11289,7 +11289,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-FZ82" mode="4:3">
-		<ID make="Panasonic" model="DC-FZ82">Panasonic DC-FZ82</ID>
+		<ID make="Panasonic" model="DC-FZ82">Panasonic DC-FZ80</ID>
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="143" white="4095"/>
 		<Aliases>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -10974,6 +10974,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ60">
+		<ID make="Panasonic" model="DMC-TZ60">Panasonic DMC-ZS40</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="145" white="3971"/>
 		<ColorMatrices>
@@ -10985,6 +10986,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ60" mode="3:2">
+		<ID make="Panasonic" model="DMC-TZ60">Panasonic DMC-ZS40</ID>
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="145" white="3971"/>
 		<ColorMatrices>
@@ -10996,6 +10998,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ60" mode="16:9">
+		<ID make="Panasonic" model="DMC-TZ60">Panasonic DMC-ZS40</ID>
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="145" white="3956"/>
 		<ColorMatrices>
@@ -11007,6 +11010,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ60" mode="1:1">
+		<ID make="Panasonic" model="DMC-TZ60">Panasonic DMC-ZS40</ID>
 		<Crop x="0" y="0" width="-8" height="0"/>
 		<Sensor black="145" white="3956"/>
 		<ColorMatrices>
@@ -11018,6 +11022,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-TZ60" mode="4:3">
+		<ID make="Panasonic" model="DMC-TZ60">Panasonic DMC-ZS40</ID>
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="145" white="3956"/>
 		<ColorMatrices>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8845,6 +8845,7 @@
 		<ID make="Panasonic" model="DMC-FZ42">Panasonic DMC-FZ40</ID>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ45">
+		<ID make="Panasonic" model="DMC-FZ45">Panasonic DMC-FZ40</ID>
 		<Crop x="0" y="0" width="-58" height="-10"/>
 		<Sensor black="150" white="3986"/>
 		<Aliases>


### PR DESCRIPTION
Change to canonical model as set by ADC in resulting DNG's UniqueCameraModel tags.

For all other Panasonic cameras the canonical model is used already in ID mapping, or [ID mappings are to be removed](https://github.com/darktable-org/rawspeed/pull/939) since the camera entry is already matching the canonical model.

AFAICT this is used in

1. [Setting `canonical_id` from DNGs](https://github.com/darktable-org/rawspeed/blob/f2f50db1b2c7b1dfcdb20de8c69fcfd6b58eef94/src/librawspeed/decoders/DngDecoder.cpp#L727) (not clear who uses this; darktable doesn't)

2. [dngmeta.sh darktable tool for making new camera.xml entries](https://github.com/darktable-org/darktable/blob/d61bb2f12c0efabc51cb58a55afd6b70bab1bfb6/tools/dngmeta.sh#L106)

I can split into individual PRs per camera if preferred...