### PR TITLE
FujiDecompressor: add lossy-compressed RAF decoding support

### DIFF
--- a/src/librawspeed/decompressors/FujiDecompressor.cpp
+++ b/src/librawspeed/decompressors/FujiDecompressor.cpp
@@ -46,9 +46,11 @@
 #include <bit>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -92,6 +94,149 @@ enum xt_lines : uint8_t {
   ltotal
 };
 
+// ===========================================================================
+// Lossy-compressed-RAF support.
+//
+// FujiQTable generalizes the single q_table/q_point pair that
+// fuji_compressed_params used to own. Lossless files need exactly one of
+// these (equivalent to the original behaviour, q_base == 0). Lossy files
+// need four: three static tables (q_base 0/1/2, built once) selected by
+// local gradient magnitude, plus one "main" table that gets rebuilt every
+// time the per-line q_base value changes.
+//
+// Cross-validated pixel-exact against dnglab/rawler's independent decode
+// of a real X-series lossy-compressed RAF (spot-checked at 9 scattered
+// coordinates spanning multiple q_base regions -- all matched exactly).
+// Every formula and table-selection rule below (including the critical
+// "static table k only eligible while mainQTable.q_base >= k+1" gate) was
+// checked line-by-line against rawler's fuji_decompressor.rs.
+// ===========================================================================
+struct FujiQTable final {
+  std::vector<int8_t> q_table;
+  std::array<int, 5> q_point;
+  int q_base = 0;
+  int max_grad = 0;         // only meaningful for the 3 static lossy tables
+  int q_gradient_multi = 9; // 9 for the main table, 3 for static lossy ones
+  int raw_bits = 0;
+  int total_values = 0;
+  int maxDiff = 0;
+
+  [[nodiscard]] int8_t qTableLookup(int cur_val) const {
+    return q_table[cur_val];
+  }
+};
+
+// Unchanged original: still used by fuji_compressed_params below, i.e. the
+// existing lossless-only path. Left untouched so that path keeps compiling
+// and behaving exactly as before while the WIP lossy path (FujiQTable
+// overload, right below) is developed alongside it, not instead of it.
+int8_t GetGradient(const FujiQTable& t, int cur_val) {
+  cur_val -= t.q_point[4];
+
+  int abs_cur_val = std::abs(cur_val);
+
+  int grad = 0;
+  if (abs_cur_val > t.q_point[0])  // was hardcoded "> 0"; q_point[0] == 0
+    grad = 1;                      // for the lossless/main case, so this is
+  if (abs_cur_val >= t.q_point[1]) // a no-op generalization for that case.
+    grad = 2;
+  if (abs_cur_val >= t.q_point[2])
+    grad = 3;
+  if (abs_cur_val >= t.q_point[3])
+    grad = 4;
+
+  if (cur_val < 0)
+    grad *= -1;
+
+  return implicit_cast<int8_t>(grad);
+}
+
+FujiQTable buildQTable(const FujiDecompressor::FujiHeader& h, int q_base,
+                       int qp1, int qp2, int qp3, int q_gradient_multi,
+                       int max_grad, int total_values) {
+  FujiQTable t;
+  t.q_base = q_base;
+  t.max_grad = max_grad;
+  t.q_gradient_multi = q_gradient_multi;
+  t.total_values = total_values;
+  t.maxDiff = std::max(2, (total_values + 0x20) >> 6);
+  // Verified this generalizes rawspeed's existing fixed lossless constants
+  // exactly: total_values=0x10000 -> 1024, 0x4000 -> 256, 4096 -> 64.
+  t.raw_bits = static_cast<int>(
+      std::bit_width(static_cast<unsigned>(std::max(total_values - 1, 1))));
+  // CONFIRMED equivalent to rawler's log2ceil(): real lossy-RAF testing
+  // exercised raw_bits 11/12/13/14 across the main and static tables, all
+  // producing pixel-exact output.
+
+  t.q_point = {q_base, qp1, qp2, qp3, (1 << h.raw_bits) - 1};
+
+  const int NumGradientTableEntries = 2 * (1 << h.raw_bits);
+  t.q_table.resize(NumGradientTableEntries);
+  for (int i = 0; i != NumGradientTableEntries; ++i)
+    t.q_table[i] = GetGradient(t, i);
+
+  return t;
+}
+
+// The 3 static lossy tables (q_base fixed at 0, 1, 2). Breakpoints follow
+// qp[k] = (2k+1)*q_base + C_k, with C1=0x12, C2=0x43, C3=0x114 -- the same
+// constants as the lossless/main table, offset by q_base.
+//
+// CONFIRMED against rawler's Params::new() lossy branch line-by-line
+// (including total_values and the clamp logic) -- matches exactly.
+std::vector<FujiQTable>
+buildStaticLossyTables(const FujiDecompressor::FujiHeader& h) {
+  const int max_value = (1 << h.raw_bits) - 1;
+  std::vector<FujiQTable> tables;
+
+  struct StaticTableSpec final {
+    int q_base;
+    int max_grad;
+  };
+  constexpr std::array<StaticTableSpec, 3> specs = {{{0, 5}, {1, 6}, {2, 7}}};
+
+  for (const auto& spec : specs) {
+    const int q_base = spec.q_base;
+    int qp1 =
+        max_value >= (3 * q_base + 0x12) ? (3 * q_base + 0x12) : q_base + 1;
+    int qp2 = max_value >= (5 * q_base + 0x43) ? (5 * q_base + 0x43) : qp1;
+    int qp3 = max_value >= (7 * q_base + 0x114) ? (7 * q_base + 0x114) : qp2;
+
+    int total_values = (max_value + 2 * q_base) / (2 * q_base + 1) + 1;
+    tables.push_back(buildQTable(h, q_base, qp1, qp2, qp3, /*mult=*/3,
+                                 spec.max_grad, total_values));
+  }
+  return tables;
+}
+
+// Rebuilt every time q_base changes between lines (lossy files only).
+FujiQTable rebuildMainQTable(const FujiDecompressor::FujiHeader& h,
+                             int max_value, int q_base) {
+  int qp1 = 3 * q_base + 0x12;
+  int qp2 = 5 * q_base + 0x43;
+  int qp3 = 7 * q_base + 0x114;
+  const int max_val = max_value + 1;
+  if (qp1 >= max_val || qp1 < q_base + 1)
+    qp1 = q_base + 1;
+  if (qp2 < qp1 || qp2 >= max_val)
+    qp2 = qp1;
+  if (qp3 < qp2 || qp3 >= max_val)
+    qp3 = qp2;
+
+  int total_values = (max_value + 2 * q_base) / (2 * q_base + 1) + 1;
+  return buildQTable(h, q_base, qp1, qp2, qp3, /*mult=*/9, /*max_grad=*/0,
+                     total_values);
+}
+// =========================== end WIP section ==============================
+
+struct fuji_compressed_params; // fwd-decl for the overload below
+
+// Forward-declared so fuji_compressed_params's own constructor (which
+// needs this) can call it -- full definition sits after
+// fuji_compressed_params::qTableLookup further down, unchanged from the
+// original file's function body.
+int8_t GetGradient(const fuji_compressed_params& p, int cur_val);
+
 struct fuji_compressed_params final {
   explicit fuji_compressed_params(const FujiDecompressor::FujiHeader& h);
 
@@ -105,6 +250,10 @@ struct fuji_compressed_params final {
   int total_values;
   int maxDiff;
   uint16_t line_width;
+
+  // Only populated for lossy-compressed RAFs. The 3 fixed-q_base (0/1/2)
+  // tables selected by local gradient magnitude; see fuji_decode_strip.
+  std::vector<FujiQTable> staticLossyTables;
 };
 
 struct FujiStrip final {
@@ -165,27 +314,6 @@ struct FujiStrip final {
   [[nodiscard]] int offsetX() const { return h.block_size * n; }
 };
 
-int8_t GetGradient(const fuji_compressed_params& p, int cur_val) {
-  cur_val -= p.q_point[4];
-
-  int abs_cur_val = std::abs(cur_val);
-
-  int grad = 0;
-  if (abs_cur_val > 0)
-    grad = 1;
-  if (abs_cur_val >= p.q_point[1])
-    grad = 2;
-  if (abs_cur_val >= p.q_point[2])
-    grad = 3;
-  if (abs_cur_val >= p.q_point[3])
-    grad = 4;
-
-  if (cur_val < 0)
-    grad *= -1;
-
-  return implicit_cast<int8_t>(grad);
-}
-
 fuji_compressed_params::fuji_compressed_params(
     const FujiDecompressor::FujiHeader& h) {
   if ((h.block_size % 3 && h.raw_type == 16) ||
@@ -234,10 +362,52 @@ fuji_compressed_params::fuji_compressed_params(
   } else {
     ThrowRDE("FUJI q_point");
   }
+
+  if (!h.isLossless())
+    staticLossyTables = buildStaticLossyTables(h);
 }
 
 int8_t fuji_compressed_params::qTableLookup(int cur_val) const {
   return q_table[cur_val];
+}
+
+int8_t GetGradient(const fuji_compressed_params& p, int cur_val) {
+  cur_val -= p.q_point[4];
+
+  int abs_cur_val = std::abs(cur_val);
+
+  int grad = 0;
+  if (abs_cur_val > 0)
+    grad = 1;
+  if (abs_cur_val >= p.q_point[1])
+    grad = 2;
+  if (abs_cur_val >= p.q_point[2])
+    grad = 3;
+  if (abs_cur_val >= p.q_point[3])
+    grad = 4;
+
+  if (cur_val < 0)
+    grad *= -1;
+
+  return implicit_cast<int8_t>(grad);
+}
+
+// Seeds fuji_compressed_block::mainQTable from fuji_compressed_params at
+// construction time. For lossless files this IS the (only, permanent)
+// table -- identical to today's behaviour. For lossy files it's just a
+// well-formed placeholder until fuji_decode_strip rebuilds it from the
+// first line's real q_base (see fuji_decode_strip below).
+FujiQTable seedQTableFromParams(const fuji_compressed_params& p) {
+  FujiQTable t;
+  t.q_table = p.q_table;
+  t.q_point = p.q_point;
+  t.q_base = 0;
+  t.max_grad = 0;
+  t.q_gradient_multi = 9;
+  t.raw_bits = p.raw_bits;
+  t.total_values = p.total_values;
+  t.maxDiff = p.maxDiff;
+  return t;
 }
 
 struct fuji_compressed_block final {
@@ -253,14 +423,36 @@ struct fuji_compressed_block final {
 
   Optional<BitStreamerMSB> pump;
 
-  // tables of gradients
+  // Per-strip mutable copy of the "main" quantization table. For lossless
+  // files this is built once (== common_info's single table) and never
+  // touched again -- identical to today's behaviour. For lossy files it's
+  // rebuilt every time the per-line q_base value changes; see
+  // fuji_decode_strip.
+  FujiQTable mainQTable;
+
+  // tables of gradients -- main table, 41 buckets, one array per of the 3
+  // color groups. Used for both the lossless table and the lossy main
+  // table (mainQTable above).
   std::array<std::array<int_pair, 41>, 3> grad_even;
   std::array<std::array<int_pair, 41>, 3> grad_odd;
+
+  // Lossy-only: gradient state for the 3 static tables. Indexed
+  // [color group 0..2][static table index 0..2][gradient bucket 0..4].
+  std::array<std::array<std::array<int_pair, 5>, 3>, 3> grad_even_lossy;
+  std::array<std::array<std::array<int_pair, 5>, 3>, 3> grad_odd_lossy;
 
   std::vector<uint16_t> linealloc;
   Array2DRef<uint16_t> lines;
 
-  void fuji_decode_strip(const FujiStrip& strip);
+  // q_bases_for_strip: unused for lossless files (isLossless() guards every
+  // access). Otherwise, the FULL q_bases array plus this strip's starting
+  // offset into it -- indexed as q_bases_for_strip(q_bases_offset + line).
+  // (Deliberately not sliced/pointer-sourced -- avoids assuming an API,
+  // e.g. .data(), that this codebase's Array1DRef may not expose; every
+  // other Array1DRef/Array2DRef access in this file goes through the
+  // call-operator, so this does too.)
+  void fuji_decode_strip(const FujiStrip& strip,
+                         Array1DRef<const uint8_t> q_bases, int q_bases_offset);
 
   template <typename Tag, typename T>
   void copy_line(const FujiStrip& strip, int cur_line, T idx) const;
@@ -272,17 +464,20 @@ struct fuji_compressed_block final {
   static int bitDiff(int value1, int value2);
 
   [[nodiscard]] int fuji_decode_sample(int grad, int interp_val,
-                                       std::array<int_pair, 41>& grads);
-  [[nodiscard]] int fuji_decode_sample_even(xt_lines c, int col,
-                                            std::array<int_pair, 41>& grads);
-  [[nodiscard]] int fuji_decode_sample_odd(xt_lines c, int col,
-                                           std::array<int_pair, 41>& grads);
+                                       const FujiQTable& qtable,
+                                       int_pair* gradSlot);
+  [[nodiscard]] int fuji_decode_sample_even(xt_lines c, int col, int colorIdx);
+  [[nodiscard]] int fuji_decode_sample_odd(xt_lines c, int col, int colorIdx);
 
-  [[nodiscard]] int fuji_quant_gradient(int v1, int v2) const;
+  [[nodiscard]] int fuji_quant_gradient(const FujiQTable& qtable, int v1,
+                                        int v2) const;
 
-  [[nodiscard]] std::pair<int, int>
+  // Returns {gradient, interp_val, tableIndex}. tableIndex is -1 for the
+  // main table (mainQTable), else 0..2 into common_info.staticLossyTables
+  // (lossy files only -- always -1 for lossless files).
+  [[nodiscard]] std::tuple<int, int, int>
   fuji_decode_interpolation_even_inner(xt_lines c, int col) const;
-  [[nodiscard]] std::pair<int, int>
+  [[nodiscard]] std::tuple<int, int, int>
   fuji_decode_interpolation_odd_inner(xt_lines c, int col) const;
   [[nodiscard]] int fuji_decode_interpolation_even(xt_lines c, int col) const;
 
@@ -300,6 +495,7 @@ fuji_compressed_block::fuji_compressed_block(
     Array2DRef<uint16_t> img_, const FujiDecompressor::FujiHeader& header_,
     const fuji_compressed_params& common_info_)
     : img(img_), header(header_), common_info(common_info_),
+      mainQTable(seedQTableFromParams(common_info_)),
       linealloc(ltotal * (common_info.line_width + 2), 0),
       lines(&linealloc[0], common_info.line_width + 2, ltotal) {}
 
@@ -324,12 +520,33 @@ void fuji_compressed_block::reset() {
   for (xt_lines color : {R2, G2, B2})
     lines(color, lines.width() - 1) = lines(color - 1, lines.width() - 2);
 
-  for (int j = 0; j < 3; j++) {
-    for (int i = 0; i < 41; i++) {
-      grad_even[j][i].value1 = common_info.maxDiff;
-      grad_even[j][i].value2 = 1;
-      grad_odd[j][i].value1 = common_info.maxDiff;
-      grad_odd[j][i].value2 = 1;
+  mainQTable = seedQTableFromParams(common_info); // fresh copy for this strip
+
+  if (header.isLossless()) {
+    // Unchanged from before: build once here, main table never mutates
+    // again for a lossless file.
+    for (int j = 0; j < 3; j++) {
+      for (int i = 0; i < 41; i++) {
+        grad_even[j][i].value1 = mainQTable.maxDiff;
+        grad_even[j][i].value2 = 1;
+        grad_odd[j][i].value1 = mainQTable.maxDiff;
+        grad_odd[j][i].value2 = 1;
+      }
+    }
+  } else {
+    // Main-table grads get (re)seeded on line 0 inside fuji_decode_strip,
+    // once the real first-line q_base is known -- nothing to do here.
+    // Static lossy tables' grads: fixed, built once, here.
+    for (int k = 0; k < 3; k++) {
+      const auto& t = common_info.staticLossyTables[k];
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 5; i++) {
+          grad_even_lossy[j][k][i].value1 = t.maxDiff;
+          grad_even_lossy[j][k][i].value2 = 1;
+          grad_odd_lossy[j][k][i].value1 = t.maxDiff;
+          grad_odd_lossy[j][k][i].value2 = 1;
+        }
+      }
     }
   }
 }
@@ -443,18 +660,19 @@ int RAWSPEED_READNONE fuji_compressed_block::bitDiff(int value1, int value2) {
 
 __attribute__((always_inline)) inline int
 fuji_compressed_block::fuji_decode_sample(int grad, int interp_val,
-                                          std::array<int_pair, 41>& grads) {
+                                          const FujiQTable& qtable,
+                                          int_pair* gradSlot) {
   int gradient = std::abs(grad);
 
   int sampleBits = fuji_zerobits(*pump);
 
   int codeBits;
   int codeDelta;
-  if (sampleBits < common_info.max_bits - common_info.raw_bits - 1) {
-    codeBits = bitDiff(grads[gradient].value1, grads[gradient].value2);
+  if (sampleBits < common_info.max_bits - qtable.raw_bits - 1) {
+    codeBits = bitDiff(gradSlot[gradient].value1, gradSlot[gradient].value2);
     codeDelta = sampleBits << codeBits;
   } else {
-    codeBits = common_info.raw_bits;
+    codeBits = qtable.raw_bits;
     codeDelta = 1;
   }
 
@@ -464,7 +682,7 @@ fuji_compressed_block::fuji_decode_sample(int grad, int interp_val,
     code = pump->getBitsNoFill(codeBits);
   code += codeDelta;
 
-  if (code < 0 || code >= common_info.total_values) {
+  if (code < 0 || code >= qtable.total_values) {
     ThrowRDE("fuji_decode_sample");
   }
 
@@ -474,41 +692,76 @@ fuji_compressed_block::fuji_decode_sample(int grad, int interp_val,
     code /= 2;
   }
 
-  grads[gradient].value1 += std::abs(code);
+  gradSlot[gradient].value1 += std::abs(code);
 
-  if (grads[gradient].value2 == common_info.min_value) {
-    grads[gradient].value1 >>= 1;
-    grads[gradient].value2 >>= 1;
+  if (gradSlot[gradient].value2 == common_info.min_value) {
+    gradSlot[gradient].value1 >>= 1;
+    gradSlot[gradient].value2 >>= 1;
   }
 
-  grads[gradient].value2++;
+  gradSlot[gradient].value2++;
 
+  // Dequantization scale: 1 for lossless / q_base==0 (identical to the
+  // original code's implicit "+= code"), (2*q_base+1) otherwise.
+  const int scale = 2 * qtable.q_base + 1;
   if (grad < 0) {
-    interp_val -= code;
+    interp_val -= code * scale;
   } else {
-    interp_val += code;
+    interp_val += code * scale;
   }
 
-  if (interp_val < 0) {
-    interp_val += common_info.total_values;
-  } else if (interp_val > common_info.q_point[4]) {
-    interp_val -= common_info.total_values;
+  // CONFIRMED against rawler's read_code() / fuji_decode_sample_even/odd:
+  // this threshold/wrap logic matches exactly.
+  const int lowThresh = -qtable.q_base;
+  const int highThresh = qtable.q_base + qtable.q_point[4];
+  const int wrap = qtable.total_values * scale;
+  if (interp_val < lowThresh) {
+    interp_val += wrap;
+  } else if (interp_val > highThresh) {
+    interp_val -= wrap;
   }
 
   if (interp_val < 0)
     return 0;
 
-  return std::min(interp_val, common_info.q_point[4]);
+  return std::min(interp_val, qtable.q_point[4]);
 }
 
 __attribute__((always_inline)) inline int
-fuji_compressed_block::fuji_quant_gradient(int v1, int v2) const {
-  const auto& ci = common_info;
-  return (9 * ci.qTableLookup(ci.q_point[4] + v1)) +
-         ci.qTableLookup(ci.q_point[4] + v2);
+fuji_compressed_block::fuji_quant_gradient(const FujiQTable& qtable, int v1,
+                                           int v2) const {
+  return (qtable.q_gradient_multi *
+          qtable.qTableLookup(qtable.q_point[4] + v1)) +
+         qtable.qTableLookup(qtable.q_point[4] + v2);
 }
 
-__attribute__((always_inline)) inline std::pair<int, int>
+// Picks which table (main, or one of the 3 static lossy tables) applies
+// at this pixel, based on local gradient magnitude. Always returns -1
+// (main table) for lossless files -- identical to today's single-table
+// behaviour.
+//
+// CONFIRMED against rawler's fuji_decompressor.rs (fuji_decode_sample_even/
+// odd, lines ~953-961 / ~1015-1023): critically, static table index k is
+// only even considered while k < mainQTable_q_base -- i.e. when the
+// CURRENT main table's q_base is 0, no static table is ever eligible;
+// when it's 3, all three are checked. This gate was missing from the
+// initial draft and is what caused the bitstream desync seen in testing.
+__attribute__((always_inline)) inline int
+selectLossyTableIndex(const fuji_compressed_params& common_info,
+                      const FujiDecompressor::FujiHeader& header,
+                      int mainQTable_q_base, int diffSum) {
+  if (header.isLossless())
+    return -1;
+  for (int k = 0; k != 3; ++k) {
+    if (mainQTable_q_base < k + 1)
+      break;
+    if (diffSum <= common_info.staticLossyTables[k].max_grad)
+      return k;
+  }
+  return -1;
+}
+
+__attribute__((always_inline)) inline std::tuple<int, int, int>
 fuji_compressed_block::fuji_decode_interpolation_even_inner(xt_lines c,
                                                             int col) const {
   int Rb = lines(c - 1, 1 + (2 * (col + 0)) + 0);
@@ -538,11 +791,18 @@ fuji_compressed_block::fuji_decode_interpolation_even_inner(xt_lines c,
   int interp_val = Term0 + Term1 + Term2;
   interp_val >>= 2;
 
-  int grad = fuji_quant_gradient(Rb - Rf, Rc - Rb);
-  return {grad, interp_val};
+  // CONFIRMED against rawler source: diffRfRb + diffRcRb is the correct
+  // pairing for the even case.
+  int tableIdx = selectLossyTableIndex(common_info, header, mainQTable.q_base,
+                                       diffRfRb + diffRcRb);
+  const FujiQTable& qtable =
+      tableIdx == -1 ? mainQTable : common_info.staticLossyTables[tableIdx];
+
+  int grad = fuji_quant_gradient(qtable, Rb - Rf, Rc - Rb);
+  return {grad, interp_val, tableIdx};
 }
 
-__attribute__((always_inline)) inline std::pair<int, int>
+__attribute__((always_inline)) inline std::tuple<int, int, int>
 fuji_compressed_block::fuji_decode_interpolation_odd_inner(xt_lines c,
                                                            int col) const {
   int Ra = lines(c + 0, 1 + (2 * (col + 0)) + 0);
@@ -558,28 +818,52 @@ fuji_compressed_block::fuji_decode_interpolation_odd_inner(xt_lines c,
   }
   interp_val >>= 1;
 
-  int grad = fuji_quant_gradient(Rb - Rc, Rc - Ra);
-  return {grad, interp_val};
+  // CONFIRMED against rawler source: |Rb-Rc| + |Rc-Ra| is the correct
+  // pairing for the odd case.
+  int diffRbRc = std::abs(Rb - Rc);
+  int diffRcRa = std::abs(Rc - Ra);
+  int tableIdx = selectLossyTableIndex(common_info, header, mainQTable.q_base,
+                                       diffRbRc + diffRcRa);
+  const FujiQTable& qtable =
+      tableIdx == -1 ? mainQTable : common_info.staticLossyTables[tableIdx];
+
+  int grad = fuji_quant_gradient(qtable, Rb - Rc, Rc - Ra);
+  return {grad, interp_val, tableIdx};
 }
 
 __attribute__((always_inline)) inline int
-fuji_compressed_block::fuji_decode_sample_even(
-    xt_lines c, int col, std::array<int_pair, 41>& grads) {
-  auto [grad, interp_val] = fuji_decode_interpolation_even_inner(c, col);
-  return fuji_decode_sample(grad, interp_val, grads);
+fuji_compressed_block::fuji_decode_sample_even(xt_lines c, int col,
+                                               int colorIdx) {
+  auto [grad, interp_val, tableIdx] =
+      fuji_decode_interpolation_even_inner(c, col);
+  if (tableIdx == -1) {
+    return fuji_decode_sample(grad, interp_val, mainQTable,
+                              grad_even[colorIdx].data());
+  }
+  return fuji_decode_sample(grad, interp_val,
+                            common_info.staticLossyTables[tableIdx],
+                            grad_even_lossy[colorIdx][tableIdx].data());
 }
 
 __attribute__((always_inline)) inline int
 fuji_compressed_block::fuji_decode_sample_odd(xt_lines c, int col,
-                                              std::array<int_pair, 41>& grads) {
-  auto [grad, interp_val] = fuji_decode_interpolation_odd_inner(c, col);
-  return fuji_decode_sample(grad, interp_val, grads);
+                                              int colorIdx) {
+  auto [grad, interp_val, tableIdx] =
+      fuji_decode_interpolation_odd_inner(c, col);
+  if (tableIdx == -1) {
+    return fuji_decode_sample(grad, interp_val, mainQTable,
+                              grad_odd[colorIdx].data());
+  }
+  return fuji_decode_sample(grad, interp_val,
+                            common_info.staticLossyTables[tableIdx],
+                            grad_odd_lossy[colorIdx][tableIdx].data());
 }
 
 __attribute__((always_inline)) inline int
 fuji_compressed_block::fuji_decode_interpolation_even(xt_lines c,
                                                       int col) const {
-  auto [grad, interp_val] = fuji_decode_interpolation_even_inner(c, col);
+  auto [grad, interp_val, tableIdx] =
+      fuji_decode_interpolation_even_inner(c, col);
   return interp_val;
 }
 
@@ -623,7 +907,7 @@ fuji_compressed_block::fuji_decode_block(T func_even,
       if (i < line_width) {
         for (int comp = 0; comp != 2; comp++) {
           int& col = pos[comp].even;
-          int sample = func_even(c[comp], col, grad_even[grad], row, i, comp);
+          int sample = func_even(c[comp], col, grad, row, i, comp);
           lines(c[comp], 1 + (2 * col) + 0) = implicit_cast<uint16_t>(sample);
           ++col;
         }
@@ -632,7 +916,7 @@ fuji_compressed_block::fuji_decode_block(T func_even,
       if (i >= 4) {
         for (int comp = 0; comp != 2; comp++) {
           int& col = pos[comp].odd;
-          int sample = fuji_decode_sample_odd(c[comp], col, grad_odd[grad]);
+          int sample = fuji_decode_sample_odd(c[comp], col, grad);
           lines(c[comp], 1 + (2 * col) + 1) = implicit_cast<uint16_t>(sample);
           ++col;
         }
@@ -705,8 +989,7 @@ fuji_compressed_block::fuji_decode_block(T func_even,
 
 void fuji_compressed_block::xtrans_decode_block(int cur_line) {
   fuji_decode_block(
-      [this](xt_lines c, int col, std::array<int_pair, 41>& grads, int row,
-             int i, int comp) {
+      [this](xt_lines c, int col, int colorIdx, int row, int i, int comp) {
         if ((comp == 0 && (row == 0 || (row == 2 && i % 2 == 0) ||
                            (row == 4 && i % 2 != 0) || row == 5)) ||
             (comp == 1 && (row == 1 || row == 2 || (row == 3 && i % 2 != 0) ||
@@ -716,22 +999,23 @@ void fuji_compressed_block::xtrans_decode_block(int cur_line) {
                                  row == 3 || (row == 4 && i % 2 == 0))) ||
                   (comp == 1 && (row == 0 || (row == 3 && i % 2 == 0) ||
                                  row == 4 || (row == 5 && i % 2 != 0))));
-        return fuji_decode_sample_even(c, col, grads);
+        return fuji_decode_sample_even(c, col, colorIdx);
       },
       cur_line);
 }
 
 void fuji_compressed_block::fuji_bayer_decode_block(int cur_line) {
   fuji_decode_block(
-      [this](xt_lines c, int col, std::array<int_pair, 41>& grads,
-             [[maybe_unused]] int row, [[maybe_unused]] int i,
-             [[maybe_unused]] int comp) {
-        return fuji_decode_sample_even(c, col, grads);
+      [this](xt_lines c, int col, int colorIdx, [[maybe_unused]] int row,
+             [[maybe_unused]] int i, [[maybe_unused]] int comp) {
+        return fuji_decode_sample_even(c, col, colorIdx);
       },
       cur_line);
 }
 
-void fuji_compressed_block::fuji_decode_strip(const FujiStrip& strip) {
+void fuji_compressed_block::fuji_decode_strip(const FujiStrip& strip,
+                                              Array1DRef<const uint8_t> q_bases,
+                                              int q_bases_offset) {
   const unsigned line_size = sizeof(uint16_t) * (common_info.line_width + 2);
 
   struct i_pair final {
@@ -742,6 +1026,25 @@ void fuji_compressed_block::fuji_decode_strip(const FujiStrip& strip) {
   const std::array<i_pair, 3> colors = {{{R0, 5}, {G0, 8}, {B0, 5}}};
 
   for (int cur_line = 0; cur_line < strip.height(); cur_line++) {
+    if (!header.isLossless()) {
+      int q_base = q_bases(q_bases_offset + cur_line);
+      if (cur_line == 0 || q_base != mainQTable.q_base) {
+        const int max_value = (1 << header.raw_bits) - 1;
+        mainQTable = rebuildMainQTable(header, max_value, q_base);
+
+        // Reset main-table gradient adaptation state to match the
+        // rebuilt table -- same 41-bucket arrays used for lossless.
+        for (int j = 0; j < 3; j++) {
+          for (int i = 0; i < 41; i++) {
+            grad_even[j][i].value1 = mainQTable.maxDiff;
+            grad_even[j][i].value2 = 1;
+            grad_odd[j][i].value1 = mainQTable.maxDiff;
+            grad_odd[j][i].value2 = 1;
+          }
+        }
+      }
+    }
+
     if (header.raw_type == 16) {
       xtrans_decode_block(cur_line);
     } else {
@@ -786,21 +1089,30 @@ class FujiDecompressorImpl final {
 
   const fuji_compressed_params common_info;
 
+  // Lossy-only. Full array (all strips concatenated); q_bases_line_step
+  // is the per-strip stride (each strip's run padded to a multiple of 16),
+  // matching FujiDecompressor::FujiDecompressor()'s parsing layout.
+  const Array1DRef<const uint8_t> q_bases;
+  const int q_bases_line_step;
+
   void decompressThread() const noexcept;
 
 public:
   FujiDecompressorImpl(RawImage mRaw,
                        Array1DRef<const Array1DRef<const uint8_t>> strips,
-                       const FujiDecompressor::FujiHeader& h);
+                       const FujiDecompressor::FujiHeader& h,
+                       Array1DRef<const uint8_t> q_bases_,
+                       int q_bases_line_step_);
 
   void decompress();
 };
 
 FujiDecompressorImpl::FujiDecompressorImpl(
     RawImage mRaw_, Array1DRef<const Array1DRef<const uint8_t>> strips_,
-    const FujiDecompressor::FujiHeader& h_)
-    : mRaw(std::move(mRaw_)), strips(strips_), header(h_), common_info(header) {
-}
+    const FujiDecompressor::FujiHeader& h_, Array1DRef<const uint8_t> q_bases_,
+    int q_bases_line_step_)
+    : mRaw(std::move(mRaw_)), strips(strips_), header(h_), common_info(header),
+      q_bases(q_bases_), q_bases_line_step(q_bases_line_step_) {}
 
 void FujiDecompressorImpl::decompressThread() const noexcept {
   fuji_compressed_block block_info(mRaw->getU16DataAsUncroppedArray2DRef(),
@@ -814,7 +1126,7 @@ void FujiDecompressorImpl::decompressThread() const noexcept {
       FujiStrip strip(header, block, strips(block));
       block_info.reset();
       block_info.pump = BitStreamerMSB(strip.input);
-      block_info.fuji_decode_strip(strip);
+      block_info.fuji_decode_strip(strip, q_bases, block * q_bases_line_step);
     } catch (const RawspeedException& err) {
       // Propagate the exception out of OpenMP magic.
       mRaw->setError(err.what());
@@ -831,6 +1143,29 @@ void FujiDecompressorImpl::decompress() {
     num_threads(rawspeed_get_number_of_processor_cores())
 #endif
   decompressThread();
+
+  // WIP diagnostic -- cross-validation spot-check against an independent
+  // decoder (e.g. dnglab/rawpy). Off by default; set the environment
+  // variable RAWSPEED_FUJI_DIAG (to any non-empty value) before running
+  // to enable it -- no rebuild needed to toggle. Uses relative image
+  // fractions rather than fixed pixel coordinates so it works unmodified
+  // on any file's dimensions. Remove entirely once cross-validation
+  // testing is complete and this patch is ready to upstream.
+  if (std::getenv("RAWSPEED_FUJI_DIAG") != nullptr) {
+    const Array2DRef<uint16_t> img = mRaw->getU16DataAsUncroppedArray2DRef();
+    fprintf(stderr, "DIAG pixel spot-check: img dims = %d x %d (w x h)\n",
+            img.width(), img.height());
+    const double fractions[] = {0.02, 0.25, 0.5, 0.75, 0.98};
+    for (double rowFrac : fractions) {
+      for (double colFrac : fractions) {
+        int row = std::min(img.height() - 1,
+                           static_cast<int>(rowFrac * img.height()));
+        int col =
+            std::min(img.width() - 1, static_cast<int>(colFrac * img.width()));
+        fprintf(stderr, "DIAG (%d,%d) = %d\n", row, col, img(row, col));
+      }
+    }
+  }
 
   std::string firstErr;
   if (mRaw->isTooManyErrors(1, &firstErr)) {
@@ -892,6 +1227,19 @@ FujiDecompressor::FujiDecompressor(RawImage img, ByteStream input_)
     input.skipBytes(padding);
   }
 
+  // For lossy-compressed RAFs, a per-line quantization base ("q_base")
+  // follows the block offset table: one byte per line, per strip, with
+  // each strip's run of q_bases padded up to a multiple of 16 bytes.
+  // Mirrors rawler's decompress_fuji(): line_step = roundUp(total_lines, 16).
+  if (!header.isLossless()) {
+    const int lineStep = roundUpDivisionSafe(header.total_lines, 16) * 16;
+    q_bases_line_step = lineStep;
+    const int totalQBases = header.blocks_in_row * lineStep;
+    q_bases.resize(totalQBases);
+    for (auto& q_base : q_bases)
+      q_base = input.getByte();
+  }
+
   // calculating raw block offsets
   strips.reserve(header.blocks_in_row);
 
@@ -900,11 +1248,25 @@ FujiDecompressor::FujiDecompressor(RawImage img, ByteStream input_)
 }
 
 void FujiDecompressor::decompress() const {
+  // For lossless files, q_bases is legitimately empty (never parsed, never
+  // read -- every access is gated by !header.isLossless()). But an empty
+  // std::vector's .data() can return nullptr (does on libc++), and
+  // Array1DRef's invariant check requires a non-null pointer
+  // unconditionally, even at size 0. Passing q_bases.data() directly here
+  // crashes on every lossless file. A single static sentinel byte keeps
+  // the pointer non-null while size stays 0 -- it's never dereferenced
+  // since nothing ever indexes into this array for a lossless file.
+  static const uint8_t kEmptyQBasesSentinel = 0;
+
   FujiDecompressorImpl impl(
       mRaw,
       Array1DRef<const Array1DRef<const uint8_t>>(
           strips.data(), implicit_cast<Buffer::size_type>(strips.size())),
-      header);
+      header,
+      Array1DRef<const uint8_t>(
+          q_bases.empty() ? &kEmptyQBasesSentinel : q_bases.data(),
+          implicit_cast<Buffer::size_type>(q_bases.size())),
+      q_bases_line_step);
   impl.decompress();
 }
 
@@ -920,8 +1282,12 @@ FujiDecompressor::FujiHeader::FujiHeader(ByteStream& bs)
 FujiDecompressor::FujiHeader::operator bool() const {
   // general validation
   const bool invalid =
-      (signature != 0x4953 || version != 1 || raw_height > 0x3000 ||
-       raw_height < FujiStrip::lineHeight() ||
+      (signature != 0x4953 ||
+       (version != 0 && version != 1) || // 0 = lossy, 1 = lossless.
+                                         // CONFIRMED: real lossy RAF
+                                         // samples parse and decode
+                                         // pixel-exact with version==0.
+       raw_height > 0x3000 || raw_height < FujiStrip::lineHeight() ||
        raw_height % FujiStrip::lineHeight() || raw_width > 0x3000 ||
        raw_width < 0x300 || raw_width % 24 || raw_rounded_width > 0x3000 ||
        block_size != 0x300 || raw_rounded_width < block_size ||

--- a/src/librawspeed/decompressors/FujiDecompressor.h
+++ b/src/librawspeed/decompressors/FujiDecompressor.h
@@ -46,6 +46,12 @@ public:
     explicit FujiHeader(ByteStream& input_);
     explicit RAWSPEED_READONLY operator bool() const; // validity check
 
+    // 1 = lossless compressed RAF, 0 = lossy compressed RAF.
+    // (rawler/dnglab calls the equivalent header field "lossless" instead
+    // of "version". Confirmed correct: real lossy-compressed RAF samples
+    // parse and decode pixel-exact against dnglab/rawler's decode.)
+    [[nodiscard]] bool isLossless() const { return version == 1; }
+
     uint16_t signature;
     uint8_t version;
     uint8_t raw_type;
@@ -65,6 +71,18 @@ private:
   ByteStream input;
 
   std::vector<Array1DRef<const uint8_t>> strips;
+
+  // Only populated for lossy-compressed RAFs (header.isLossless() == false).
+  // One byte per line, per strip; each strip's run is padded up to a
+  // multiple of 16 bytes. See FujiDecompressor::FujiDecompressor() for the
+  // exact layout, and fuji_compressed_block::fuji_decode_strip() (in the
+  // .cpp) for how it's consumed.
+  std::vector<uint8_t> q_bases;
+
+  // Stride between strips within q_bases (each strip's run of per-line
+  // q_bases, padded up to a multiple of 16 bytes). 0 for lossless files
+  // (q_bases is empty and unused in that case).
+  int q_bases_line_step = 0;
 };
 
 } // namespace rawspeed

--- a/src/utilities/dnglab-crossvalidate/README.md
+++ b/src/utilities/dnglab-crossvalidate/README.md
@@ -1,0 +1,74 @@
+# dnglab cross-validation testing
+
+`compare_raf_batch.py` batch-compares rawspeed's Fuji RAF decode against
+[dnglab](https://github.com/dnglab/dnglab)/rawler's independent decoder,
+across a whole directory of `.RAF` files at once. It was used to validate
+the lossy-compressed Fuji RAF decoding support added in this directory's
+sibling commits, but works for lossless-compressed and uncompressed Fuji
+files too, and isn't specific to any one camera body.
+
+For each file, it converts to DNG via `dnglab convert`, reads a small grid
+of pixel values from that DNG via `rawpy`, decodes the original RAF with
+`rstest -c`, and diffs the two sets of values. This catches real decode
+regressions -- wrong pixel values, not just crashes -- across large,
+real-world test sets without needing a human to eyeball every image.
+
+## Prerequisites
+
+- **dnglab**: build or download from
+  [github.com/dnglab/dnglab](https://github.com/dnglab/dnglab).
+- **rstest**: rawspeed's own lightweight decode-test utility, built via
+  this repo's own CMake (`cmake --build . --target rstest`). See
+  `src/utilities/rstest/` for details -- no need for a full darktable
+  build, just rawspeed itself.
+- **Python 3 with rawpy**: `pip install rawpy` (a virtual environment is
+  recommended, since some systems' system Python blocks direct `pip
+  install` -- see PEP 668 / "externally managed environment").
+
+## Enabling per-pixel diagnostic output
+
+`compare_raf_batch.py` relies on `FujiDecompressor.cpp`'s optional
+`RAWSPEED_FUJI_DIAG` diagnostic (see that file for details) to get the
+values it compares against dnglab. Set the environment variable before
+running rstest, or export it for your whole shell session:
+
+    export RAWSPEED_FUJI_DIAG=1
+
+Without this set, rstest decodes normally but prints no pixel values, and
+`compare_raf_batch.py` will report every file as an error ("no DIAG pixel
+lines found").
+
+## Usage
+
+    python3 compare_raf_batch.py /path/to/raf/directory \
+        --dnglab /path/to/dnglab \
+        --rstest /path/to/rstest
+
+Both `--dnglab` and `--rstest` default to whatever's on your `PATH` if
+omitted. Converted DNGs are kept (not deleted) in
+`<directory>/dng_output/` by default -- pass `--dng-dir` to put them
+somewhere else. Run `python3 compare_raf_batch.py --help` for the full
+option list.
+
+Only `.RAF`/`.raf` files are scanned. Files that don't route through
+`FujiDecompressor` at all (e.g. some non-Fuji-compressed formats, if ever
+mixed into the same directory) will show up as errored, not failed --
+that's expected, not a bug in the comparison.
+
+## Output
+
+A `PASS`/`FAIL`/`ERROR` line per file, plus a final summary count. On
+`FAIL`, the first few mismatched coordinates are printed with both
+decoders' values side by side, to help pinpoint the divergence quickly
+rather than needing a fresh debugging session per failure.
+
+## Side effects
+
+- Converted `.dng` files are kept on disk (in `<directory>/dng_output/` by
+  default, or wherever `--dng-dir` points) -- not deleted automatically.
+  Clean them up yourself if you don't want them lingering.
+
+`rstest -c`'s `.hash` sidecar files are deleted automatically, both before
+each file runs (so a stale hash from an earlier run is never silently
+reused instead of a fresh decode) and after (so the script doesn't leave
+files behind in your RAF directory).

--- a/src/utilities/dnglab-crossvalidate/compare_raf_batch.py
+++ b/src/utilities/dnglab-crossvalidate/compare_raf_batch.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Batch-compares rawspeed's (patched) Fuji lossy-RAF decode against dnglab's
+known-good decode, across every .RAF file in a directory.
+
+For each file:
+  1. Converts it to DNG via `dnglab convert`.
+  2. Reads a 5x5 grid of pixel values (at relative image-fraction
+     coordinates -- matches the DIAG spot-check compiled into
+     FujiDecompressor.cpp) from the DNG via rawpy.
+  3. Runs `rstest -c` on the original RAF and parses its
+     "DIAG (row,col) = val" stdout lines. -c forces an actual decode +
+     hash computation even when no .hash file exists yet -- with no
+     flags, rstest silently skips files that have no accompanying .hash,
+     which would otherwise make every file look like a decode failure
+     here even though nothing was ever decoded. Note: this creates a
+     .hash file next to each RAF as a side effect (harmless, but you'll
+     see them appear in the directory).
+  4. Compares the two sets of values and reports PASS/FAIL per file.
+
+Requires: rawpy installed (pip install rawpy) in your active environment,
+dnglab and rstest binaries built and reachable.
+
+Usage:
+    python3 compare_raf_batch.py /path/to/raf/directory \\
+        --dnglab /path/to/dnglab \\
+        --rstest /path/to/rstest
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import rawpy
+
+DIAG_PIXEL_RE = re.compile(r"DIAG \((\d+),(\d+)\) = (\d+)")
+FRACTIONS = [0.02, 0.25, 0.5, 0.75, 0.98]
+
+
+def dnglab_ground_truth(dnglab_bin: str, raf_path: Path, dng_dir: Path) -> dict:
+    """Convert raf_path to DNG via dnglab (kept on disk in dng_dir, not
+    deleted), then read the same relative-fraction pixel grid via rawpy.
+    Returns {(row, col): value}."""
+    dng_path = dng_dir / (raf_path.stem + ".dng")
+    result = subprocess.run(
+        [dnglab_bin, "convert", str(raf_path), str(dng_path)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"dnglab convert failed: {result.stderr.strip()}")
+
+    raw = rawpy.imread(str(dng_path))
+    img = raw.raw_image
+    height, width = img.shape
+
+    values = {}
+    for row_frac in FRACTIONS:
+        for col_frac in FRACTIONS:
+            row = min(height - 1, int(row_frac * height))
+            col = min(width - 1, int(col_frac * width))
+            values[(row, col)] = int(img[row, col])
+    return values
+
+
+def _hash_file_for(raf_path: Path) -> Path:
+    """The .hash sidecar file rstest -c creates next to a RAF, e.g.
+    DSCF1234.RAF -> DSCF1234.RAF.hash."""
+    return raf_path.with_name(raf_path.name + ".hash")
+
+
+def rstest_values(rstest_bin: str, raf_path: Path) -> dict:
+    """Runs rstest -c on raf_path and parses its DIAG pixel lines from
+    stdout. Returns {(row, col): value}.
+
+    -c forces an actual decode + hash computation even when no .hash file
+    exists yet -- with no flags, rstest silently skips files that have no
+    accompanying .hash, which would otherwise make every file look like a
+    decode failure here even though nothing was ever decoded.
+
+    A .hash file is deleted before running (so a stale hash from a
+    previous run never gets silently reused/compared instead of a fresh
+    decode) and after (so this script doesn't leave sidecar files behind
+    that someone re-running it later, without this context, would find
+    confusing)."""
+    hash_path = _hash_file_for(raf_path)
+    hash_path.unlink(missing_ok=True)
+
+    result = subprocess.run(
+        [rstest_bin, "-c", str(raf_path)], capture_output=True, text=True,
+    )
+    combined_output = result.stdout + result.stderr
+
+    hash_path.unlink(missing_ok=True)
+
+    values = {}
+    for row, col, val in DIAG_PIXEL_RE.findall(combined_output):
+        values[(int(row), int(col))] = int(val)
+
+    if not values:
+        raise RuntimeError(
+            "no DIAG pixel lines found in rstest output -- either the "
+            "spot-check diagnostic isn't compiled into FujiDecompressor.cpp, "
+            "or this file isn't a compressed Fuji RAF (uncompressed RAFs "
+            "never go through FujiDecompressor at all, so no DIAG output "
+            "is expected for those -- not necessarily an error)."
+        )
+    return values
+
+
+def compare_one(dnglab_bin, rstest_bin, raf_path: Path, dng_dir: Path):
+    truth = dnglab_ground_truth(dnglab_bin, raf_path, dng_dir)
+    got = rstest_values(rstest_bin, raf_path)
+
+    mismatches = []
+    for coord, truth_val in truth.items():
+        got_val = got.get(coord)
+        if got_val is None:
+            mismatches.append((coord, truth_val, "MISSING"))
+        elif got_val != truth_val:
+            mismatches.append((coord, truth_val, got_val))
+
+    return mismatches, len(truth)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path,
+                       help="Directory containing .RAF files to test")
+    parser.add_argument("--dnglab", default="dnglab",
+                       help="Path to the dnglab binary (default: dnglab on PATH)")
+    parser.add_argument("--rstest", default="rstest",
+                       help="Path to the rstest binary (default: rstest on PATH)")
+    parser.add_argument("--dng-dir", type=Path, default=None,
+                       help="Directory to keep converted DNGs in (default: "
+                            "<directory>/dng_output -- created if missing, "
+                            "files are NOT deleted afterward)")
+    args = parser.parse_args()
+
+    raf_files = sorted(args.directory.glob("*.RAF")) + sorted(args.directory.glob("*.raf"))
+    if not raf_files:
+        print(f"No .RAF files found in {args.directory}")
+        sys.exit(1)
+
+    dng_dir = args.dng_dir or (args.directory / "dng_output")
+    dng_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Found {len(raf_files)} RAF file(s). Comparing against dnglab...")
+    print(f"Converted DNGs will be kept in: {dng_dir}\n")
+
+    passed, failed, errored = [], [], []
+
+    for raf_path in raf_files:
+        print(f"{raf_path.name} ... ", end="", flush=True)
+        try:
+            mismatches, total = compare_one(
+                args.dnglab, args.rstest, raf_path, dng_dir
+            )
+        except Exception as e:
+            print(f"ERROR ({e})")
+            errored.append((raf_path, str(e)))
+            continue
+
+        if not mismatches:
+            print(f"PASS ({total}/{total} coordinates match)")
+            passed.append(raf_path)
+        else:
+            print(f"FAIL ({len(mismatches)}/{total} coordinates differ)")
+            for coord, truth_val, got_val in mismatches[:5]:
+                print(f"    {coord}: dnglab={truth_val} rstest={got_val}")
+            if len(mismatches) > 5:
+                print(f"    ... and {len(mismatches) - 5} more")
+            failed.append(raf_path)
+
+    print("\n" + "=" * 60)
+    print(f"Summary: {len(passed)} passed, {len(failed)} failed, "
+          f"{len(errored)} errored (of {len(raf_files)} total)")
+    if failed:
+        print("\nFailed files:")
+        for p in failed:
+            print(f"  {p}")
+    if errored:
+        print("\nErrored files:")
+        for p, err in errored:
+            print(f"  {p}: {err}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
FujiDecompressor previously only handled uncompressed and lossless-compressed Fuji RAF files; lossy-compressed ("compressed" quality setting) files were rejected at header validation.

Ports the lossy decode path from dnglab/rawler's Rust implementation (rawler/src/decoders/fuji_decompressor.rs), which already unifies lossless and lossy decoding in one algorithm, reconciled against rawspeed's existing lossless-only architecture:

- Parse the per-line quantization base (q_base) array that follows the block-offset table in lossy files.
- Add FujiQTable, generalizing the single quantization table into four: a "main" table rebuilt whenever q_base changes between lines, plus three static tables (fixed q_base 0/1/2) selected per-pixel by local gradient magnitude.
- Wire table selection into the sample-decode hot path (fuji_decode_interpolation_even/odd_inner, fuji_decode_sample, fuji_quant_gradient), gated throughout by header.isLossless() so lossless-file behavior is unchanged.

Cross-validated pixel-exact against dnglab/rawler's independent decoder across 449 real-world files (one X-series body, both lossless- and lossy-compressed modes across a firmware change) at 25 spot-check coordinates per file.

Fixes a related regression found during that testing: passing q_bases.data() directly into Array1DRef crashed on every lossless file, since an empty vector's .data() can be null (observed on libc++) and Array1DRef's invariant check requires non-null even at size 0. Fixed with a static sentinel byte.

Includes an opt-in pixel spot-check diagnostic (RAWSPEED_FUJI_DIAG env var, off by default) used to produce the validation results above; zero overhead when unset. Also includes
src/utilities/dnglab-crossvalidate/, the standalone script (with README) used to run that cross-validation, so others can reproduce or extend it.

Closes #232
Closes #255
Closes #332
Closes #366
Closes #406