### PR TITLE
Fix white levels for Canon 5D Mark II

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -842,6 +842,8 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="158" y="52" width="5634" height="3752"/>
+		<Sensor black="1024" white="12995" iso_list="160 320 640 1250"/>
+		<Sensor black="1024" white="15950"/>
 		<BlackAreas>
 			<Vertical x="0" width="156"/>
 			<Horizontal y="2" height="48"/>


### PR DESCRIPTION
Partially revert 13e454a07. MakerNote NormalWhiteLevel for Canon 5D Mark II cannot be used for clipping detection. Use white values from `<Sensor>` instead. Fixes https://github.com/darktable-org/rawspeed/issues/969