### PR TITLE
Restore Panasonic DC-G95 ID mapping

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -11266,6 +11266,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-G95">
+		<ID make="Panasonic" model="DC-G95">Panasonic DC-G99</ID>
 		<Crop x="0" y="0" width="-66" height="0"/>
 		<Sensor black="144" white="4095"/>
 		<Aliases>
@@ -11285,6 +11286,7 @@
 		</ColorMatrices>
 	</Camera>
 	<Camera make="Panasonic" model="DC-G95" mode="4:3">
+		<ID make="Panasonic" model="DC-G95">Panasonic DC-G99</ID>
 		<Crop x="0" y="0" width="-66" height="0"/>
 		<Sensor black="144" white="4095"/>
 		<Aliases>


### PR DESCRIPTION
The regex in commit 2f7c77f1453d5bd80adfa39ea4b803dad2afb1f2 correctly identified this for removal, but the original entry was inaccurate.

ADC maps this to "UniqueCameraModel" Panasonic DC-G99.