### PR TITLE
DngOpcodes: add WarpRectilinear2 placeholder

### DIFF
--- a/src/librawspeed/common/DngOpcodes.cpp
+++ b/src/librawspeed/common/DngOpcodes.cpp
@@ -796,6 +796,8 @@ DngOpcodes::Map(uint32_t code) {
         "ScalePerColumn",
         &DngOpcodes::constructor<
             DngOpcodes::ScalePerRowOrCol<DeltaRowOrColBase::SelectX>>);
+  case 14U:
+    return make_pair("WarpRectilinear2", nullptr);
   default:
     return std::nullopt;
   }


### PR DESCRIPTION
Introduced in DNG spec version 1.6.0.0

This is just for completeness, doesn't really change anything apart from the exception message.