### PR TITLE
Remove unnecessary DNG entries

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -18627,9 +18627,6 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="Nikon" model="LS-5000" mode="dng">
-		<ID make="Nikon" model="LS-5000">Nikon LS-5000</ID>
-	</Camera>
 	<Camera make="Sigma" model="Sigma BF" mode="dng">
 		<ID make="Sigma" model="BF">Sigma BF</ID>
 	</Camera>


### PR DESCRIPTION
Make, Model (and UniqueCameraModel) tags for these are already "clean" so there is no ID remapping done, as for most other devices outputting DNG.

This one (scanner) slipped through in #943