### PR TITLE
Phase One IQ4 150MP ID fix

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -17703,8 +17703,7 @@
 	<Camera make="Phase One A/S" model="IQ3 100MP Trichr" supported="no">
 		<ID make="Phase One" model="IQ3 100MP Trichr">Phase One IQ3 100MP Trichr</ID>
 	</Camera>
-	<Camera make="Phase One A/S" model="IQ4 150MP" supported="no">
-		<ID make="Phase One" model="IQ4 150MP">Phase One IQ4 150MP</ID>
+	<Camera make="Phase One" model="IQ4 150MP" supported="no">
 	</Camera>
 	<Camera make="Kodak" model="DCS Pro SLR/n">
 		<ID make="Kodak" model="DCS Pro SLR/n">Kodak DCS Pro SLR/n</ID>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -460,6 +460,7 @@
       <xs:enumeration value="Paralenz"/>
       <xs:enumeration value="Pentax"/>
       <xs:enumeration value="Phase One A/S"/>
+      <xs:enumeration value="Phase One"/>
       <xs:enumeration value="Pixelink"/>
       <xs:enumeration value="RICOH IMAGING COMPANY, LTD."/>
       <xs:enumeration value="RICOH"/>


### PR DESCRIPTION
No "A/S" for maker in this model, so ID remapping not needed.