### PR TITLE
Sony ILCE-7RM6 support

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13969,8 +13969,23 @@
 			</ColorMatrix>
 		</ColorMatrices>
 	</Camera>
-	<Camera make="SONY" model="ILCE-7RM6" supported="unknown-no-samples">
+	<Camera make="SONY" model="ILCE-7RM6">
 		<ID make="Sony" model="ILCE-7RM6">Sony ILCE-7RM6</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-8" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<ColorMatrices>
+			<ColorMatrix planes="3">
+				<ColorMatrixRow plane="0">11765 -5595 -1192</ColorMatrixRow>
+				<ColorMatrixRow plane="1">-3689 11507 2485</ColorMatrixRow>
+				<ColorMatrixRow plane="2">51 681 5731</ColorMatrixRow>
+			</ColorMatrix>
+		</ColorMatrices>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7S">
 		<ID make="Sony" model="ILCE-7S">Sony ILCE-7S</ID>

--- a/src/librawspeed/decoders/ArwDecoder.cpp
+++ b/src/librawspeed/decoders/ArwDecoder.cpp
@@ -316,7 +316,7 @@ void ArwDecoder::DecodeLJpeg(const TiffIFD* raw) {
   }
 
   if (width == 0 || height == 0 || width % 2 != 0 || height % 2 != 0 ||
-      width > 9728 || height > 6656)
+      width > 10240 || height > 7168)
     ThrowRDE("Unexpected image dimensions found: (%u; %u)", width, height);
 
   mRaw->dim = iPoint2D(width, height);

--- a/src/librawspeed/decompressors/LJpegDecoder.cpp
+++ b/src/librawspeed/decompressors/LJpegDecoder.cpp
@@ -56,7 +56,7 @@ LJpegDecoder::LJpegDecoder(ByteStream bs, const RawImage& img)
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   // Yeah, sure, here it would be just dumb to leave this for production :)
-  if (mRaw->dim.x > 9728 || mRaw->dim.y > 6656) {
+  if (mRaw->dim.x > 10240 || mRaw->dim.y > 7168) {
     ThrowRDE("Unexpected image dimensions found: (%i; %i)", mRaw->dim.x,
              mRaw->dim.y);
   }

--- a/src/librawspeed/decompressors/LJpegDecompressor.cpp
+++ b/src/librawspeed/decompressors/LJpegDecompressor.cpp
@@ -75,7 +75,7 @@ LJpegDecompressor::LJpegDecompressor(RawImage img, iRectangle2D imgFrame_,
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   // Yeah, sure, here it would be just dumb to leave this for production :)
-  if (mRaw->dim.x > 9728 || mRaw->dim.y > 6656) {
+  if (mRaw->dim.x > 10240 || mRaw->dim.y > 7168) {
     ThrowRDE("Unexpected image dimensions found: (%i; %i)", mRaw->dim.x,
              mRaw->dim.y);
   }


### PR DESCRIPTION
Partly addresses #968 _for lossless only_.

Used public samples at https://rawdb.dnglab.org/sets/Sony/ILCE-7RM6 w/ ADC 18.4.1.

@emko @chairman2s Please feel free to submit your own PRs in the future.