### PR TITLE
Decoders: use 1ULL for whitePoint shift to avoid UB at bps=32

### DIFF
--- a/src/librawspeed/decoders/DngDecoder.cpp
+++ b/src/librawspeed/decoders/DngDecoder.cpp
@@ -374,7 +374,7 @@ void DngDecoder::decodeData(const TiffIFD* raw, uint32_t sample_format) const {
 
   if (mRaw->getDataType() == RawImageType::UINT16) {
     // Default white level is (2 ** BitsPerSample) - 1
-    mRaw->whitePoint = implicit_cast<int>((1UL << *bps) - 1UL);
+    mRaw->whitePoint = implicit_cast<int>((1ULL << *bps) - 1ULL);
   } else if (mRaw->getDataType() == RawImageType::F32) {
     // 1. We divide by white level to normalize the image,
     //    s.t. the 1.0 becomes the white level.

--- a/src/librawspeed/decoders/RafDecoder.cpp
+++ b/src/librawspeed/decoders/RafDecoder.cpp
@@ -289,7 +289,7 @@ void RafDecoder::decodeMetaDataInternal(const CameraMetaData* meta) {
         mRootIFD->getEntryRecursive(TiffTag::FUJI_BITSPERSAMPLE)->getU32();
     if (bps > 16)
       ThrowRDE("Unexpected bit depth: %u", bps);
-    mRaw->whitePoint = implicit_cast<int>((1UL << bps) - 1UL);
+    mRaw->whitePoint = implicit_cast<int>((1ULL << bps) - 1ULL);
   }
 
   // This is where we'd normally call setMetaData but since we may still need

--- a/src/librawspeed/decoders/RawDecoder.cpp
+++ b/src/librawspeed/decoders/RawDecoder.cpp
@@ -121,7 +121,7 @@ void RawDecoder::decodeUncompressed(const TiffIFD* rawIFD,
   mRaw->createData();
 
   // Default white level is (2 ** BitsPerSample) - 1
-  mRaw->whitePoint = implicit_cast<int>((1UL << bitPerPixel) - 1UL);
+  mRaw->whitePoint = implicit_cast<int>((1ULL << bitPerPixel) - 1ULL);
 
   offY = 0;
   for (const RawSlice& slice : slices) {


### PR DESCRIPTION
## Bug

Identified a potential undefined behavior (UB) in several decoders where a 32-bit shift is performed on a value that can be 32, specifically when calculating the default white level:

- `src/librawspeed/decoders/DngDecoder.cpp:377`
- `src/librawspeed/decoders/RafDecoder.cpp:292`
- `src/librawspeed/decoders/RawDecoder.cpp:124`

```cpp
mRaw->whitePoint = implicit_cast<int>((1UL << bits) - 1UL);
```

The bit depth (`bits`) is permitted to be 32 (e.g., in DNG). `1UL << 32` is undefined per C++17 [expr.shift]/1 on platforms where `sizeof(unsigned long) == 4`: Windows MSVC (LLP64) and 32-bit Linux/macOS (ILP32).

## Reproduction

Standalone extract built with `gcc -O1 -g -fsanitize=undefined`. To make the UB visible regardless of host `sizeof(long)`, the PoC runs the equivalent shift on an explicit `uint32_t`:

```
runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int'
bps= 1: uint32_t shift -> 1, unsigned long shift -> 1
bps= 8: uint32_t shift -> 255, unsigned long shift -> 255
bps=16: uint32_t shift -> 65535, unsigned long shift -> 65535
bps=24: uint32_t shift -> 16777215, unsigned long shift -> 16777215
bps=31: uint32_t shift -> 2147483647, unsigned long shift -> 2147483647
bps=32: uint32_t shift -> 0, unsigned long shift -> -1
```

On a 32-bit target or Windows MSVC, the `unsigned long` expression is UB.

## Fix

Switched from `1UL` to `1ULL` (unsigned long long) for the shift calculation in `DngDecoder`, `RafDecoder`, and `RawDecoder`. `unsigned long long` is guaranteed to be at least 64 bits per C99, making `1ULL << 32` well-defined on every platform.

## Verification

Verified with the patched PoC; no sanitizer errors and correct results for all bit depths:

```
bps= 1: uint32_t shift -> 1, unsigned long long shift -> 1
bps= 8: uint32_t shift -> 255, unsigned long long shift -> 255
bps=16: uint32_t shift -> 65535, unsigned long long shift -> 65535
bps=24: uint32_t shift -> 16777215, unsigned long long shift -> 16777215
bps=31: uint32_t shift -> 2147483647, unsigned long long shift -> 2147483647
bps=32: uint32_t shift -> -1, unsigned long long shift -> -1
```

All `bits < 32` cases produce identical values to the unpatched version. `bits == 32` now portably produces `-1` (0xFFFFFFFF).