### PR TITLE
LJpeg: support predictor modes 2–7

### DIFF
--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -88,10 +88,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
                     });
 
     const int numLJpegRowsPerRestartInterval = bs.getI32();
+    const int predictorMode = bs.getByte();
 
     rawspeed::LJpegDecompressor d(
         mRaw, rawspeed::iRectangle2D(mRaw->dim.x, mRaw->dim.y), frame, rec,
-        numLJpegRowsPerRestartInterval,
+        numLJpegRowsPerRestartInterval, predictorMode,
         bs.getSubStream(/*offset=*/0).peekRemainingBuffer().getAsArray1DRef());
     mRaw->createData();
     (void)d.decode();

--- a/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/fuzz/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -90,9 +90,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
     const int numLJpegRowsPerRestartInterval = bs.getI32();
     const int predictorMode = bs.getByte();
 
+    const rawspeed::LJpegDecompressor::DecodeSettings settings{
+        numLJpegRowsPerRestartInterval, predictorMode};
     rawspeed::LJpegDecompressor d(
         mRaw, rawspeed::iRectangle2D(mRaw->dim.x, mRaw->dim.y), frame, rec,
-        numLJpegRowsPerRestartInterval, predictorMode,
+        settings,
         bs.getSubStream(/*offset=*/0).peekRemainingBuffer().getAsArray1DRef());
     mRaw->createData();
     (void)d.decode();

--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -699,12 +699,20 @@ void DngDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
 
   TiffID id;
 
-  try {
+  if (mRootIFD->hasEntryRecursive(TiffTag::MAKE) &&
+      mRootIFD->hasEntryRecursive(TiffTag::MODEL)) {
     id = mRootIFD->getID();
-  } catch (const RawspeedException& e) {
-    mRaw->setError(e.what());
-    // not all dngs have MAKE/MODEL entries,
-    // will be dealt with by using UNIQUECAMERAMODEL below
+  } else if (mRootIFD->hasEntryRecursive(TiffTag::UNIQUECAMERAMODEL)) {
+    // Not all DNGs have MAKE/MODEL entries (e.g. Blackmagic CinemaDNG).
+    // Fall back to UNIQUECAMERAMODEL for identification.
+    std::string unique =
+        mRootIFD->getEntryRecursive(TiffTag::UNIQUECAMERAMODEL)->getString();
+    if (unique.empty())
+      ThrowRDE("UNIQUECAMERAMODEL is empty");
+    id.make = unique;
+    id.model = unique;
+  } else {
+    ThrowRDE("DNG has neither MAKE/MODEL nor UNIQUECAMERAMODEL");
   }
 
   // Set the make and model

--- a/src/librawspeed/decoders/SimpleTiffDecoder.h
+++ b/src/librawspeed/decoders/SimpleTiffDecoder.h
@@ -39,7 +39,8 @@ class SimpleTiffDecoder : public AbstractTiffDecoder {
 
 public:
   SimpleTiffDecoder(TiffRootIFDOwner&& root, Buffer file)
-      : AbstractTiffDecoder(std::move(root), file) {}
+      : AbstractTiffDecoder(std::move(root), file), raw(nullptr), width(0),
+        height(0), off(0), c2(0) {}
 
   void prepareForRawDecoding();
 

--- a/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
@@ -35,6 +35,7 @@
 #include "io/ByteStream.h"
 #include "io/Endianness.h"
 #include "io/IOException.h"
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <string>

--- a/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
+++ b/src/librawspeed/decompressors/AbstractDngDecompressor.cpp
@@ -51,6 +51,64 @@
 
 namespace rawspeed {
 
+namespace {
+
+// Some DNG files (e.g. Blackmagic CinemaDNG) use TIFF compression=7
+// (lossless JPEG) but the actual tile data contains lossy DCT JPEG
+// (SOF0/SOF1/SOF2 with DQT). Detect this by scanning the first few
+// JPEG markers in the tile stream.
+[[nodiscard]] bool tileContainsLossyJpeg(const ByteStream& bs) {
+  const auto remaining = bs.getRemainSize();
+  if (remaining < 4)
+    return false;
+
+  // Must start with JPEG SOI marker
+  if (bs.peekByte(0) != 0xFF || bs.peekByte(1) != 0xD8)
+    return false;
+
+  // Scan markers after SOI. Stop after a reasonable number of bytes.
+  const auto limit =
+      std::min(remaining, static_cast<ByteStream::size_type>(1024));
+  ByteStream::size_type pos = 2;
+
+  while (pos + 3 < limit) {
+    if (bs.peekByte(pos) != 0xFF)
+      return false; // Invalid marker - stop scanning
+
+    const uint8_t marker = bs.peekByte(pos + 1);
+
+    // DQT (quantization table) is definitive proof of lossy JPEG
+    if (marker == 0xDB) // DQT
+      return true;
+
+    // SOF0/SOF1/SOF2 = lossy DCT-based JPEG
+    if (marker == 0xC0 || marker == 0xC1 || marker == 0xC2)
+      return true;
+
+    // SOF3 = lossless - this is what compression=7 should be
+    if (marker == 0xC3)
+      return false;
+
+    // SOS = start of scan data - stop scanning
+    if (marker == 0xDA)
+      return false;
+
+    // Skip this marker segment
+    if (pos + 4 > remaining)
+      return false;
+    const auto segLen = static_cast<uint16_t>(
+        (static_cast<uint16_t>(bs.peekByte(pos + 2)) << 8) |
+        static_cast<uint16_t>(bs.peekByte(pos + 3)));
+    if (segLen < 2)
+      return false;
+    pos += 2 + segLen;
+  }
+
+  return false;
+}
+
+} // namespace
+
 template <> void AbstractDngDecompressor::decompressThread<1>() const noexcept {
 #ifdef HAVE_OPENMP
 #pragma omp for schedule(static)
@@ -116,6 +174,15 @@ template <> void AbstractDngDecompressor::decompressThread<7>() const noexcept {
   for (const auto& e :
        Array1DRef(slices.data(), implicit_cast<int>(slices.size()))) {
     try {
+#ifdef HAVE_JPEG
+      // Some cameras (e.g. Blackmagic CinemaDNG) mislabel lossy DCT JPEG
+      // tiles as compression=7 (lossless JPEG). Detect and redirect.
+      if (tileContainsLossyJpeg(e.bs)) {
+        JpegDecompressor j(e.bs.peekBuffer(e.bs.getRemainSize()), mRaw);
+        j.decode(e.offX, e.offY);
+        continue;
+      }
+#endif
       LJpegDecoder d(e.bs, mRaw);
       d.decode(e.offX, e.offY, e.width, e.height,
                iPoint2D(e.dsc.tileW, e.dsc.tileH), mFixLjpeg);

--- a/src/librawspeed/decompressors/JpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/JpegDecompressor.cpp
@@ -139,6 +139,10 @@ void JpegDecompressor::decode(uint32_t offX,
   if (JPEG_HEADER_OK != jpeg_read_header(&dinfo, static_cast<boolean>(true)))
     ThrowRDE("Unable to read JPEG header");
 
+  if (dinfo.data_precision != 8)
+    ThrowRDE("Lossy JPEG tiles with %d-bit precision are not yet supported.",
+             dinfo.data_precision);
+
   jpeg_start_decompress(&dinfo);
   if (dinfo.output_components != static_cast<int>(mRaw->getCpp()))
     ThrowRDE("Component count doesn't match");

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -32,8 +32,10 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <vector>
 
 using std::copy_n;
@@ -104,7 +106,7 @@ void LJpegDecoder::decode(uint32_t offsetX, uint32_t offsetY, uint32_t width,
 Buffer::size_type LJpegDecoder::decodeScan() {
   invariant(frame.cps > 0);
 
-  if (predictorMode != 1)
+  if (predictorMode < 1 || predictorMode > 7)
     ThrowRDE("Unsupported predictor mode: %u", predictorMode);
 
   for (uint32_t i = 0; i < frame.cps; i++)
@@ -123,9 +125,6 @@ Buffer::size_type LJpegDecoder::decodeScan() {
                     return {*hts[i], initPred[i]};
                   });
 
-  const iRectangle2D imgFrame = {
-      {static_cast<int>(offX), static_cast<int>(offY)},
-      {static_cast<int>(w), static_cast<int>(h)}};
   const auto jpegFrameDim = iPoint2D(frame.w, frame.h);
 
   if (implicit_cast<int64_t>(maxDim.x) * implicit_cast<int>(mRaw->getCpp()) >
@@ -137,31 +136,119 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   if (maxRes.area() != N_COMP * jpegFrameDim.area())
     ThrowRDE("LJpeg frame area does not match maximal tile area");
 
-  if (maxRes.x % jpegFrameDim.x != 0 || maxRes.y % jpegFrameDim.y != 0)
-    ThrowRDE("Maximal output tile size is not a multiple of LJpeg frame size");
+  // Detect whether the JPEG frame uses an inverted reshape (e.g. DJI/Blackmagic
+  // CinemaDNG): JPEG frame is wider than tile and shorter, with packed rows.
+  // Standard (Adobe): maxRes.x >= jpegFrameDim.x (tile is wider/equal)
+  // Inverted (DJI):   jpegFrameDim.x > maxRes.x  (JPEG frame is wider)
+  bool invertedReshape = (jpegFrameDim.x > maxRes.x);
 
-  auto MCUSize = iPoint2D{maxRes.x / jpegFrameDim.x, maxRes.y / jpegFrameDim.y};
-  if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
-    ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
+  if (!invertedReshape) {
+    // Standard case: tile width is a multiple of JPEG frame width.
+    if (maxRes.x % jpegFrameDim.x != 0 || maxRes.y % jpegFrameDim.y != 0)
+      ThrowRDE(
+          "Maximal output tile size is not a multiple of LJpeg frame size");
 
+    auto MCUSize =
+        iPoint2D{maxRes.x / jpegFrameDim.x, maxRes.y / jpegFrameDim.y};
+    if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
+      ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
+
+    const iRectangle2D imgFrame = {
+        {static_cast<int>(offX), static_cast<int>(offY)},
+        {static_cast<int>(w), static_cast<int>(h)}};
+    const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
+
+    int numLJpegRowsPerRestartInterval;
+    if (numMCUsPerRestartInterval == 0) {
+      numLJpegRowsPerRestartInterval = jpegFrameDim.y;
+    } else {
+      const int numMCUsPerRow = jpegFrameDim.x;
+      if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
+        ThrowRDE("Restart interval is not a multiple of frame row size");
+      numLJpegRowsPerRestartInterval =
+          numMCUsPerRestartInterval / numMCUsPerRow;
+    }
+
+    LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
+                        numLJpegRowsPerRestartInterval,
+                        implicit_cast<int>(predictorMode),
+                        input.peekRemainingBuffer().getAsArray1DRef());
+    return d.decode();
+  }
+
+  // Inverted reshape case (DJI/Blackmagic CinemaDNG):
+  // JPEG frame is wider than tile, e.g. JPEG=8000x1500 1-comp, tile=4000x3000.
+  // Each JPEG row contains 'widthPack' tile rows concatenated.
+  if (N_COMP != 1)
+    ThrowRDE("Inverted reshape only supported for single-component LJpeg");
+
+  if (jpegFrameDim.x % maxRes.x != 0)
+    ThrowRDE("LJpeg frame width is not a multiple of tile width");
+  if (maxRes.y % jpegFrameDim.y != 0)
+    ThrowRDE("Tile height is not a multiple of LJpeg frame height");
+
+  const int widthPack = jpegFrameDim.x / maxRes.x;
+  if (widthPack * jpegFrameDim.y != maxRes.y)
+    ThrowRDE("Inverted reshape dimensions mismatch");
+
+  if (widthPack < 1 || widthPack > 4)
+    ThrowRDE("Unexpected row packing factor: %d", widthPack);
+
+  // Decode into a temporary buffer at JPEG frame dimensions.
+  // MCU is {1,1} since we have a single component.
+  const auto MCUSize = iPoint2D{1, 1};
+
+  // Create a temporary raw image to decode the JPEG into.
+  // RawImage::create with dimensions already calls createData() internally.
+  RawImage tmpRaw = RawImage::create(
+      iPoint2D(jpegFrameDim.x, jpegFrameDim.y), RawImageType::UINT16, 1);
+
+  const iRectangle2D tmpFrame = {
+      {0, 0}, {jpegFrameDim.x, jpegFrameDim.y}};
   const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
   int numLJpegRowsPerRestartInterval;
   if (numMCUsPerRestartInterval == 0) {
-    // Restart interval not enabled, so all of the rows
-    // are contained in the first (implicit) restart interval.
     numLJpegRowsPerRestartInterval = jpegFrameDim.y;
   } else {
     const int numMCUsPerRow = jpegFrameDim.x;
     if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
       ThrowRDE("Restart interval is not a multiple of frame row size");
-    numLJpegRowsPerRestartInterval = numMCUsPerRestartInterval / numMCUsPerRow;
+    numLJpegRowsPerRestartInterval =
+        numMCUsPerRestartInterval / numMCUsPerRow;
   }
 
-  LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
+  LJpegDecompressor d(tmpRaw, tmpFrame, jpegFrame, rec,
                       numLJpegRowsPerRestartInterval,
+                      implicit_cast<int>(predictorMode),
                       input.peekRemainingBuffer().getAsArray1DRef());
-  return d.decode();
+  auto consumed = d.decode();
+
+  // Deinterleave: each JPEG row of width (widthPack * tileW) maps to
+  // widthPack consecutive tile rows of width tileW.
+  const auto tmpData = tmpRaw->getU16DataAsUncroppedArray2DRef();
+  const auto outData = mRaw->getU16DataAsUncroppedArray2DRef();
+
+  const int tileW = implicit_cast<int>(w);
+  const int cpp = implicit_cast<int>(mRaw->getCpp());
+  const int outRowPixels = cpp * tileW;
+
+  for (int jpegRow = 0; jpegRow < jpegFrameDim.y; ++jpegRow) {
+    for (int pack = 0; pack < widthPack; ++pack) {
+      const int tileRow =
+          implicit_cast<int>(offY) + jpegRow * widthPack + pack;
+      if (tileRow >= mRaw->dim.y)
+        continue;
+      const int srcCol = pack * outRowPixels;
+      const int dstCol = cpp * implicit_cast<int>(offX);
+      for (int col = 0; col < outRowPixels && (srcCol + col) < jpegFrameDim.x;
+           ++col) {
+        outData(tileRow, dstCol + col) = tmpData(jpegRow, srcCol + col);
+      }
+    }
+  }
+
+  return consumed;
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -199,11 +199,10 @@ Buffer::size_type LJpegDecoder::decodeScan() {
 
   // Create a temporary raw image to decode the JPEG into.
   // RawImage::create with dimensions already calls createData() internally.
-  RawImage tmpRaw = RawImage::create(
-      iPoint2D(jpegFrameDim.x, jpegFrameDim.y), RawImageType::UINT16, 1);
+  RawImage tmpRaw = RawImage::create(iPoint2D(jpegFrameDim.x, jpegFrameDim.y),
+                                     RawImageType::UINT16, 1);
 
-  const iRectangle2D tmpFrame = {
-      {0, 0}, {jpegFrameDim.x, jpegFrameDim.y}};
+  const iRectangle2D tmpFrame = {{0, 0}, {jpegFrameDim.x, jpegFrameDim.y}};
   const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
   int numLJpegRowsPerRestartInterval;
@@ -213,8 +212,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
     const int numMCUsPerRow = jpegFrameDim.x;
     if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
       ThrowRDE("Restart interval is not a multiple of frame row size");
-    numLJpegRowsPerRestartInterval =
-        numMCUsPerRestartInterval / numMCUsPerRow;
+    numLJpegRowsPerRestartInterval = numMCUsPerRestartInterval / numMCUsPerRow;
   }
 
   LJpegDecompressor d(tmpRaw, tmpFrame, jpegFrame, rec,
@@ -234,8 +232,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
 
   for (int jpegRow = 0; jpegRow < jpegFrameDim.y; ++jpegRow) {
     for (int pack = 0; pack < widthPack; ++pack) {
-      const int tileRow =
-          implicit_cast<int>(offY) + jpegRow * widthPack + pack;
+      const int tileRow = implicit_cast<int>(offY) + jpegRow * widthPack + pack;
       if (tileRow >= mRaw->dim.y)
         continue;
       const int srcCol = pack * outRowPixels;

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -152,57 +152,68 @@ Buffer::size_type LJpegDecoder::decodeScan() {
     if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
       ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
 
-    const iRectangle2D imgFrame = {
-        {static_cast<int>(offX), static_cast<int>(offY)},
-        {static_cast<int>(w), static_cast<int>(h)}};
-    const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
+    // Standard MCU layouts have MCU.x >= MCU.y: {1,1}, {2,1}, {3,1},
+    // {4,1}, {2,2}. If the MCU is purely vertical (e.g., {1,2}), the
+    // encoder uses horizontal component interleaving with wider effective
+    // JPEG rows that must be reshaped. Fall through to inverted reshape.
+    if (MCUSize.x >= MCUSize.y) {
+      const iRectangle2D imgFrame = {
+          {static_cast<int>(offX), static_cast<int>(offY)},
+          {static_cast<int>(w), static_cast<int>(h)}};
+      const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
-    int numLJpegRowsPerRestartInterval;
-    if (numMCUsPerRestartInterval == 0) {
-      numLJpegRowsPerRestartInterval = jpegFrameDim.y;
-    } else {
-      const int numMCUsPerRow = jpegFrameDim.x;
-      if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
-        ThrowRDE("Restart interval is not a multiple of frame row size");
-      numLJpegRowsPerRestartInterval =
-          numMCUsPerRestartInterval / numMCUsPerRow;
+      int numLJpegRowsPerRestartInterval;
+      if (numMCUsPerRestartInterval == 0) {
+        numLJpegRowsPerRestartInterval = jpegFrameDim.y;
+      } else {
+        const int numMCUsPerRow = jpegFrameDim.x;
+        if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
+          ThrowRDE("Restart interval is not a multiple of frame row size");
+        numLJpegRowsPerRestartInterval =
+            numMCUsPerRestartInterval / numMCUsPerRow;
+      }
+
+      LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
+                          numLJpegRowsPerRestartInterval,
+                          implicit_cast<int>(predictorMode),
+                          input.peekRemainingBuffer().getAsArray1DRef());
+      return d.decode();
     }
-
-    LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
-                        numLJpegRowsPerRestartInterval,
-                        implicit_cast<int>(predictorMode),
-                        input.peekRemainingBuffer().getAsArray1DRef());
-    return d.decode();
   }
 
-  // Inverted reshape case (DJI/Blackmagic CinemaDNG):
-  // JPEG frame is wider than tile, e.g. JPEG=8000x1500 1-comp, tile=4000x3000.
-  // Each JPEG row contains 'widthPack' tile rows concatenated.
-  if (N_COMP != 1)
-    ThrowRDE("Inverted reshape only supported for single-component LJpeg");
+  // Inverted reshape case:
+  // The effective decoded width per JPEG row exceeds the tile width.
+  // This occurs when:
+  //   (a) The JPEG frame is wider than the tile (DJI/Blackmagic CinemaDNG):
+  //       e.g., JPEG=8000x1500 1-comp, tile=4000x3000.
+  //   (b) Multi-component JPEG with vertical MCU ratio:
+  //       e.g., JPEG=592x79 2-comp, tile=592x158 (effectiveWidth=1184).
+  // In both cases, components are interleaved horizontally, and each JPEG row
+  // contains 'widthPack' tile rows of pixel data concatenated.
+  const int effectiveJpegWidth = jpegFrameDim.x * N_COMP;
 
-  if (jpegFrameDim.x % maxRes.x != 0)
-    ThrowRDE("LJpeg frame width is not a multiple of tile width");
+  if (effectiveJpegWidth % maxRes.x != 0)
+    ThrowRDE("Effective JPEG width is not a multiple of tile width");
   if (maxRes.y % jpegFrameDim.y != 0)
     ThrowRDE("Tile height is not a multiple of LJpeg frame height");
 
-  const int widthPack = jpegFrameDim.x / maxRes.x;
+  const int widthPack = effectiveJpegWidth / maxRes.x;
   if (widthPack * jpegFrameDim.y != maxRes.y)
     ThrowRDE("Inverted reshape dimensions mismatch");
 
   if (widthPack < 1 || widthPack > 4)
     ThrowRDE("Unexpected row packing factor: %d", widthPack);
 
-  // Decode into a temporary buffer at JPEG frame dimensions.
-  // MCU is {1,1} since we have a single component.
-  const auto MCUSize = iPoint2D{1, 1};
+  // Decode into a temporary buffer at effective decoded dimensions.
+  // Components are always interleaved horizontally: MCU{N_COMP, 1}.
+  const auto MCUSize = iPoint2D{N_COMP, 1};
 
   // Create a temporary raw image to decode the JPEG into.
   // RawImage::create with dimensions already calls createData() internally.
-  RawImage tmpRaw = RawImage::create(iPoint2D(jpegFrameDim.x, jpegFrameDim.y),
-                                     RawImageType::UINT16, 1);
+  RawImage tmpRaw = RawImage::create(
+      iPoint2D(effectiveJpegWidth, jpegFrameDim.y), RawImageType::UINT16, 1);
 
-  const iRectangle2D tmpFrame = {{0, 0}, {jpegFrameDim.x, jpegFrameDim.y}};
+  const iRectangle2D tmpFrame = {{0, 0}, {effectiveJpegWidth, jpegFrameDim.y}};
   const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
 
   int numLJpegRowsPerRestartInterval;
@@ -226,8 +237,8 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   const auto tmpData = tmpRaw->getU16DataAsUncroppedArray2DRef();
   const auto outData = mRaw->getU16DataAsUncroppedArray2DRef();
 
-  const int tileW = implicit_cast<int>(w);
-  const int cpp = implicit_cast<int>(mRaw->getCpp());
+  const auto tileW = implicit_cast<int>(w);
+  const auto cpp = implicit_cast<int>(mRaw->getCpp());
   const int outRowPixels = cpp * tileW;
 
   for (int jpegRow = 0; jpegRow < jpegFrameDim.y; ++jpegRow) {
@@ -238,7 +249,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
       const int srcCol = pack * outRowPixels;
       const int dstCol = cpp * implicit_cast<int>(offX);
       // Contiguous row-segment copy. Bounds guaranteed by validation:
-      // srcCol + outRowPixels <= widthPack * outRowPixels <= jpegFrameDim.x
+      // srcCol + outRowPixels <= widthPack * outRowPixels <= effectiveJpegWidth
       std::memcpy(&outData(tileRow, dstCol), &tmpData(jpegRow, srcCol),
                   sizeof(uint16_t) * outRowPixels);
     }

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -30,17 +30,138 @@
 #include "io/Buffer.h"
 #include "io/ByteStream.h"
 #include <algorithm>
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
 #include <limits>
-#include <memory>
 #include <vector>
 
-using std::copy_n;
-
 namespace rawspeed {
+
+namespace {
+
+using PerCompRecipeVec = std::vector<LJpegDecompressor::PerComponentRecipe>;
+
+struct ScanSettings final {
+  RawImage raw;
+  iRectangle2D imgFrame;
+  iPoint2D jpegFrameDim;
+  iPoint2D maxRes;
+  LJpegDecompressor::DecodeSettings decode;
+  Array1DRef<const uint8_t> input;
+};
+
+[[nodiscard]] int
+getNumLJpegRowsPerRestartInterval(uint32_t numMCUsPerRestartInterval,
+                                  iPoint2D jpegFrameDim) {
+  if (numMCUsPerRestartInterval == 0)
+    return jpegFrameDim.y;
+
+  const int numMCUsPerRow = jpegFrameDim.x;
+  if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
+    ThrowRDE("Restart interval is not a multiple of frame row size");
+  return implicit_cast<int>(numMCUsPerRestartInterval) / numMCUsPerRow;
+}
+
+[[nodiscard]] iPoint2D getMaxResolution(const RawImage& raw, iPoint2D maxDim,
+                                        int numComponents,
+                                        iPoint2D jpegFrameDim) {
+  if (implicit_cast<int64_t>(maxDim.x) * implicit_cast<int>(raw->getCpp()) >
+      std::numeric_limits<int>::max())
+    ThrowRDE("Maximal output tile is too large");
+
+  const auto maxRes =
+      iPoint2D(implicit_cast<int>(raw->getCpp()) * maxDim.x, maxDim.y);
+  if (maxRes.area() != numComponents * jpegFrameDim.area())
+    ThrowRDE("LJpeg frame area does not match maximal tile area");
+
+  return maxRes;
+}
+
+[[nodiscard]] iPoint2D
+getStandardMCUSize(int numComponents, iPoint2D jpegFrameDim, iPoint2D maxRes) {
+  if (jpegFrameDim.x > maxRes.x)
+    return {};
+
+  if (maxRes.x % jpegFrameDim.x != 0 || maxRes.y % jpegFrameDim.y != 0)
+    ThrowRDE("Maximal output tile size is not a multiple of LJpeg frame size");
+
+  const auto mcuSize =
+      iPoint2D{maxRes.x / jpegFrameDim.x, maxRes.y / jpegFrameDim.y};
+  if (mcuSize.area() != implicit_cast<uint64_t>(numComponents))
+    ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
+
+  if (mcuSize.x < mcuSize.y)
+    return {};
+
+  return mcuSize;
+}
+
+[[nodiscard]] ByteStream::size_type
+decodeStandardScan(const ScanSettings& settings, iPoint2D mcuSize,
+                   const PerCompRecipeVec& rec) {
+  const LJpegDecompressor::Frame jpegFrame = {mcuSize, settings.jpegFrameDim};
+  LJpegDecompressor d(settings.raw, settings.imgFrame, jpegFrame, rec,
+                      settings.decode, settings.input);
+  return d.decode();
+}
+
+void copyDeinterleavedRows(const RawImage& raw, RawImage tmpRaw, uint32_t offX,
+                           uint32_t offY, uint32_t tileWidth, int widthPack) {
+  const auto tmpData = tmpRaw->getU16DataAsUncroppedArray2DRef();
+  const auto outData = raw->getU16DataAsUncroppedArray2DRef();
+
+  const auto cpp = implicit_cast<int>(raw->getCpp());
+  const int outRowPixels = cpp * implicit_cast<int>(tileWidth);
+
+  for (int jpegRow = 0; jpegRow < tmpRaw->dim.y; ++jpegRow) {
+    for (int pack = 0; pack < widthPack; ++pack) {
+      const int tileRow = implicit_cast<int>(offY) + jpegRow * widthPack + pack;
+      if (tileRow >= raw->dim.y)
+        continue;
+
+      const int srcCol = pack * outRowPixels;
+      const int dstCol = cpp * implicit_cast<int>(offX);
+      std::memcpy(&outData(tileRow, dstCol), &tmpData(jpegRow, srcCol),
+                  sizeof(uint16_t) * outRowPixels);
+    }
+  }
+}
+
+[[nodiscard]] ByteStream::size_type
+decodeInvertedScan(const ScanSettings& settings, int numComponents,
+                   uint32_t offX, uint32_t offY, uint32_t tileWidth,
+                   const PerCompRecipeVec& rec) {
+  const int effectiveJpegWidth = settings.jpegFrameDim.x * numComponents;
+
+  if (effectiveJpegWidth % settings.maxRes.x != 0)
+    ThrowRDE("Effective JPEG width is not a multiple of tile width");
+  if (settings.maxRes.y % settings.jpegFrameDim.y != 0)
+    ThrowRDE("Tile height is not a multiple of LJpeg frame height");
+
+  const int widthPack = effectiveJpegWidth / settings.maxRes.x;
+  if (widthPack * settings.jpegFrameDim.y != settings.maxRes.y)
+    ThrowRDE("Inverted reshape dimensions mismatch");
+  if (widthPack < 1 || widthPack > 4)
+    ThrowRDE("Unexpected row packing factor: %d", widthPack);
+
+  const auto mcuSize = iPoint2D{numComponents, 1};
+  RawImage tmpRaw =
+      RawImage::create(iPoint2D(effectiveJpegWidth, settings.jpegFrameDim.y),
+                       RawImageType::UINT16, 1);
+  const iRectangle2D tmpFrame = {{0, 0},
+                                 {effectiveJpegWidth, settings.jpegFrameDim.y}};
+  const LJpegDecompressor::Frame jpegFrame = {mcuSize, settings.jpegFrameDim};
+
+  LJpegDecompressor d(tmpRaw, tmpFrame, jpegFrame, rec, settings.decode,
+                      settings.input);
+  const auto consumed = d.decode();
+
+  copyDeinterleavedRows(settings.raw, tmpRaw, offX, offY, tileWidth, widthPack);
+  return consumed;
+}
+
+} // namespace
 
 LJpegDecoder::LJpegDecoder(ByteStream bs, const RawImage& img)
     : AbstractLJpegDecoder(bs, img) {
@@ -113,149 +234,37 @@ Buffer::size_type LJpegDecoder::decodeScan() {
     if (frame.compInfo[i].superH != 1 || frame.compInfo[i].superV != 1)
       ThrowRDE("Unsupported subsampling");
 
-  const int N_COMP = frame.cps;
+  const int numComponents = frame.cps;
 
-  std::vector<LJpegDecompressor::PerComponentRecipe> rec;
-  rec.reserve(N_COMP);
-  std::generate_n(std::back_inserter(rec), N_COMP,
-                  [&rec, hts = getPrefixCodeDecoders(N_COMP),
-                   initPred = getInitialPredictors(
-                       N_COMP)]() -> LJpegDecompressor::PerComponentRecipe {
+  PerCompRecipeVec rec;
+  rec.reserve(numComponents);
+  std::generate_n(std::back_inserter(rec), numComponents,
+                  [&rec, hts = getPrefixCodeDecoders(numComponents),
+                   initPred = getInitialPredictors(numComponents)]()
+                      -> LJpegDecompressor::PerComponentRecipe {
                     const auto i = implicit_cast<int>(rec.size());
                     return {*hts[i], initPred[i]};
                   });
 
   const auto jpegFrameDim = iPoint2D(frame.w, frame.h);
-
-  if (implicit_cast<int64_t>(maxDim.x) * implicit_cast<int>(mRaw->getCpp()) >
-      std::numeric_limits<int>::max())
-    ThrowRDE("Maximal output tile is too large");
-
   const auto maxRes =
-      iPoint2D(implicit_cast<int>(mRaw->getCpp()) * maxDim.x, maxDim.y);
-  if (maxRes.area() != N_COMP * jpegFrameDim.area())
-    ThrowRDE("LJpeg frame area does not match maximal tile area");
+      getMaxResolution(mRaw, maxDim, numComponents, jpegFrameDim);
+  const ScanSettings settings{mRaw,
+                              {{static_cast<int>(offX), static_cast<int>(offY)},
+                               {static_cast<int>(w), static_cast<int>(h)}},
+                              jpegFrameDim,
+                              maxRes,
+                              {getNumLJpegRowsPerRestartInterval(
+                                   numMCUsPerRestartInterval, jpegFrameDim),
+                               implicit_cast<int>(predictorMode)},
+                              input.peekRemainingBuffer().getAsArray1DRef()};
 
-  // Detect whether the JPEG frame uses an inverted reshape (e.g. DJI/Blackmagic
-  // CinemaDNG): JPEG frame is wider than tile and shorter, with packed rows.
-  // Standard (Adobe): maxRes.x >= jpegFrameDim.x (tile is wider/equal)
-  // Inverted (DJI):   jpegFrameDim.x > maxRes.x  (JPEG frame is wider)
-  const bool invertedReshape = (jpegFrameDim.x > maxRes.x);
-  if (!invertedReshape) {
-    // Standard case: tile width is a multiple of JPEG frame width.
-    if (maxRes.x % jpegFrameDim.x != 0 || maxRes.y % jpegFrameDim.y != 0)
-      ThrowRDE(
-          "Maximal output tile size is not a multiple of LJpeg frame size");
+  if (const auto mcuSize =
+          getStandardMCUSize(numComponents, jpegFrameDim, maxRes);
+      mcuSize.hasPositiveArea())
+    return decodeStandardScan(settings, mcuSize, rec);
 
-    const auto MCUSize =
-        iPoint2D{maxRes.x / jpegFrameDim.x, maxRes.y / jpegFrameDim.y};
-    if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
-      ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
-
-    // Standard MCU layouts have MCU.x >= MCU.y: {1,1}, {2,1}, {3,1},
-    // {4,1}, {2,2}. If the MCU is purely vertical (e.g., {1,2}), the
-    // encoder uses horizontal component interleaving with wider effective
-    // JPEG rows that must be reshaped. Fall through to inverted reshape.
-    if (MCUSize.x >= MCUSize.y) {
-      const iRectangle2D imgFrame = {
-          {static_cast<int>(offX), static_cast<int>(offY)},
-          {static_cast<int>(w), static_cast<int>(h)}};
-      const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
-
-      int numLJpegRowsPerRestartInterval;
-      if (numMCUsPerRestartInterval == 0) {
-        numLJpegRowsPerRestartInterval = jpegFrameDim.y;
-      } else {
-        const int numMCUsPerRow = jpegFrameDim.x;
-        if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
-          ThrowRDE("Restart interval is not a multiple of frame row size");
-        numLJpegRowsPerRestartInterval =
-            numMCUsPerRestartInterval / numMCUsPerRow;
-      }
-
-      LJpegDecompressor d(mRaw, imgFrame, jpegFrame, rec,
-                          numLJpegRowsPerRestartInterval,
-                          implicit_cast<int>(predictorMode),
-                          input.peekRemainingBuffer().getAsArray1DRef());
-      return d.decode();
-    }
-  }
-
-  // Inverted reshape case:
-  // The effective decoded width per JPEG row exceeds the tile width.
-  // This occurs when:
-  //   (a) The JPEG frame is wider than the tile (DJI/Blackmagic CinemaDNG):
-  //       e.g., JPEG=8000x1500 1-comp, tile=4000x3000.
-  //   (b) Multi-component JPEG with vertical MCU ratio:
-  //       e.g., JPEG=592x79 2-comp, tile=592x158 (effectiveWidth=1184).
-  // In both cases, components are interleaved horizontally, and each JPEG row
-  // contains 'widthPack' tile rows of pixel data concatenated.
-  const int effectiveJpegWidth = jpegFrameDim.x * N_COMP;
-
-  if (effectiveJpegWidth % maxRes.x != 0)
-    ThrowRDE("Effective JPEG width is not a multiple of tile width");
-  if (maxRes.y % jpegFrameDim.y != 0)
-    ThrowRDE("Tile height is not a multiple of LJpeg frame height");
-
-  const int widthPack = effectiveJpegWidth / maxRes.x;
-  if (widthPack * jpegFrameDim.y != maxRes.y)
-    ThrowRDE("Inverted reshape dimensions mismatch");
-
-  if (widthPack < 1 || widthPack > 4)
-    ThrowRDE("Unexpected row packing factor: %d", widthPack);
-
-  // Decode into a temporary buffer at effective decoded dimensions.
-  // Components are always interleaved horizontally: MCU{N_COMP, 1}.
-  const auto MCUSize = iPoint2D{N_COMP, 1};
-
-  // Create a temporary raw image to decode the JPEG into.
-  // RawImage::create with dimensions already calls createData() internally.
-  RawImage tmpRaw = RawImage::create(
-      iPoint2D(effectiveJpegWidth, jpegFrameDim.y), RawImageType::UINT16, 1);
-
-  const iRectangle2D tmpFrame = {{0, 0}, {effectiveJpegWidth, jpegFrameDim.y}};
-  const LJpegDecompressor::Frame jpegFrame = {MCUSize, jpegFrameDim};
-
-  int numLJpegRowsPerRestartInterval;
-  if (numMCUsPerRestartInterval == 0) {
-    numLJpegRowsPerRestartInterval = jpegFrameDim.y;
-  } else {
-    const int numMCUsPerRow = jpegFrameDim.x;
-    if (numMCUsPerRestartInterval % numMCUsPerRow != 0)
-      ThrowRDE("Restart interval is not a multiple of frame row size");
-    numLJpegRowsPerRestartInterval = numMCUsPerRestartInterval / numMCUsPerRow;
-  }
-
-  LJpegDecompressor d(tmpRaw, tmpFrame, jpegFrame, rec,
-                      numLJpegRowsPerRestartInterval,
-                      implicit_cast<int>(predictorMode),
-                      input.peekRemainingBuffer().getAsArray1DRef());
-  const auto consumed = d.decode();
-
-  // Deinterleave: each JPEG row of width (widthPack * tileW) maps to
-  // widthPack consecutive tile rows of width tileW.
-  const auto tmpData = tmpRaw->getU16DataAsUncroppedArray2DRef();
-  const auto outData = mRaw->getU16DataAsUncroppedArray2DRef();
-
-  const auto tileW = implicit_cast<int>(w);
-  const auto cpp = implicit_cast<int>(mRaw->getCpp());
-  const int outRowPixels = cpp * tileW;
-
-  for (int jpegRow = 0; jpegRow < jpegFrameDim.y; ++jpegRow) {
-    for (int pack = 0; pack < widthPack; ++pack) {
-      const int tileRow = implicit_cast<int>(offY) + jpegRow * widthPack + pack;
-      if (tileRow >= mRaw->dim.y)
-        continue;
-      const int srcCol = pack * outRowPixels;
-      const int dstCol = cpp * implicit_cast<int>(offX);
-      // Contiguous row-segment copy. Bounds guaranteed by validation:
-      // srcCol + outRowPixels <= widthPack * outRowPixels <= effectiveJpegWidth
-      std::memcpy(&outData(tileRow, dstCol), &tmpData(jpegRow, srcCol),
-                  sizeof(uint16_t) * outRowPixels);
-    }
-  }
-
-  return consumed;
+  return decodeInvertedScan(settings, numComponents, offX, offY, w, rec);
 }
 
 } // namespace rawspeed

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -113,7 +113,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
     if (frame.compInfo[i].superH != 1 || frame.compInfo[i].superV != 1)
       ThrowRDE("Unsupported subsampling");
 
-  int N_COMP = frame.cps;
+  const int N_COMP = frame.cps;
 
   std::vector<LJpegDecompressor::PerComponentRecipe> rec;
   rec.reserve(N_COMP);
@@ -131,7 +131,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
       std::numeric_limits<int>::max())
     ThrowRDE("Maximal output tile is too large");
 
-  auto maxRes =
+  const auto maxRes =
       iPoint2D(implicit_cast<int>(mRaw->getCpp()) * maxDim.x, maxDim.y);
   if (maxRes.area() != N_COMP * jpegFrameDim.area())
     ThrowRDE("LJpeg frame area does not match maximal tile area");
@@ -140,15 +140,14 @@ Buffer::size_type LJpegDecoder::decodeScan() {
   // CinemaDNG): JPEG frame is wider than tile and shorter, with packed rows.
   // Standard (Adobe): maxRes.x >= jpegFrameDim.x (tile is wider/equal)
   // Inverted (DJI):   jpegFrameDim.x > maxRes.x  (JPEG frame is wider)
-  bool invertedReshape = (jpegFrameDim.x > maxRes.x);
-
+  const bool invertedReshape = (jpegFrameDim.x > maxRes.x);
   if (!invertedReshape) {
     // Standard case: tile width is a multiple of JPEG frame width.
     if (maxRes.x % jpegFrameDim.x != 0 || maxRes.y % jpegFrameDim.y != 0)
       ThrowRDE(
           "Maximal output tile size is not a multiple of LJpeg frame size");
 
-    auto MCUSize =
+    const auto MCUSize =
         iPoint2D{maxRes.x / jpegFrameDim.x, maxRes.y / jpegFrameDim.y};
     if (MCUSize.area() != implicit_cast<uint64_t>(N_COMP))
       ThrowRDE("Unexpected MCU size, does not match LJpeg component count");
@@ -222,7 +221,7 @@ Buffer::size_type LJpegDecoder::decodeScan() {
                       numLJpegRowsPerRestartInterval,
                       implicit_cast<int>(predictorMode),
                       input.peekRemainingBuffer().getAsArray1DRef());
-  auto consumed = d.decode();
+  const auto consumed = d.decode();
 
   // Deinterleave: each JPEG row of width (widthPack * tileW) maps to
   // widthPack consecutive tile rows of width tileW.
@@ -241,10 +240,10 @@ Buffer::size_type LJpegDecoder::decodeScan() {
         continue;
       const int srcCol = pack * outRowPixels;
       const int dstCol = cpp * implicit_cast<int>(offX);
-      for (int col = 0; col < outRowPixels && (srcCol + col) < jpegFrameDim.x;
-           ++col) {
-        outData(tileRow, dstCol + col) = tmpData(jpegRow, srcCol + col);
-      }
+      // Contiguous row-segment copy. Bounds guaranteed by validation:
+      // srcCol + outRowPixels <= widthPack * outRowPixels <= jpegFrameDim.x
+      std::memcpy(&outData(tileRow, dstCol), &tmpData(jpegRow, srcCol),
+                  sizeof(uint16_t) * outRowPixels);
     }
   }
 

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "decompressors/LJpegDecoder.h"
+#include "adt/Array1DRef.h"
 #include "adt/Casts.h"
 #include "adt/Invariant.h"
 #include "adt/Point.h"
@@ -106,8 +107,9 @@ decodeStandardScan(const ScanSettings& settings, iPoint2D mcuSize,
   return d.decode();
 }
 
-void copyDeinterleavedRows(const RawImage& raw, RawImage tmpRaw, uint32_t offX,
-                           uint32_t offY, uint32_t tileWidth, int widthPack) {
+void copyDeinterleavedRows(const RawImage& raw, const RawImage& tmpRaw,
+                           uint32_t offX, uint32_t offY, uint32_t tileWidth,
+                           int widthPack) {
   const auto tmpData = tmpRaw->getU16DataAsUncroppedArray2DRef();
   const auto outData = raw->getU16DataAsUncroppedArray2DRef();
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -102,8 +102,8 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
     ThrowRDE("Frame has zero size");
 
   if (iPoint2D{1, 1} != frame.mcu && iPoint2D{2, 1} != frame.mcu &&
-      iPoint2D{3, 1} != frame.mcu && iPoint2D{4, 1} != frame.mcu &&
-      iPoint2D{2, 2} != frame.mcu)
+      iPoint2D{1, 2} != frame.mcu && iPoint2D{3, 1} != frame.mcu &&
+      iPoint2D{4, 1} != frame.mcu && iPoint2D{2, 2} != frame.mcu)
     ThrowRDE("Unexpected MCU size: {%i, %i}", frame.mcu.x, frame.mcu.y);
 
   if (rec.size() != static_cast<unsigned>(frame.mcu.area()))
@@ -422,6 +422,9 @@ ByteStream::size_type LJpegDecompressor::decode() const {
   case 2:
     if (frame.mcu == MCU<2, 1>) {
       return decodeN<MCU<2, 1>>();
+    }
+    if (frame.mcu == MCU<1, 2>) {
+      return decodeN<MCU<1, 2>>();
     }
     break;
   case 3:

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -52,13 +52,12 @@ namespace rawspeed {
 LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
                                      Frame frame_,
                                      std::vector<PerComponentRecipe> rec_,
-                                     int numLJpegRowsPerRestartInterval_,
-                                     int predictorMode_,
+                                     DecodeSettings settings,
                                      Array1DRef<const uint8_t> input_)
     : mRaw(std::move(img)), input(input_), imgFrame(imgFrame_),
       frame(std::move(frame_)), rec(std::move(rec_)),
-      numLJpegRowsPerRestartInterval(numLJpegRowsPerRestartInterval_),
-      predictorMode(predictorMode_) {
+      numLJpegRowsPerRestartInterval(settings.numLJpegRowsPerRestartInterval),
+      predictorMode(settings.predictorMode) {
 
   if (mRaw->getDataType() != RawImageType::UINT16)
     ThrowRDE("Unexpected data type (%u)",

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -246,9 +246,8 @@ void LJpegDecompressor::decodeRowN(
           const int Ra = pred(MCURow, MCUСol);
           const int stripeCol = MCUSize.x * mcuIdx + MCUСol;
           const int Rb = prevStripe(MCURow, stripeCol);
-          const int Rc = (mcuIdx > 0)
-                             ? prevStripe(MCURow, stripeCol - MCUSize.x)
-                             : Rb;
+          const int Rc =
+              (mcuIdx > 0) ? prevStripe(MCURow, stripeCol - MCUSize.x) : Rb;
           prediction = computePrediction(predictorMode, Ra, Rb, Rc);
         }
         const int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
@@ -383,15 +382,14 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
       // For the first row, prevStripe points to outStripe itself (unused
       // since Use2DPred will be false).
       const Array2DRef<const uint16_t> prevStripe =
-          isFirstRow
-              ? Array2DRef<const uint16_t>(outStripe)
-              : CroppedArray2DRef<const uint16_t>(
-                    img,
-                    /*offsetCols=*/0,
-                    /*offsetRows=*/row - frame.mcu.y,
-                    /*croppedWidth=*/img.width(),
-                    /*croppedHeight=*/frame.mcu.y)
-                    .getAsArray2DRef();
+          isFirstRow ? Array2DRef<const uint16_t>(outStripe)
+                     : CroppedArray2DRef<const uint16_t>(
+                           img,
+                           /*offsetCols=*/0,
+                           /*offsetRows=*/row - frame.mcu.y,
+                           /*croppedWidth=*/img.width(),
+                           /*croppedHeight=*/frame.mcu.y)
+                           .getAsArray2DRef();
 
       if (!isFirstRow && predictorMode != 1)
         decodeRowN<MCU, N_COMP, true>(outStripe, pred, prevStripe, ht, bs);

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -212,10 +212,10 @@ inline int computePrediction(int predMode, int Ra, int Rb, int Rc) {
 
 } // namespace
 
-template <const iPoint2D& MCUSize, int N_COMP>
+template <const iPoint2D& MCUSize, int N_COMP, bool Use2DPred>
 void LJpegDecompressor::decodeRowN(
     Array2DRef<uint16_t> outStripe, Array2DRef<const uint16_t> pred,
-    int predMode, Array2DRef<const uint16_t> prevStripe,
+    Array2DRef<const uint16_t> prevStripe,
     std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
     BitStreamerJPEG& bs) const {
   invariant(MCUSize.area() == N_COMP);
@@ -238,25 +238,22 @@ void LJpegDecompressor::decodeRowN(
                              .getAsArray2DRef();
     for (int MCURow = 0; MCURow != MCUSize.y; ++MCURow) {
       for (int MCUСol = 0; MCUСol != MCUSize.x; ++MCUСol) {
-        int c = (MCUSize.x * MCURow) + MCUСol;
+        const int c = (MCUSize.x * MCURow) + MCUСol;
         int prediction;
-        if (predMode == 1) {
-          // Fast path for the common case (mode 1 = left neighbor).
+        if constexpr (!Use2DPred) {
           prediction = pred(MCURow, MCUСol);
         } else {
-          // For modes 2-7, compute Ra, Rb, Rc.
-          int Ra = pred(MCURow, MCUСol); // left neighbor
-          int stripeCol = MCUSize.x * mcuIdx + MCUСol;
-          int stripeRow = MCURow;
-          int Rb = prevStripe(stripeRow, stripeCol);
-          int Rc = (stripeCol >= MCUSize.x)
-                       ? prevStripe(stripeRow, stripeCol - MCUSize.x)
-                       : Rb; // First column: Rc = Rb
-          prediction = computePrediction(predMode, Ra, Rb, Rc);
+          const int Ra = pred(MCURow, MCUСol);
+          const int stripeCol = MCUSize.x * mcuIdx + MCUСol;
+          const int Rb = prevStripe(MCURow, stripeCol);
+          const int Rc = (mcuIdx > 0)
+                             ? prevStripe(MCURow, stripeCol - MCUSize.x)
+                             : Rb;
+          prediction = computePrediction(predictorMode, Ra, Rb, Rc);
         }
-        int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
-                       .decodeDifference(bs);
-        int pix = prediction + diff;
+        const int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
+                             .decodeDifference(bs);
+        const int pix = prediction + diff;
         outTile(MCURow, MCUСol) = uint16_t(pix);
       }
     }
@@ -275,29 +272,27 @@ void LJpegDecompressor::decodeRowN(
     // We may end up needing just part of last N_COMP pixels.
     for (int MCURow = 0; MCURow != MCUSize.y; ++MCURow) {
       for (int MCUСol = 0; MCUСol != MCUSize.x; ++MCUСol) {
-        int c = (MCUSize.x * MCURow) + MCUСol;
+        const int c = (MCUSize.x * MCURow) + MCUСol;
         int prediction;
-        if (predMode == 1) {
+        if constexpr (!Use2DPred) {
           prediction = pred(MCURow, MCUСol);
         } else {
-          int Ra = pred(MCURow, MCUСol);
-          int stripeCol = MCUSize.x * mcuIdx + MCUСol;
-          int stripeRow = MCURow;
-          int Rb = (stripeCol < prevStripe.width())
-                       ? prevStripe(stripeRow, stripeCol)
-                       : Ra;
-          int Rc = (stripeCol >= MCUSize.x && stripeCol < prevStripe.width())
-                       ? prevStripe(stripeRow, stripeCol - MCUSize.x)
-                       : Rb;
-          prediction = computePrediction(predMode, Ra, Rb, Rc);
+          const int Ra = pred(MCURow, MCUСol);
+          const int stripeCol = MCUSize.x * mcuIdx + MCUСol;
+          const int Rb = (stripeCol < prevStripe.width())
+                             ? prevStripe(MCURow, stripeCol)
+                             : Ra;
+          const int Rc = (mcuIdx > 0 && stripeCol < prevStripe.width())
+                             ? prevStripe(MCURow, stripeCol - MCUSize.x)
+                             : Rb;
+          prediction = computePrediction(predictorMode, Ra, Rb, Rc);
         }
-        int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
-                       .decodeDifference(bs);
-        int pix = prediction + diff;
-        int stripeRow = MCURow;
-        int stripeCol = (MCUSize.x * mcuIdx) + MCUСol;
+        const int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
+                             .decodeDifference(bs);
+        const int pix = prediction + diff;
+        const int stripeCol = (MCUSize.x * mcuIdx) + MCUСol;
         if (stripeCol < outStripe.width())
-          outStripe(stripeRow, stripeCol) = uint16_t(pix);
+          outStripe(MCURow, stripeCol) = uint16_t(pix);
       }
     }
     ++mcuIdx; // We did just process one more MCU.
@@ -386,8 +381,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
       // For the first row of each restart interval, use predictor mode 1
       // (per ITU-T T.81: first row always uses horizontal prediction).
       // For the first row, prevStripe points to outStripe itself (unused
-      // since predMode will be 1).
-      const int predMode = isFirstRow ? 1 : predictorMode;
+      // since Use2DPred will be false).
       const Array2DRef<const uint16_t> prevStripe =
           isFirstRow
               ? Array2DRef<const uint16_t>(outStripe)
@@ -399,7 +393,10 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
                     /*croppedHeight=*/frame.mcu.y)
                     .getAsArray2DRef();
 
-      decodeRowN<MCU, N_COMP>(outStripe, pred, predMode, prevStripe, ht, bs);
+      if (!isFirstRow && predictorMode != 1)
+        decodeRowN<MCU, N_COMP, true>(outStripe, pred, prevStripe, ht, bs);
+      else
+        decodeRowN<MCU, N_COMP, false>(outStripe, pred, prevStripe, ht, bs);
 
       // The predictor for the next line is the start of this line.
       pred = CroppedArray2DRef(outStripe,

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -53,10 +53,12 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
                                      Frame frame_,
                                      std::vector<PerComponentRecipe> rec_,
                                      int numLJpegRowsPerRestartInterval_,
+                                     int predictorMode_,
                                      Array1DRef<const uint8_t> input_)
     : mRaw(std::move(img)), input(input_), imgFrame(imgFrame_),
       frame(std::move(frame_)), rec(std::move(rec_)),
-      numLJpegRowsPerRestartInterval(numLJpegRowsPerRestartInterval_) {
+      numLJpegRowsPerRestartInterval(numLJpegRowsPerRestartInterval_),
+      predictorMode(predictorMode_) {
 
   if (mRaw->getDataType() != RawImageType::UINT16)
     ThrowRDE("Unexpected data type (%u)",
@@ -181,9 +183,39 @@ constexpr iPoint2D MCU = {MCUWidth, MCUHeight};
 
 } // namespace
 
+namespace {
+
+// Compute the LJpeg prediction value given predictor mode and neighbor values.
+// Ra = left, Rb = above, Rc = above-left.
+// All arithmetic done in int32_t to avoid overflow in modes 4-6.
+// Result is modulo 2^16 per ITU-T T.81.
+inline int computePrediction(int predMode, int Ra, int Rb, int Rc) {
+  switch (predMode) {
+  case 1:
+    return Ra;
+  case 2:
+    return Rb;
+  case 3:
+    return Rc;
+  case 4:
+    return Ra + Rb - Rc;
+  case 5:
+    return Ra + ((Rb - Rc) >> 1);
+  case 6:
+    return Rb + ((Ra - Rc) >> 1);
+  case 7:
+    return (Ra + Rb) >> 1;
+  default:
+    __builtin_unreachable();
+  }
+}
+
+} // namespace
+
 template <const iPoint2D& MCUSize, int N_COMP>
 void LJpegDecompressor::decodeRowN(
     Array2DRef<uint16_t> outStripe, Array2DRef<const uint16_t> pred,
+    int predMode, Array2DRef<const uint16_t> prevStripe,
     std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
     BitStreamerJPEG& bs) const {
   invariant(MCUSize.area() == N_COMP);
@@ -207,7 +239,21 @@ void LJpegDecompressor::decodeRowN(
     for (int MCURow = 0; MCURow != MCUSize.y; ++MCURow) {
       for (int MCUСol = 0; MCUСol != MCUSize.x; ++MCUСol) {
         int c = (MCUSize.x * MCURow) + MCUСol;
-        int prediction = pred(MCURow, MCUСol);
+        int prediction;
+        if (predMode == 1) {
+          // Fast path for the common case (mode 1 = left neighbor).
+          prediction = pred(MCURow, MCUСol);
+        } else {
+          // For modes 2-7, compute Ra, Rb, Rc.
+          int Ra = pred(MCURow, MCUСol); // left neighbor
+          int stripeCol = MCUSize.x * mcuIdx + MCUСol;
+          int stripeRow = MCURow;
+          int Rb = prevStripe(stripeRow, stripeCol);
+          int Rc = (stripeCol >= MCUSize.x)
+                       ? prevStripe(stripeRow, stripeCol - MCUSize.x)
+                       : Rb; // First column: Rc = Rb
+          prediction = computePrediction(predMode, Ra, Rb, Rc);
+        }
         int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
                        .decodeDifference(bs);
         int pix = prediction + diff;
@@ -230,7 +276,21 @@ void LJpegDecompressor::decodeRowN(
     for (int MCURow = 0; MCURow != MCUSize.y; ++MCURow) {
       for (int MCUСol = 0; MCUСol != MCUSize.x; ++MCUСol) {
         int c = (MCUSize.x * MCURow) + MCUСol;
-        int prediction = pred(MCURow, MCUСol);
+        int prediction;
+        if (predMode == 1) {
+          prediction = pred(MCURow, MCUСol);
+        } else {
+          int Ra = pred(MCURow, MCUСol);
+          int stripeCol = MCUSize.x * mcuIdx + MCUСol;
+          int stripeRow = MCURow;
+          int Rb = (stripeCol < prevStripe.width())
+                       ? prevStripe(stripeRow, stripeCol)
+                       : Ra;
+          int Rc = (stripeCol >= MCUSize.x && stripeCol < prevStripe.width())
+                       ? prevStripe(stripeRow, stripeCol - MCUSize.x)
+                       : Rb;
+          prediction = computePrediction(predMode, Ra, Rb, Rc);
+        }
         int diff = (static_cast<const PrefixCodeDecoder<>&>(ht[c]))
                        .decodeDifference(bs);
         int pix = prediction + diff;
@@ -284,6 +344,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
        restartIntervalIndex != numRestartIntervals; ++restartIntervalIndex) {
     auto predStorage = getInitialPreds<N_COMP>();
     auto pred = Array2DRef(predStorage.data(), MCU.x, MCU.y);
+    bool isFirstRow = true;
 
     if (restartIntervalIndex != 0) {
       auto marker = peekMarker(inputStream);
@@ -321,7 +382,24 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
                                                /*croppedHeight=*/frame.mcu.y)
                                  .getAsArray2DRef();
 
-      decodeRowN<MCU, N_COMP>(outStripe, pred, ht, bs);
+      // For predictor modes 2-7, we need the previous row (stripe).
+      // For the first row of each restart interval, use predictor mode 1
+      // (per ITU-T T.81: first row always uses horizontal prediction).
+      // For the first row, prevStripe points to outStripe itself (unused
+      // since predMode will be 1).
+      const int predMode = isFirstRow ? 1 : predictorMode;
+      const Array2DRef<const uint16_t> prevStripe =
+          isFirstRow
+              ? Array2DRef<const uint16_t>(outStripe)
+              : CroppedArray2DRef<const uint16_t>(
+                    img,
+                    /*offsetCols=*/0,
+                    /*offsetRows=*/row - frame.mcu.y,
+                    /*croppedWidth=*/img.width(),
+                    /*croppedHeight=*/frame.mcu.y)
+                    .getAsArray2DRef();
+
+      decodeRowN<MCU, N_COMP>(outStripe, pred, predMode, prevStripe, ht, bs);
 
       // The predictor for the next line is the start of this line.
       pred = CroppedArray2DRef(outStripe,
@@ -330,6 +408,7 @@ ByteStream::size_type LJpegDecompressor::decodeN() const {
                                /*croppedWidth=*/MCU.x,
                                /*croppedHeight=*/MCU.y)
                  .getAsArray2DRef();
+      isFirstRow = false;
     }
 
     inputStream.skipBytes(bs.getStreamPosition());

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -116,6 +116,9 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
   if (numLJpegRowsPerRestartInterval < 1)
     ThrowRDE("Number of rows per restart interval must be positives");
 
+  if (predictorMode < 1 || predictorMode > 7)
+    ThrowRDE("Unsupported predictor mode: %i", predictorMode);
+
   if (static_cast<int64_t>(frame.mcu.x) * frame.dim.x >
           std::numeric_limits<int>::max() ||
       static_cast<int64_t>(frame.mcu.y) * frame.dim.y >

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -59,6 +59,7 @@ private:
   const Frame frame;
   const std::vector<PerComponentRecipe> rec;
   const int numLJpegRowsPerRestartInterval;
+  const int predictorMode;
 
   int numFullMCUs = 0;
   int trailingPixels = 0;
@@ -79,6 +80,7 @@ private:
   template <const iPoint2D& MCUSize, int N_COMP>
   __attribute__((always_inline)) inline void decodeRowN(
       Array2DRef<uint16_t> outStripe, Array2DRef<const uint16_t> pred,
+      int predMode, Array2DRef<const uint16_t> prevStripe,
       std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
       BitStreamerJPEG& bs) const;
 
@@ -89,6 +91,7 @@ public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,
                     std::vector<PerComponentRecipe> rec,
                     int numLJpegRowsPerRestartInterval_,
+                    int predictorMode_,
                     Array1DRef<const uint8_t> input);
 
   [[nodiscard]] ByteStream::size_type decode() const;

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -77,10 +77,10 @@ private:
   template <int N_COMP>
   [[nodiscard]] std::array<uint16_t, N_COMP> getInitialPreds() const;
 
-  template <const iPoint2D& MCUSize, int N_COMP>
+  template <const iPoint2D& MCUSize, int N_COMP, bool Use2DPred>
   __attribute__((always_inline)) inline void decodeRowN(
       Array2DRef<uint16_t> outStripe, Array2DRef<const uint16_t> pred,
-      int predMode, Array2DRef<const uint16_t> prevStripe,
+      Array2DRef<const uint16_t> prevStripe,
       std::array<std::reference_wrapper<const PrefixCodeDecoder<>>, N_COMP> ht,
       BitStreamerJPEG& bs) const;
 

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -90,8 +90,7 @@ private:
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,
                     std::vector<PerComponentRecipe> rec,
-                    int numLJpegRowsPerRestartInterval_,
-                    int predictorMode_,
+                    int numLJpegRowsPerRestartInterval_, int predictorMode_,
                     Array1DRef<const uint8_t> input);
 
   [[nodiscard]] ByteStream::size_type decode() const;

--- a/src/librawspeed/decompressors/LJpegDecompressor.h
+++ b/src/librawspeed/decompressors/LJpegDecompressor.h
@@ -45,6 +45,10 @@ public:
     const iPoint2D mcu;
     const iPoint2D dim;
   };
+  struct DecodeSettings final {
+    const int numLJpegRowsPerRestartInterval;
+    const int predictorMode;
+  };
   struct PerComponentRecipe final {
     const PrefixCodeDecoder<>& ht;
     const uint16_t initPred;
@@ -90,8 +94,7 @@ private:
 public:
   LJpegDecompressor(RawImage img, iRectangle2D imgFrame, Frame frame,
                     std::vector<PerComponentRecipe> rec,
-                    int numLJpegRowsPerRestartInterval_, int predictorMode_,
-                    Array1DRef<const uint8_t> input);
+                    DecodeSettings settings, Array1DRef<const uint8_t> input);
 
   [[nodiscard]] ByteStream::size_type decode() const;
 };

--- a/src/librawspeed/io/FileReader.cpp
+++ b/src/librawspeed/io/FileReader.cpp
@@ -53,9 +53,12 @@ FileReader::readFile() const {
   size_t fileSize = 0;
 
 #if defined(__unix__) || defined(__APPLE__)
-  auto fclose = [](std::FILE* fp) { std::fclose(fp); };
-  using file_ptr = std::unique_ptr<FILE, decltype(fclose)>;
-  file_ptr file(fopen(fileName, "rb"), fclose);
+  using file_ptr = std::unique_ptr<std::FILE, int (*)(std::FILE*)>;
+  // The opened stream is owned by `file`, whose deleter (std::fclose) closes it
+  // on every exit path. The static analyzer does not model the unique_ptr
+  // destructor, so it wrongly reports a leak here.
+  // codechecker_false_positive [unix.Stream] close done by unique_ptr deleter
+  file_ptr file(std::fopen(fileName, "rb"), &std::fclose);
 
   if (file == nullptr)
     ThrowFIE("Could not open file \"%s\".", fileName);


### PR DESCRIPTION
This PR is supposed to address https://github.com/darktable-org/rawspeed/issues/189, https://github.com/darktable-org/rawspeed/issues/191 and https://github.com/darktable-org/rawspeed/issues/258 and was created with the help of Claude.


**Summary**

rawspeed's LJpeg decoder previously supported only predictor mode 1 (left neighbor). ITU-T T.81 defines seven predictor modes, and several camera manufacturers — notably DJI (Mavic 3S, Mavic 3 Pro, etc.) and Blackmagic — use mode 6 in their DNG files. This change adds support for all seven modes and handles the associated tile geometry those cameras use.

**Predictor modes 2–7**

* Added a computePrediction(mode, Ra, Rb, Rc) helper that computes the seven ITU-T T.81 predictions. Arithmetic is done in int32_t to avoid overflow in modes 4–6, where Ra + Rb - Rc can transiently exceed the 16-bit range; the final result wraps via uint16_t cast per the standard.
* decodeRowN() is extended to accept predMode and prevStripe. For mode 1, the existing fast path (no memory access to the previous row) is preserved. For modes 2–7, the three 2D neighbors (Ra = left, Rb = above, Rc = above-left) are looked up from prevStripe; at the start of a row the above-left neighbor is not available, so Rc = Rb per the JPEG specification.
* decodeN() now tracks isFirstRow per restart interval. The first row of each interval always uses predictor mode 1 (per T.81: the standard mandates horizontal prediction for the first row). For subsequent rows, prevStripe is a CroppedArray2DRef into the already-decoded portion of the output image. No extra allocation is needed. Inverted tile reshape (LJpegDecoder)

**Inverted tile reshape**

DJI DNGs present tiles in a non-standard geometry: the JPEG SOF3 frame is wider than the declared tile (e.g. 8000×1500 for a 4000×3000 tile). Each JPEG row encodes two tile rows concatenated side-by-side — a widthPack = jpegFrameDim.x / tileW packing. This is the inverse of the Adobe-style reshape rawspeed already handles (MCU > 1×1).

**Design trade-offs**

* **Separate decode-then-deinterleave vs. in-place**: Reusing the existing LJpegDecompressor in-place would require threading the tile geometry inversion through all MCU addressing logic. Instead, the inverted-reshape path decodes into a temporary RawImage at the JPEG frame dimensions, then copies/deinterleaves rows into the real output image. The extra allocation is bounded by a single tile's worth of data and avoids touching the hot-path decompressor.
* **`widthPack` validation**: The factor is computed from the ratio jpegFrameDim.x / maxRes.x and validated against widthPack * jpegFrameDim.y == maxRes.y before decoding begins. An upper bound of 4 is enforced as a sanity check.
* The inverted reshape is restricted to single-component LJpeg (N_COMP == 1), which is the only case seen in practice for this layout.


**Fuzz harness**

The LJpegDecompressor fuzz entry point is updated to source a predictorMode byte from the fuzzer input, covering the new code paths.


**Testing**

Additionally to sucessfully testing my DJI Mavic Air 3S DNG files I also downloaded [this tarball](https://chaospixel.com/pub/temp/dng_pred_tests.tar.bz2) (shared by @cytrinox  [here](https://github.com/darktable-org/rawspeed/pull/334#issuecomment-1007410740)) containing DNG images with various encodings and tested all with the following result:

* cfaraw_16bit_tiled_pred1_2comp_doublewidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred3_2comp_normalwidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred4_2comp_doublewidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred4_2comp_normalwidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred5_2comp_doublewidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred5_2comp_normalwidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred6_1comp_doublewidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred7_2comp_doublewidth.dng :heavy_check_mark: 
* cfaraw_16bit_tiled_pred7_2comp_normalwidth.dng :heavy_check_mark: 


Fixes https://github.com/darktable-org/rawspeed/issues/189
Fixes https://github.com/darktable-org/rawspeed/issues/258
Fixes https://github.com/darktable-org/rawspeed/issues/191

In order to also fix https://github.com/darktable-org/rawspeed/issues/190, we need to add a decoding path for 12bit lossy JPEG encoding, this is going to be future work.